### PR TITLE
Add oiloil-ui-ux-guide skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -610,6 +610,7 @@ Official curated skills from OpenAI's skills repository.
 - **[lackeyjb/playwright-skill](https://github.com/lackeyjb/playwright-skill)** - Browser automation with Playwright
 - **[ibelick/ui-skills](https://github.com/ibelick/ui-skills)** - Opinionated, evolving constraints to guide agents when building interfaces
 - **[nextlevelbuilder/ui-ux-pro-max-skill](https://github.com/nextlevelbuilder/ui-ux-pro-max-skill)** - UI/UX design patterns and best practices
+- **[oil-oil/oiloil-ui-ux-guide](https://github.com/oil-oil/oiloil-ui-ux-guide)** - Modern clean UI/UX guidance and review skill with CRAP principles, task-first UX, cognitive load control, and actionable P0/P1/P2 design review checklists
 - **[ehmo/platform-design-skills](https://github.com/ehmo/platform-design-skills)** - 300+ design rules from Apple HIG, Material Design 3, and WCAG 2.2 for cross-platform apps
 - **[scarletkc/vexor](https://github.com/scarletkc/vexor)** - Vector-powered CLI for semantic file search with a Claude/Codex skill
 - **[obra/test-driven-development](https://github.com/obra/superpowers/blob/main/skills/test-driven-development/SKILL.md)** - Write tests before implementing code


### PR DESCRIPTION
Adds oiloil-ui-ux-guide — a modern, clean UI/UX guidance and review skill.

- Two modes: `guide` (do/don't rules) and `review` (P0/P1/P2 fix list)
- Covers CRAP principles, task-first UX, cognitive load, HCI laws, and interaction psychology
- Enforces modern minimal style, no emoji icons, consistent icon sets
- Install: `npx skills add oil-oil/oiloil-ui-ux-guide`

Repo: https://github.com/oil-oil/oiloil-ui-ux-guide