### PR TITLE
Add skill: chadboyda/agent-gtm-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,6 +528,7 @@ Domain-specific knowledge for Azure SDK and Foundry development.
 - **[ComposioHQ/content-research-writer](https://github.com/ComposioHQ/awesome-claude-skills/tree/master/content-research-writer)** - Enhance writing with research
 - **[ComposioHQ/competitive-ads-extractor](https://github.com/ComposioHQ/awesome-claude-skills/tree/master/competitive-ads-extractor)** - Analyze competitor advertising
 - **[wshuyi/x-article-publisher-skill](https://github.com/wshuyi/x-article-publisher-skill)** - Publish articles to X/Twitter
+- **[chadboyda/agent-gtm-skills](https://github.com/chadboyda/agent-gtm-skills)** - 18 GTM skills: pricing, outbound, SEO, retention, and ops
 
 </details>
 


### PR DESCRIPTION
Adds [agent-gtm-skills](https://github.com/chadboyda/agent-gtm-skills) to the Marketing subcategory under Community Skills.

**Entry added:**
```
- **[chadboyda/agent-gtm-skills](https://github.com/chadboyda/agent-gtm-skills)** - 18 GTM skills: pricing, outbound, SEO, retention, and ops
```

**About the skill:**
18 dense skill files (9,800+ lines) that turn any coding agent into a GTM operator. Each is a 300-900 line playbook with real frameworks, current benchmarks (2025-2026), and decision matrices. Covers the full revenue surface across 6 layers: strategy, outbound, inbound, paid, retention, and operations.

- Public repo with SKILL.md documentation for each skill
- MIT licensed
- Landing page: [agentgtmskills.com](https://agentgtmskills.com)
- Already indexed on skills.sh (18 skills) and SkillsMP
- Compatible with Claude Code, Codex CLI, Cursor, Windsurf, GitHub Copilot, Gemini CLI, Cline, and more