### PR TITLE
Add chitin-id to Specialized Domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -628,6 +628,7 @@ Domain-specific knowledge for Azure SDK and Foundry development.
 - **[huifer/Claude-Ally-Health](https://github.com/huifer/Claude-Ally-Health)** - A health assistant skill for medical information analysis, symptom tracking, and wellness guidance.
 - **[frmoretto/clarity-gate](https://github.com/frmoretto/clarity-gate)** - Epistemic quality verification for RAG systems
 - **[zechenzhangAGI/AI-research-SKILLs](https://github.com/zechenzhangAGI/AI-research-SKILLs)** - 77 AI research skills for model training, inference, and MLOps
+- **[EijiAC24/chitin-id](https://clawhub.ai/EijiAC24/chitin-id)** - Birth certificates for AI agents — on-chain identity registration, soul hash verification, chronicle tracking, and selective disclosure via ERC-8004 + soulbound tokens on Base L2. [MCP server](https://www.npmjs.com/package/chitin-mcp-server) also available
 
 </details>
 


### PR DESCRIPTION
Adds [chitin-id](https://clawhub.ai/EijiAC24/chitin-id) to the Community Skills > Specialized Domains section.

Birth certificates for AI agents — on-chain identity registration, soul hash verification, chronicle tracking, and selective disclosure via ERC-8004 + soulbound tokens on Base L2.

- ClawHub: https://clawhub.ai/EijiAC24/chitin-id (security scan: Benign / high confidence)
- MCP Server: `npx -y chitin-mcp-server`
- Contracts: https://github.com/chitin-id/chitin-contracts

🤖 Generated with [Claude Code](https://claude.ai/claude-code)