### PR TITLE
Add skill: wondelai/skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,6 +562,7 @@ Official curated skills from OpenAI's skills repository.
 - **[ComposioHQ/content-research-writer](https://github.com/ComposioHQ/awesome-claude-skills/tree/master/content-research-writer)** - Enhance writing with research
 - **[ComposioHQ/competitive-ads-extractor](https://github.com/ComposioHQ/awesome-claude-skills/tree/master/competitive-ads-extractor)** - Analyze competitor advertising
 - **[wshuyi/x-article-publisher-skill](https://github.com/wshuyi/x-article-publisher-skill)** - Publish articles to X/Twitter
+- **[wondelai/skills](https://github.com/wondelai/skills)** - 25 business skills for UX, marketing, sales, and strategy
 
 </details>
 


### PR DESCRIPTION
## What's being added
[wondelai/skills](https://github.com/wondelai/skills) — a marketplace of 25 agent skills for Claude Code organized in 7 plugin collections.

Covers UX design (Refactoring UI, iOS HIG, web typography, usability heuristics), marketing/CRO (StoryBrand, Scorecard Marketing, Contagious), sales (Cialdini's Influence, $100M Offers, Predictable Revenue), product innovation (Lean Startup, Design Sprint, Jobs to Be Done), and business strategy (Blue Ocean, Crossing the Chasm, EOS/Traction, Obviously Awesome).

Each skill provides structured scoring rubrics, diagnostic checklists, and reference materials based on established business books.

## Installation
```bash
npx skills add wondelai/skills
```

## License
MIT