### PR TITLE
Add ddaakk/agent-skills - React.js focused fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ See the [official repo](https://github.com/anthropics/skills) and [creation guid
 - **[omkamal/pypict-skill](https://github.com/omkamal/pypict-claude-skill/blob/main/SKILL.md)** - Pairwise test generation
 - **[alinaqi/claude-bootstrap](https://github.com/alinaqi/claude-bootstrap)** - Opinionated project initialization with security-first guardrails, spec-driven atomic todos, LLM testing patterns, and CLI tool orchestration (gh, vercel, supabase)
 - **[ZhangHanDong/makepad-skills](https://github.com/ZhangHanDong/makepad-skills)** - Makepad UI development skills for Rust apps: setup, patterns, shaders, packaging, and troubleshooting.
+- **[ddaakk/agent-skills](https://github.com/ddaakk/agent-skills)** - React.js focused fork of vercel-labs/agent-skills. Removes Next.js patterns for cleaner LLM context in React-only projects. Includes multilingual docs (EN/KO/ZH/JA).
 
 ### Context Engineering
 


### PR DESCRIPTION
## Summary

Adds [ddaakk/agent-skills](https://github.com/ddaakk/agent-skills) to the Development and Testing section.

## About This Skill

This is a fork of [vercel-labs/agent-skills](https://github.com/vercel-labs/agent-skills) customized for **React.js-only projects**.

### Key Changes from Original

| Original Pattern | Converted To |
|------------------|--------------|
| `next/dynamic` | `React.lazy()` + `Suspense` |
| Next.js `optimizePackageImports` | Vite plugin |
| Next.js `after()` API | `on-finished` / Express patterns |

### Why This Matters for LLMs

When AI agents reference mixed framework patterns (React + Next.js), they may generate inconsistent code for teams that only use React. This fork provides:

- Cleaner context without irrelevant Next.js patterns
- More consistent code generation for React-only projects
- No need for conditional "don't use Next.js" instructions

### Additional Features

- Multilingual documentation (English, Korean, Chinese, Japanese)
- Updated installation: `npx add-skill ddaakk/agent-skills`

## Checklist

- [x] Follows the existing format
- [x] Link is valid and accessible
- [x] Description is concise