### PR TITLE
Add skills by Transloadit Team

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ The most contributed Agent Skills repository, built and maintained together with
 - [Skills by Sanity Team](#skills-by-sanity-team)
 - [Skills by Remotion Team](#skills-by-remotion-team)
 - [Skills by WordPress Development Team](#skills-by-wordpress-development-team)
+- [Skills by Transloadit Team](#skills-by-transloadit-team)
 - [Community Skills](#community-skills)
 
 
@@ -482,6 +483,18 @@ Domain-specific knowledge for Azure SDK and Foundry development.
 - **[WordPress/wp-phpstan](https://github.com/WordPress/agent-skills/tree/trunk/skills/wp-phpstan)** - PHPStan static analysis for WordPress projects
 - **[WordPress/wp-playground](https://github.com/WordPress/agent-skills/tree/trunk/skills/wp-playground)** - WordPress Playground for instant local environments
 - **[WordPress/wpds](https://github.com/WordPress/agent-skills/tree/trunk/skills/wpds)** - WordPress Design System
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Skills by Transloadit Team</h3></summary>
+
+- **[transloadit/transloadit](https://github.com/transloadit/skills/tree/main/skills/transloadit)** - Routes media tasks to the right skill
+- **[transloadit/docs-transloadit-robots](https://github.com/transloadit/skills/tree/main/skills/docs-transloadit-robots)** - Look up any of 86+ processing Robots
+- **[transloadit/transform-generate-image](https://github.com/transloadit/skills/tree/main/skills/transform-generate-image-with-transloadit)** - Generate images via AI models
+- **[transloadit/transform-encode-hls-video](https://github.com/transloadit/skills/tree/main/skills/transform-encode-hls-video-with-transloadit)** - Encode video to HLS streaming format
+- **[transloadit/integrate-uppy-s3-uploading](https://github.com/transloadit/skills/tree/main/skills/integrate-uppy-transloadit-s3-uploading-to-nextjs)** - Add Uppy file uploads to Next.js apps
+- **[transloadit/integrate-smartcdn-delivery](https://github.com/transloadit/skills/tree/main/skills/integrate-asset-delivery-with-transloadit-smartcdn-in-nextjs)** - Smart CDN asset delivery in Next.js
 
 </details>
 


### PR DESCRIPTION
Adds a new "Skills by Transloadit Team" section with 6 agent skills for media processing:

- **transloadit** — Router skill that classifies tasks and dispatches to the right skill
- **docs-transloadit-robots** — Look up any of 86+ processing Robots
- **transform-generate-image** — Generate images via AI models
- **transform-encode-hls-video** — Encode video to HLS streaming format
- **integrate-uppy-s3-uploading** — Add Uppy file uploads to Next.js apps
- **integrate-smartcdn-delivery** — Smart CDN asset delivery in Next.js

**Repo:** [transloadit/skills](https://github.com/transloadit/skills)
**Docs:** [transloadit.com/docs/topics/ai-agents](https://transloadit.com/docs/topics/ai-agents/)

All skills follow the Agent Skills open standard (agentskills.io/specification) with SKILL.md frontmatter. Also discoverable via `npx skills add https://transloadit.com` (.well-known/skills/index.json).