### PR TITLE
Add skill: oil-oil/ios-hig-design-guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -638,6 +638,7 @@ Official curated skills from OpenAI's skills repository.
 - **[rudrankriyam/app-store-connect-cli-skills](https://github.com/rudrankriyam/app-store-connect-cli-skills)** - Automate App Store deployments and management using ASC CLI
 - **[rameerez/claude-code-startup-skills](https://github.com/rameerez/claude-code-startup-skills)** - Skills for building and running software startups, apps, and SaaS
 - **[zscole/model-hierarchy-skill](https://github.com/zscole/model-hierarchy-skill)** - Cost-optimized model routing based on task complexity
+- **[oil-oil/ios-hig-design-guide](https://github.com/oil-oil/ios-hig-design-guide-skill/tree/main/skills/ios-hig-design-guide)** - iOS HIG-based design specs with official source synchronization
 - **[CloudAI-X/threejs-skills](https://github.com/CloudAI-X/threejs-skills)** - Three.js skills for creating 3D elements and interactive experiences
 
 </details>


### PR DESCRIPTION
## Summary
- add oil-oil/ios-hig-design-guide to Community Skills > Development and Testing
- include a concise description following repository entry format

## Skill link
- https://github.com/oil-oil/ios-hig-design-guide-skill/tree/main/skills/ios-hig-design-guide

## Notes
This skill helps generate iOS feature design specs aligned with Apple Human Interface Guidelines and includes a source sync script for refreshing official HIG content.