### PR TITLE
Add ShieldCortex — persistent memory & security for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -625,6 +625,7 @@ Domain-specific knowledge for Azure SDK and Foundry development.
 - **[jeffersonwarrior/claudisms](https://github.com/jeffersonwarrior/claudisms)** - SMS messaging integration
 - **[SHADOWPR0/security-bluebook-builder](https://github.com/SHADOWPR0/security-bluebook-builder)** - Build security Blue Books for sensitive apps
 - **[obra/defense-in-depth](https://github.com/obra/superpowers/blob/main/skills/defense-in-depth/SKILL.md)** - Multi-layered security approaches
+- **[Drakon-Systems-Ltd/ShieldCortex](https://github.com/Drakon-Systems-Ltd/ShieldCortex/tree/main/skills/shieldcortex)** - Persistent memory with knowledge graphs, decay, contradiction detection, and a 6-layer defence pipeline against memory poisoning. MCP server with 19 tools
 - **[huifer/Claude-Ally-Health](https://github.com/huifer/Claude-Ally-Health)** - A health assistant skill for medical information analysis, symptom tracking, and wellness guidance.
 - **[frmoretto/clarity-gate](https://github.com/frmoretto/clarity-gate)** - Epistemic quality verification for RAG systems
 - **[zechenzhangAGI/AI-research-SKILLs](https://github.com/zechenzhangAGI/AI-research-SKILLs)** - 77 AI research skills for model training, inference, and MLOps


### PR DESCRIPTION
Adds [ShieldCortex](https://github.com/Drakon-Systems-Ltd/ShieldCortex) to the **Specialized Domains** community skills section.

ShieldCortex gives AI agents persistent memory with knowledge graphs, decay-based forgetting, contradiction detection, and a 6-layer defence pipeline that blocks memory poisoning attacks.

- **npm:** [shieldcortex](https://www.npmjs.com/package/shieldcortex) (2,300+ downloads)
- **License:** MIT
- **MCP server** with 19 tools for memory, knowledge graph, security, and audit
- **Skill:** [skills/shieldcortex/SKILL.md](https://github.com/Drakon-Systems-Ltd/ShieldCortex/tree/main/skills/shieldcortex)