### PR TITLE
Add agent-deep-links-skill to Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,6 +552,7 @@ Domain-specific knowledge for Azure SDK and Foundry development.
 - **[jthack/ffuf-claude-skill](https://github.com/jthack/ffuf_claude_skill)** - Web fuzzing with ffuf
 - **[lackeyjb/playwright-skill](https://github.com/lackeyjb/playwright-skill)** - Browser automation with Playwright
 - **[ibelick/ui-skills](https://github.com/ibelick/ui-skills)** - Opinionated, evolving constraints to guide agents when building interfaces
+- **[alxDisplayr/agent-deep-links-skill](https://github.com/alxDisplayr/agent-deep-links-skill)** - Cross-agent deep-link patterns for Codex, Cursor, and VS Code with Slack link formatting and support/fallback matrix
 - **[nextlevelbuilder/ui-ux-pro-max-skill](https://github.com/nextlevelbuilder/ui-ux-pro-max-skill)** - UI/UX design patterns and best practices
 - **[ehmo/platform-design-skills](https://github.com/ehmo/platform-design-skills)** - 300+ design rules from Apple HIG, Material Design 3, and WCAG 2.2 for cross-platform apps
 - **[scarletkc/vexor](https://github.com/scarletkc/vexor)** - Vector-powered CLI for semantic file search with a Claude/Codex skill


### PR DESCRIPTION
Adds a new public skill for cross-agent deep-linking (Codex/Cursor/VS Code), including Slack-safe formatting and fallback guidance for unsupported IDE links.