### PR TITLE
Add skill: nerddaddy/web-demo-video_skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -607,6 +607,7 @@ Official curated skills from OpenAI's skills repository.
 - **[sanjay3290/deep-research](https://github.com/sanjay3290/ai-skills/tree/main/skills/deep-research)** - Autonomous multi-step research using Gemini Deep Research Agent
 - **[jthack/ffuf-claude-skill](https://github.com/jthack/ffuf_claude_skill)** - Web fuzzing with ffuf
 - **[lackeyjb/playwright-skill](https://github.com/lackeyjb/playwright-skill)** - Browser automation with Playwright
+- **[nerddaddy/web-demo-video_skills](https://github.com/nerddaddy/web-demo-video_skills)** - Auto-generate website demo videos with Playwright + Remotion
 - **[ibelick/ui-skills](https://github.com/ibelick/ui-skills)** - Opinionated, evolving constraints to guide agents when building interfaces
 - **[nextlevelbuilder/ui-ux-pro-max-skill](https://github.com/nextlevelbuilder/ui-ux-pro-max-skill)** - UI/UX design patterns and best practices
 - **[ehmo/platform-design-skills](https://github.com/ehmo/platform-design-skills)** - 300+ design rules from Apple HIG, Material Design 3, and WCAG 2.2 for cross-platform apps


### PR DESCRIPTION
## Skill Details

- **Name:** nerddaddy/web-demo-video_skills
- **URL:** https://github.com/nerddaddy/web-demo-video_skills
- **Category:** Community Skills > Development and Testing
- **Description:** Auto-generate website demo videos with Playwright + Remotion

## What it does

A Claude Code skill that auto-generates polished website demo videos:

1. Records website interactions via Playwright (each scene as separate clip)
2. Composites with Remotion: branded intro/outro, 3 caption styles, virtual cursor with click effects, scene transitions
3. Outputs production-ready MP4

Placed next to `lackeyjb/playwright-skill` in Development and Testing as it extends Playwright capabilities into video production.

## Checklist

- [x] Public repository
- [x] SKILL.md documentation
- [x] README with usage instructions
- [x] MIT License
- [x] Entry format follows convention