### PR TITLE
Add dev-agent-skills to Development and Testing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ See the [official repo](https://github.com/anthropics/skills) and [creation guid
 - **[obra/condition-based-waiting](https://github.com/obra/superpowers/blob/main/skills/condition-based-waiting/SKILL.md)** - Manage conditional pauses or delays
 - **[obra/commands](https://github.com/obra/superpowers/tree/main/skills/commands)** - Create and manage command structures
 - **[obra/writing-skills](https://github.com/obra/superpowers/blob/main/skills/writing-skills/SKILL.md)** - Develop and document capabilities
+- **[fvadicamo/dev-agent-skills](https://github.com/fvadicamo/dev-agent-skills)** - Git and GitHub workflow skills: git-commit (Conventional Commits), github-pr-creation, github-pr-merge, github-pr-review, plus creating-skills guide
 - **[omkamal/pypict-skill](https://github.com/omkamal/pypict-claude-skill/blob/main/SKILL.md)** - Pairwise test generation
 
 ### Specialized Domains


### PR DESCRIPTION
## Summary
Adds dev-agent-skills to the Development and Testing section.

## Description
A collection of 5 agent skills organized in 2 plugins for Git and GitHub workflows:

### github-workflow plugin
- **git-commit**: Creates commits following Conventional Commits format
- **github-pr-creation**: PR creation with validation and task tracking
- **github-pr-merge**: Pre-merge checklist validation
- **github-pr-review**: Review comment resolution with severity classification

### skill-authoring plugin
- **creating-skills**: Guide for creating Claude Code skills following Anthropic's best practices

## Installation
```bash
/plugin marketplace add fvadicamo/dev-agent-skills
/plugin install github-workflow@dev-agent-skills
```

## Repository
https://github.com/fvadicamo/dev-agent-skills

## Checklist
- [x] Repository is public
- [x] Skills have SKILL.md with proper frontmatter
- [x] README with installation instructions
- [x] MIT License
- [x] Link tested and working