### PR TITLE
Add skill: first-fluke/oh-my-ag

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,7 @@ Official AI agent skills from the Expo team for building, deploying, and debuggi
 - **[ibelick/ui-skills](https://github.com/ibelick/ui-skills)** - Opinionated, evolving constraints to guide agents when building interfaces
 - **[nextlevelbuilder/ui-ux-pro-max-skill](https://github.com/nextlevelbuilder/ui-ux-pro-max-skill)** - UI/UX design patterns and best practices
 - **[ehmo/platform-design-skills](https://github.com/ehmo/platform-design-skills)** - 300+ design rules from Apple HIG, Material Design 3, and WCAG 2.2 for cross-platform apps
+- **[first-fluke/oh-my-ag](https://github.com/first-fluke/oh-my-ag)** - Multi-agent skills orchestrating PM, Frontend, Backend, Mobile, QA, and Debug agents
 - **[scarletkc/vexor](https://github.com/scarletkc/vexor)** - Vector-powered CLI for semantic file search with a Claude/Codex skill
 - **[obra/test-driven-development](https://github.com/obra/superpowers/blob/main/skills/test-driven-development/SKILL.md)** - Write tests before implementing code
 - **[ComposioHQ/changelog-generator](https://github.com/ComposioHQ/awesome-claude-skills/tree/master/changelog-generator)** - Transform git commits into release notes


### PR DESCRIPTION
## Add skill: first-fluke/oh-my-ag

**Entry added to:** Development and Testing (Community Skills)

**Format:**
```
- **[first-fluke/oh-my-ag](https://github.com/first-fluke/oh-my-ag)** - Multi-agent skills orchestrating PM, Frontend, Backend, Mobile, QA, and Debug agents
```

### About
oh-my-ag is a collection of Antigravity Skills enabling collaborative multi-agent development. It provides 9 specialized skills (PM, Frontend, Backend, Mobile, QA, Debug, Workflow Guide, Orchestrator, Commit) with a token-optimized two-layer architecture.

### Checklist
- [x] Public repository with working skills
- [x] Documentation (README + SKILL.md for each skill)
- [x] Author/org prefix included (`first-fluke/oh-my-ag`)
- [x] Short description (10 words or fewer)
- [x] All links verified
- [x] No duplicate entries