### PR TITLE
Add AdaL CLI to compatible agents table

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ See the [official repo](https://github.com/anthropics/skills) and [creation guid
 
 | Tool | Project Path | Global Path | Official Docs |
 |------|-------------|-------------|---------------|
+| AdaL CLI | `.adal/skills/` | `~/.adal/skills/` | [AdaL Skills](https://docs.sylph.ai/features/plugins-and-skills) |
 | Antigravity | `.agent/skills/` | `~/.gemini/antigravity/skills/` | [Antigravity Skills](https://antigravity.google/docs/skills) |
 | Claude Code | `.claude/skills/` | `~/.claude/skills/` | [Claude Code Skills](https://docs.anthropic.com/en/docs/claude-code/skills) |
 | Codex | `.codex/skills/` | `~/.codex/skills/` | [Codex Skills](https://developers.openai.com/codex/skills) |


### PR DESCRIPTION
## Add AdaL CLI to Compatible Agents

Add AdaL CLI as a compatible agent that supports Agent Skills.

| Field | Value |
|-------|-------|
| **Tool** | AdaL CLI |
| **Project Path** | `.adal/skills/` |
| **Global Path** | `~/.adal/skills/` |
| **Docs** | [AdaL Skills](https://docs.sylph.ai/features/plugins-and-skills) |

**Evidence:** AdaL CLI implements the Agent Skills specification and is fully compatible with Claude Code skills.

- Homepage: https://sylph.ai/
- Skills Documentation: https://docs.sylph.ai/features/plugins-and-skills

🌸 Generated with [AdaL](https://sylph.ai/)