### PR TITLE
Add skill: lee-fuhr/claude-session-index

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ Official AI agent skills from the Expo team for building, deploying, and debuggi
 - **[ComposioHQ/image-enhancer](https://github.com/ComposioHQ/awesome-claude-skills/tree/master/image-enhancer)** - Improve image quality
 - **[wrsmith108/linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill)** - Manage Linear issues, projects, and teams
 - **[Shpigford/readme](https://github.com/Shpigford/skills/tree/main/readme)** - Generate comprehensive project documentation
+- **[lee-fuhr/claude-session-index](https://github.com/lee-fuhr/claude-session-index)** - Search and analyze Claude Code session history
 
 ### Development and Testing
 


### PR DESCRIPTION
## Summary

Adding [lee-fuhr/claude-session-index](https://github.com/lee-fuhr/claude-session-index) to the Productivity and Collaboration section under Community Skills.

- **Entry:** `- **[lee-fuhr/claude-session-index](https://github.com/lee-fuhr/claude-session-index)** - Search and analyze Claude Code session history`
- **Category:** Community Skills > Productivity and Collaboration
- **License:** MIT

## What it does

Indexes Claude Code's JSONL session files into a local SQLite FTS5 database for instant full-text search across all sessions. Returns conversation snippets with `claude --resume` links. Installable as a skill via `npx skills add lee-fuhr/claude-session-index` or as a CLI via `pip install claude-session-index`.

Has documentation (README and SKILL.md). Description is under 10 words as required.