### PR TITLE
Add story-skills to Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,6 +545,7 @@ Domain-specific knowledge for Azure SDK and Foundry development.
 - **[Shpigford/readme](https://github.com/Shpigford/skills/tree/main/readme)** - Generate comprehensive project documentation
 - **[hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill)** - Minimal, low-friction hierarchical memory system with background agents and filesystem-based persistence
 - **[kreuzberg-dev/kreuzberg](https://github.com/kreuzberg-dev/kreuzberg/tree/main/skills/kreuzberg)** - Extract text, tables, and metadata from 62+ document formats
+- **[danjdewhurst/story-skills](https://github.com/danjdewhurst/story-skills)** - End-to-end fiction writing: story init, character management, worldbuilding, plot structure, and chapter writing with cross-referenced markdown
 
 </details>
 


### PR DESCRIPTION
## Summary

Adds [story-skills](https://github.com/danjdewhurst/story-skills) to the Productivity and Collaboration section under Community Skills.

**What it is:** A suite of 5 cross-referenced agent skills for end-to-end fiction writing powered by markdown:

- **story-init** — scaffolds a story project with structured markdown
- **character-management** — rich profiles, relationships, family trees
- **worldbuilding** — locations and world systems (magic, politics, technology, etc.)
- **plot-structure** — arcs, timelines, foreshadowing tracking
- **chapter-writing** — outline-first workflow with cross-referencing

All skills follow the Agent Skills standard and work across Claude Code, Gemini CLI, OpenAI Codex, GitHub Copilot, Cursor, Windsurf, and OpenCode.

Includes a [complete example story project](https://github.com/danjdewhurst/story-skills/tree/main/examples/the-last-ember) demonstrating all skill outputs.