### PR TITLE
Add the-council: multi-model advisory board skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -700,6 +700,7 @@ Official curated skills from OpenAI's skills repository.
 - **[SeanZoR/claude-speed-reader](https://github.com/SeanZoR/claude-speed-reader)** -Speed read Claude's responses at 600+ WPM using RSVP with Spritz-style ORP highlighting
 - **[Skill_Seekers](https://github.com/yusufkaraaslan/Skill_Seekers)** -Automatically convert documentation websites, GitHub repositories, and PDFs into Claude AI skills in minutes.
 - **[blader/humanizer](https://github.com/blader/humanizer)** - Remove signs of AI-generated writing from text, making it sound more natural and human
+- **[DantesPeak85/the-council](https://github.com/DantesPeak85/the-council)** - Multi-model advisory board that invokes Codex and Gemini CLIs in parallel for second opinions on code reviews, architecture, and debugging
 
 </details>
 


### PR DESCRIPTION
Adds [the-council](https://github.com/DantesPeak85/the-council) to the Community Skills > Other section.

**What it does:** Invokes OpenAI Codex CLI and Google Gemini CLI in parallel as an advisory board for code reviews, architecture evaluation, debugging, and general engineering decisions. Both advisors run in read-only sandboxes with full codebase access, and Claude synthesizes their responses into a unified recommendation.

**Key features:**
- Parallel CLI invocation with read-only sandboxes
- Startup preflight check with graceful single-advisor degradation
- Prompt templates for code review, architecture, debugging, and general advisory
- Claude Code plugin marketplace structure for easy installation