### PR TITLE
Add skill: jeffallan/claude-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Official AI agent skills from the Expo team for building, deploying, and debuggi
 - **[alinaqi/claude-bootstrap](https://github.com/alinaqi/claude-bootstrap)** - Opinionated project initialization with security-first guardrails, spec-driven atomic todos, LLM testing patterns, and CLI tool orchestration (gh, vercel, supabase)
 - **[ZhangHanDong/makepad-skills](https://github.com/ZhangHanDong/makepad-skills)** - Makepad UI development skills for Rust apps: setup, patterns, shaders, packaging, and troubleshooting.
 - **[callstackincubator/react-native-best-practices](https://github.com/callstackincubator/agent-skills/blob/main/skills/react-native-best-practices/SKILL.md)** - Performance optimization for React Native apps from Callstack
+- **[jeffallan/claude-skills](https://github.com/jeffallan/claude-skills)** - 65 full-stack development skills with progressive disclosure architecture covering React, NestJS, Python, DevOps, testing, and 30+ frameworks
 
 ### Context Engineering
 
@@ -215,6 +216,7 @@ Official AI agent skills from the Expo team for building, deploying, and debuggi
 - **[muratcankoylan/memory-systems](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/memory-systems)** - Design short-term, long-term, and graph-based memory architectures
 - **[muratcankoylan/tool-design](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/tool-design)** - Build tools that agents can use effectively, including architectural reduction patterns
 - **[muratcankoylan/evaluation](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/evaluation)** - Build evaluation frameworks for agent systems
+- **[jeffallan/claude-skills (common-ground)](https://github.com/jeffallan/claude-skills/blob/main/commands/common-ground/COMMAND.md)** - Surfaces and validates Claude's hidden assumptions about projects with confidence tiers (ESTABLISHED/WORKING/OPEN) and interactive adjustment flows
 
 ### Specialized Domains
 


### PR DESCRIPTION
## Add jeffallan/claude-skills

Adding two entries from the claude-skills collection:

### 1. Development and Testing
65 specialized full-stack development skills with progressive disclosure architecture, covering React, NestJS, Python, DevOps, and 30+ frameworks.

### 2. Context Engineering
The `common-ground` command surfaces and validates Claude's hidden assumptions about projects. Features:
- Assumption classification by type (stated/inferred/assumed/uncertain)
- Confidence tiers (ESTABLISHED/WORKING/OPEN)
- Interactive two-phase flow for surfacing and adjusting assumptions
- Persistent storage per project

**Repository:** https://github.com/jeffallan/claude-skills
**License:** MIT