### PR TITLE
Add ClawFu: 169 expert-sourced marketing skills (MCP server)

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,6 +495,7 @@ Domain-specific knowledge for Azure SDK and Foundry development.
 - **[ComposioHQ/content-research-writer](https://github.com/ComposioHQ/awesome-claude-skills/tree/master/content-research-writer)** - Enhance writing with research
 - **[ComposioHQ/competitive-ads-extractor](https://github.com/ComposioHQ/awesome-claude-skills/tree/master/competitive-ads-extractor)** - Analyze competitor advertising
 - **[wshuyi/x-article-publisher-skill](https://github.com/wshuyi/x-article-publisher-skill)** - Publish articles to X/Twitter
+- **[ClawFu](https://github.com/guia-matthieu/clawfu-skills)** - MCP server with 169 expert-sourced marketing skills (copywriting, strategy, positioning, audio, video, leadership). Brand memory system for voice consistency.
 
 </details>
 


### PR DESCRIPTION
Adds [ClawFu](https://github.com/guia-matthieu/clawfu-skills) to the **Community Skills > Marketing** section.

**What it is:** An MCP server with 169 marketing methodology skills across 28 categories (copywriting, strategy, positioning, audio, video, leadership). Every skill is sourced from a named expert. Includes brand memory for voice consistency.

- npm: `@clawfu/mcp-skills`
- License: MIT
- Website: https://clawfu.com