### PR TITLE
Add skill: product-on-purpose/pm-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,6 +555,7 @@ Domain-specific knowledge for Azure SDK and Foundry development.
 - **[Shpigford/readme](https://github.com/Shpigford/skills/tree/main/readme)** - Generate comprehensive project documentation
 - **[hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill)** - Minimal, low-friction hierarchical memory system with background agents and filesystem-based persistence
 - **[kreuzberg-dev/kreuzberg](https://github.com/kreuzberg-dev/kreuzberg/tree/main/skills/kreuzberg)** - Extract text, tables, and metadata from 62+ document formats
+- **[product-on-purpose/pm-skills](https://github.com/product-on-purpose/pm-skills)** - 24 product management skills for PRDs, roadmaps, and OKRs
 
 </details>
 


### PR DESCRIPTION
Adds [product-on-purpose/pm-skills](https://github.com/product-on-purpose/pm-skills) to the
Productivity and Collaboration subcategory under Community Skills.

**Entry added:**

- **[product-on-purpose/pm-skills](https://github.com/product-on-purpose/pm-skills)** - 24 product management skills for PRDs, roadmaps, and OKRs

**About the skill:**

- 24 plug-and-play PM skills across 6 product lifecycle phases (Discover, Define, Develop, Deliver, Measure, Iterate)
- Follows the [agentskills.io specification](https://agentskills.io/specification) -- referenced in this repo's own Quality Standards section
- Each skill includes SKILL.md documentation with structured metadata
- v2.3.0 with multiple versioned releases, 100+ merged PRs
- Apache 2.0 licensed
- Compatible with Claude Code, Codex, Cursor, Gemini CLI, and others