### PR TITLE
Add shadcn-skills to Development and Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ Official AI agent skills from the Expo team for building, deploying, and debuggi
 - **[jthack/ffuf-claude-skill](https://github.com/jthack/ffuf_claude_skill)** - Web fuzzing with ffuf
 - **[lackeyjb/playwright-skill](https://github.com/lackeyjb/playwright-skill)** - Browser automation with Playwright
 - **[ibelick/ui-skills](https://github.com/ibelick/ui-skills)** - Opinionated, evolving constraints to guide agents when building interfaces
+- **[mattbx/shadcn-skills](https://github.com/mattbx/shadcn-skills)** - Discover shadcn components and review against design patterns
 - **[nextlevelbuilder/ui-ux-pro-max-skill](https://github.com/nextlevelbuilder/ui-ux-pro-max-skill)** - UI/UX design patterns and best practices
 - **[scarletkc/vexor](https://github.com/scarletkc/vexor)** - Vector-powered CLI for semantic file search with a Claude/Codex skill
 - **[obra/test-driven-development](https://github.com/obra/superpowers/blob/main/skills/test-driven-development/SKILL.md)** - Write tests before implementing code


### PR DESCRIPTION
## Summary

Adding [mattbx/shadcn-skills](https://github.com/mattbx/shadcn-skills) to the Development and Testing section.

**Description:** Discover shadcn components and review against design patterns

## What it includes

Two skills for building better shadcn/ui applications:

1. **shadcn-component-discovery** - Search 1,500+ existing components across @shadcn, @blocks, @reui, @animate-ui, @diceui, and 30+ community registries before building custom
2. **shadcn-component-review** - Review components against shadcn patterns and all 5 theme styles (Vega, Nova, Maia, Lyra, Mira)

## Installation

```bash
/plugin marketplace add mattbx/shadcn-skills
/plugin install shadcn-component-discovery
/plugin install shadcn-component-review
```

Compatible with Claude Code, Cursor, Codex, and other tools that support the Agent Skills standard.