### PR TITLE
Add Apple HIG Skills to Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -659,6 +659,7 @@ Official curated skills from OpenAI's skills repository.
 <details>
 <summary><h3 style="display:inline">Specialized Domains</h3></summary>
 
+- **[raintree-technology/apple-hig-skills](https://github.com/raintree-technology/apple-hig-skills)** - Apple Human Interface Guidelines as 14 agent skills covering platforms, foundations, components, patterns, inputs, and technologies for iOS, macOS, visionOS, watchOS, and tvOS
 - **[K-Dense-AI/claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)** - Scientific research and analysis skills
 - **[NotMyself/claude-win11-speckit-update-skill](https://github.com/NotMyself/claude-win11-speckit-update-skill)** - Windows 11 system management
 - **[sanjay3290/imagen](https://github.com/sanjay3290/ai-skills/tree/main/skills/imagen)** - Generate images using Google Gemini's API


### PR DESCRIPTION
Adds [apple-hig-skills](https://github.com/raintree-technology/apple-hig-skills) — 14 agent skills providing Apple Human Interface Guidelines for iOS, macOS, visionOS, watchOS, and tvOS design decisions. Covers platforms, foundations, components (layout, controls, dialogs, menus, search, status, system, content), patterns, inputs, and technologies.