### PR TITLE
Add skill: CosmoBlk/email-marketing-bible

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,6 +562,7 @@ Official curated skills from OpenAI's skills repository.
 - **[ComposioHQ/content-research-writer](https://github.com/ComposioHQ/awesome-claude-skills/tree/master/content-research-writer)** - Enhance writing with research
 - **[ComposioHQ/competitive-ads-extractor](https://github.com/ComposioHQ/awesome-claude-skills/tree/master/competitive-ads-extractor)** - Analyze competitor advertising
 - **[wshuyi/x-article-publisher-skill](https://github.com/wshuyi/x-article-publisher-skill)** - Publish articles to X/Twitter
+- **[CosmoBlk/email-marketing-bible](https://github.com/CosmoBlk/email-marketing-bible)** - 55K-word email marketing guide as an AI skill
 
 </details>
 


### PR DESCRIPTION
## What

Adds [CosmoBlk/email-marketing-bible](https://github.com/CosmoBlk/email-marketing-bible) to the **Marketing** subcategory under Community Skills.

## About the skill

The Email Marketing Bible is a 55,000-word, data-backed email marketing guide (908 sources, 16 chapters) packaged as a Claude Code skill. Install it with one command and Claude becomes an email marketing co-pilot — audits setups, drafts sequences, pulls industry benchmarks, and gives sourced recommendations.

- **Install:** `claude install-skill https://github.com/CosmoBlk/email-marketing-bible`
- **Website:** https://emailmarketingskill.com
- **License:** MIT