### PR TITLE
Add Reepl - LinkedIn Content Creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,6 +508,7 @@ Domain-specific knowledge for Azure SDK and Foundry development.
 - **[ComposioHQ/content-research-writer](https://github.com/ComposioHQ/awesome-claude-skills/tree/master/content-research-writer)** - Enhance writing with research
 - **[ComposioHQ/competitive-ads-extractor](https://github.com/ComposioHQ/awesome-claude-skills/tree/master/competitive-ads-extractor)** - Analyze competitor advertising
 - **[wshuyi/x-article-publisher-skill](https://github.com/wshuyi/x-article-publisher-skill)** - Publish articles to X/Twitter
+- **[reepl-io/skills](https://github.com/reepl-io/skills)** - 18 tools for LinkedIn content management: drafts, publishing, scheduling, voice profiles, contacts, collections, templates, and AI image generation
 
 </details>
 


### PR DESCRIPTION
Adds Reepl skill for LinkedIn content management. 18 MCP tools including drafts, publishing, scheduling, voice profiles, contacts, collections, templates, and AI image generation.

Website: https://reepl.io | GitHub: https://github.com/reepl-io/skills