### PR TITLE
Add skill: Ask-Ditto/ditto-product-research-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,8 @@ Official AI agent skills from the Expo team for building, deploying, and debuggi
 - **[ComposioHQ/content-research-writer](https://github.com/ComposioHQ/awesome-claude-skills/tree/master/content-research-writer)** - Enhance writing with research
 - **[ComposioHQ/competitive-ads-extractor](https://github.com/ComposioHQ/awesome-claude-skills/tree/master/competitive-ads-extractor)** - Analyze competitor advertising
 - **[wshuyi/x-article-publisher-skill](https://github.com/wshuyi/x-article-publisher-skill)** - Publish articles to X/Twitter
+- **[Ask-Ditto/ditto-product-research-skill](https://github.com/Ask-Ditto/ditto-product-research-skill)** - Run synthetic customer research with 300K+ AI personas
+- **[Ask-Ditto/ditto-product-marketing](https://github.com/Ask-Ditto/ditto-product-marketing)** - PMM research: positioning, messaging, competitive, pricing
 
 ### Productivity and Collaboration
 


### PR DESCRIPTION
## Adding two Ditto skills to the Marketing category

### Skills

**[Ask-Ditto/ditto-product-research-skill](https://github.com/Ask-Ditto/ditto-product-research-skill)** - Run synthetic customer research with 300K+ AI personas

**[Ask-Ditto/ditto-product-marketing](https://github.com/Ask-Ditto/ditto-product-marketing)** - PMM research: positioning, messaging, competitive, pricing

### What these skills do

Both skills connect Claude Code to the [Ditto API](https://askditto.io) for synthetic market research. Ditto maintains 300,000+ AI-powered personas calibrated to census data across 15+ countries (EY validated at 92% correlation with traditional research).

- **Product Research skill** (1,266 lines, 6 files): General customer research - pain discovery, concept validation, pricing tests, competitive analysis, startup diligence
- **Product Marketing skill** (867 lines, 5 files): PMM-specific workflows - 8 study types with proven 7-question frameworks for positioning validation, messaging testing, competitive intelligence, pricing & packaging, GTM validation, product launches, buyer personas, and brand tracking

### Requirements met

- [x] Public repositories with functional skills
- [x] Documentation (README.md + SKILL.md in both repos)
- [x] Author/org prefix included (Ask-Ditto/)
- [x] Descriptions under 10 words
- [x] Both skills follow the Agent Skills SKILL.md standard