### PR TITLE
Add skill: wrsmith108/varlock-claude-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,8 @@ See the [official repo](https://github.com/anthropics/skills) and [creation guid
 - **[SHADOWPR0/security-bluebook-builder](https://github.com/SHADOWPR0/security-bluebook-builder)** - Build a concise, normative security Blue Book for sensitive apps (threat model, data classes, auth/session, logging/audit, retention, IR, security gates)
 - **[obra/defense-in-depth](https://github.com/obra/superpowers/blob/main/skills/defense-in-depth/SKILL.md)** - Multi-layered security approaches
 - **[haunchen/n8n-skill](https://github.com/haunchen/n8n-skills)** - Enables AI assistants to understand and operate n8n workflows with information on 542 nodes and 20 templates.
-- **[materials-simulation-skills](https://github.com/HeshamFS/materials-simulation-skills)** - Agent skills for computational materials science: numerical stability, time-stepping, linear solvers, mesh generation, simulation validation, parameter optimization, and post-processing.  
+- **[materials-simulation-skills](https://github.com/HeshamFS/materials-simulation-skills)** - Agent skills for computational materials science: numerical stability, time-stepping, linear solvers, mesh generation, simulation validation, parameter optimization, and post-processing.
+- **[wrsmith108/varlock-claude-skill](https://github.com/wrsmith108/varlock-claude-skill)** - Secure environment variable management ensuring secrets are never exposed in Claude sessions, terminals, logs, or git commits
 
 ## Articles and Tutorials
 


### PR DESCRIPTION
## Summary
- Adds the Varlock secure environment variable skill to the Specialized Domains section

## Skill Details
- **Repository**: [wrsmith108/varlock-claude-skill](https://github.com/wrsmith108/varlock-claude-skill)
- **Description**: Secure environment variable management ensuring secrets are never exposed in Claude sessions, terminals, logs, or git commits
- **License**: MIT

## Features
- Prevents accidental secret exposure in Claude's context
- Safe validation commands that mask sensitive values
- Schema-based configuration with `@sensitive` annotations
- Integration with the Varlock CLI tool

## Checklist
- [x] Link works and repository is public
- [x] Relevant to Claude Skills
- [x] Correct formatting and placement
- [x] Author prefix included in skill name

🤖 Generated with [Claude Code](https://claude.com/claude-code)