### PR TITLE
Add postgres and imagen skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ See the [official repo](https://github.com/anthropics/skills) and [creation guid
 
 - **[zxkane/aws-skills](https://github.com/zxkane/aws-skills)** - AWS development with infrastructure automation and cloud architecture patterns
 - **[conorluddy/ios-simulator-skill](https://github.com/conorluddy/ios-simulator-skill)** - Control iOS Simulator
+- **[sanjay3290/postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres)** - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support
 - **[jthack/ffuf-claude-skill](https://github.com/jthack/ffuf_claude_skill)** - Web fuzzing with ffuf
 - **[lackeyjb/playwright-skill](https://github.com/lackeyjb/playwright-skill)** - Browser automation with Playwright
 - **[scarletkc/vexor](https://github.com/scarletkc/vexor)** - Vector-powered CLI for semantic file search with a Claude/Codex skill
@@ -145,6 +146,7 @@ See the [official repo](https://github.com/anthropics/skills) and [creation guid
 
 - **[K-Dense-AI/claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)** - Scientific research and analysis skills
 - **[NotMyself/claude-win11-speckit-update-skill](https://github.com/NotMyself/claude-win11-speckit-update-skill)** - Windows 11 system management
+- **[sanjay3290/imagen](https://github.com/sanjay3290/ai-skills/tree/main/skills/imagen)** - Generate images using Google Gemini's API for UI mockups, icons, and visual assets
 - **[jeffersonwarrior/claudisms](https://github.com/jeffersonwarrior/claudisms)** - SMS messaging integration
 - **[obra/defense-in-depth](https://github.com/obra/superpowers/blob/main/skills/defense-in-depth/SKILL.md)** - Multi-layered security approaches
 - **[haunchen/n8n-skill](https://github.com/haunchen/n8n-skills)** - Enables AI assistants to understand and operate n8n workflows with information on 542 nodes and 20 templates.


### PR DESCRIPTION
## New Community Skills

Adding two skills from [ai-skills](https://github.com/sanjay3290/ai-skills):

### postgres (Development and Testing)
- Execute safe read-only SQL queries against PostgreSQL databases
- Multi-connection support with intelligent auto-selection
- Defense-in-depth security (read-only session + query validation)

### imagen (Specialized Domains)
- Generate images using Google Gemini's API
- UI mockups, icons, illustrations, and visual assets
- Cross-platform (Windows, macOS, Linux)

Both skills tested with Claude Code.