### PR TITLE
Add skill: wrsmith108/linear-claude-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ See the [official repo](https://github.com/anthropics/skills) and [creation guid
 - **[ComposioHQ/meeting-insights-analyzer](https://github.com/ComposioHQ/awesome-claude-skills/tree/master/meeting-insights-analyzer)** - Analyze meeting communication patterns
 - **[ComposioHQ/competitive-ads-extractor](https://github.com/ComposioHQ/awesome-claude-skills/tree/master/competitive-ads-extractor)** - Analyze competitor advertising
 - **[ComposioHQ/image-enhancer](https://github.com/ComposioHQ/awesome-claude-skills/tree/master/image-enhancer)** - Improve image quality
+- **[wrsmith108/linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill)** - Manage Linear issues, projects, and teams with MCP tools, SDK scripts, and GraphQL fallbacks
 
 ### Development and Testing
 


### PR DESCRIPTION
## Summary
- Adds the Linear project management skill to the Productivity and Collaboration section

## Skill Details
- **Repository**: [wrsmith108/linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill)
- **Description**: Manage Linear issues, projects, and teams with MCP tools, SDK scripts, and GraphQL fallbacks
- **License**: MIT

## Features
- MCP tool reliability matrix (knows when to use MCP vs GraphQL)
- SDK scripts for bulk operations
- Helper scripts for common workflows (status updates, project linking)
- Patterns for issue → project → initiative hierarchy

## Checklist
- [x] Link works and repository is public
- [x] Relevant to Claude Skills
- [x] Correct formatting and placement
- [x] Author prefix included in skill name

🤖 Generated with [Claude Code](https://claude.com/claude-code)