### PR TITLE
Add skill: firecrawl/firecrawl-cli, firecrawl/firecrawl-claude-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ The most contributed Agent Skills repository, built and maintained together with
 - [Skills by Remotion Team](#skills-by-remotion-team)
 - [Skills by WordPress Development Team](#skills-by-wordpress-development-team)
 - [Skills by Transloadit Team](#skills-by-transloadit-team)
+- [Skills by Firecrawl Team](#skills-by-firecrawl-team)
 - [Community Skills](#community-skills)
 - [Skill Quality Standards](#skill-quality-standards)
 
@@ -515,6 +516,14 @@ Domain-specific knowledge for Azure SDK and Foundry development.
 - **[transloadit/transform-encode-hls-video](https://github.com/transloadit/skills/tree/main/skills/transform-encode-hls-video-with-transloadit)** - Encode video to HLS streaming format
 - **[transloadit/integrate-uppy-s3-uploading](https://github.com/transloadit/skills/tree/main/skills/integrate-uppy-transloadit-s3-uploading-to-nextjs)** - Add Uppy file uploads to Next.js apps
 - **[transloadit/integrate-smartcdn-delivery](https://github.com/transloadit/skills/tree/main/skills/integrate-asset-delivery-with-transloadit-smartcdn-in-nextjs)** - Smart CDN asset delivery in Next.js
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Skills by Firecrawl Team</h3></summary>
+
+- **[firecrawl/firecrawl-cli](https://github.com/firecrawl/cli/tree/main/skills/firecrawl-cli)** - Scrape, crawl, search, and map the web via CLI
+- **[firecrawl/firecrawl-claude-plugin](https://github.com/firecrawl/firecrawl-claude-plugin)** - Claude Code plugin for web scraping and search
 
 </details>
 


### PR DESCRIPTION
I'm Leo, dev rel at Firecrawl. Adding Firecrawl to the list, it gives agents the ability to scrape, crawl, and search the web. Happy to help if you need anything, extra API credits for the community included.

---

## What this adds

Two entries under a new "Skills by Firecrawl Team" section in the README:

- **[firecrawl/firecrawl-cli](https://github.com/firecrawl/cli/tree/main/skills/firecrawl-cli)** - The CLI-based agent skill. Works across Claude Code, Codex, Gemini CLI, Cursor, and other compatible tools. Teaches agents to scrape pages, crawl sites, search the web, and map URLs using the `firecrawl` CLI, with output saved to `.firecrawl/` to keep context windows clean.

- **[firecrawl/firecrawl-claude-plugin](https://github.com/firecrawl/firecrawl-claude-plugin)** - The same skill packaged as a Claude Code plugin, installable via the plugin system. Contains `plugin.json`, `marketplace.json`, and the skill files for Claude Code's plugin marketplace.

### Follows repo conventions

- Entry format matches `**[org/skill-name](url)** - description` with descriptions under 10 words
- Added as an official team section (Firecrawl publishes and maintains both repos)
- Placed before Community Skills, consistent with other team sections
- Table of Contents updated with matching anchor link
- Purely additive, no existing content changed