### PR TITLE
Add learn skill for skill discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,6 +561,7 @@ Domain-specific knowledge for Azure SDK and Foundry development.
 <details>
 <summary><h3 style="display:inline">Development and Testing</h3></summary>
 
+- **[agentskill-sh/learn](https://agentskill.sh/learn)** - Discover and install 44k+ skills for Claude Code, Cursor, Codex with two-layer security scanning
 - **[robzolkos/skill-rails-upgrade](https://github.com/robzolkos/skill-rails-upgrade)** - Analyze Rails apps and provide upgrade assessments
 - **[Shpigford/screenshots](https://github.com/Shpigford/skills/tree/main/screenshots)** - Generate marketing screenshots with Playwright
 - **[antonbabenko/terraform-skill](https://github.com/antonbabenko/terraform-skill)** - Terraform infrastructure as code best practices


### PR DESCRIPTION
Adds the `/learn` skill from [agentskill.sh](https://agentskill.sh) to the Development and Testing section.

**What it does:**
- Search across 44k+ skills for Claude Code, Cursor, Codex
- Two-layer security scanning (server-side + client-side)
- One-command installation: `/learn @owner/skill-name`

[Browse skills](https://agentskill.sh) | [Security dashboard](https://agentskill.sh/security)