### PR TITLE
fix: remove outdated Sentry's "deslop" skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,6 @@ Agent Skills for the Stitch MCP server, compatible with Claude Code, Gemini CLI,
 - **[getsentry/code-review](https://github.com/getsentry/skills/tree/main/plugins/sentry-skills/skills/code-review)** - Perform code reviews
 - **[getsentry/commit](https://github.com/getsentry/skills/tree/main/plugins/sentry-skills/skills/commit)** - Create commits with best practices
 - **[getsentry/create-pr](https://github.com/getsentry/skills/tree/main/plugins/sentry-skills/skills/create-pr)** - Create pull requests
-- **[getsentry/deslop](https://github.com/getsentry/skills/tree/main/plugins/sentry-skills/skills/deslop)** - Clean up sloppy code
 - **[getsentry/find-bugs](https://github.com/getsentry/skills/tree/main/plugins/sentry-skills/skills/find-bugs)** - Find and identify bugs in code
 - **[getsentry/iterate-pr](https://github.com/getsentry/skills/tree/main/plugins/sentry-skills/skills/iterate-pr)** - Iterate on pull request feedback
 


### PR DESCRIPTION
The Sentry's `deslop` skill has been removed last week in favor of their "code simplifier" subagent (see the [PR](https://github.com/getsentry/skills/pull/20) of this change) and now the link in this repo points to a 404 page.

The new "code simplifier" replacement is not a _skill_, so it is technically not fitting for this repo, which is why this PR removed the link rather than replace it. Please consider whether this is the correct decision. Some alternatives would be:
1. replace it with a blob link pointing to the original `deslop` skill before it was removed, see [blob](https://github.com/getsentry/skills/blob/ec9e0a3d7635754f830bff27269d8ef3267d400f/plugins/sentry-skills/skills/deslop/SKILL.md)
2. replace it with a link to the code simplifier agent, see [link](https://github.com/getsentry/skills/blob/main/plugins/sentry-skills/agents/code-simplifier.md)