### PR TITLE
Add EUrouter Integration skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,6 +640,7 @@ Official curated skills from OpenAI's skills repository.
 - **[rameerez/claude-code-startup-skills](https://github.com/rameerez/claude-code-startup-skills)** - Skills for building and running software startups, apps, and SaaS
 - **[zscole/model-hierarchy-skill](https://github.com/zscole/model-hierarchy-skill)** - Cost-optimized model routing based on task complexity
 - **[CloudAI-X/threejs-skills](https://github.com/CloudAI-X/threejs-skills)** - Three.js skills for creating 3D elements and interactive experiences
+- **[EUrouter/eurouter-skill](https://github.com/EUrouter/eurouter-skill)** - Integrate EUrouter, an OpenAI-compatible AI gateway for EU/GDPR compliance with data residency controls, provider routing, and zero-data-retention
 
 </details>
 


### PR DESCRIPTION
Adds [EUrouter Integration](https://github.com/EUrouter/eurouter-skill) to the Community Skills > Development and Testing section.

EUrouter is an OpenAI-compatible AI gateway built for EU customers who need GDPR compliance. This skill helps developers integrate EUrouter into their applications, covering:

- Drop-in migration from OpenAI or OpenRouter
- EU/GDPR compliance configuration (data residency, zero-data-retention)
- All API endpoints: chat completions, embeddings, streaming, tool calling, vision
- Multi-model fallback routing

**Install:** `npx skills add eurouter/eurouter-skill`