### PR TITLE
Add propel-code-skills to Development and Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -627,6 +627,7 @@ Official curated skills from OpenAI's skills repository.
 - **[obra/commands](https://github.com/obra/superpowers/tree/main/skills/commands)** - Create and manage command structures
 - **[obra/writing-skills](https://github.com/obra/superpowers/blob/main/skills/writing-skills/SKILL.md)** - Develop and document capabilities
 - **[fvadicamo/dev-agent-skills](https://github.com/fvadicamo/dev-agent-skills)** - Git and GitHub workflow skills for commits, PRs, and code reviews
+- **[propel-gtm/propel-code-skills](https://github.com/propel-gtm/propel-code-skills)** - Propel diff review skills for PR triage and fixes
 - **[omkamal/pypict-skill](https://github.com/omkamal/pypict-claude-skill/blob/main/SKILL.md)** - Pairwise test generation
 - **[alinaqi/claude-bootstrap](https://github.com/alinaqi/claude-bootstrap)** - Opinionated project initialization with security-first guardrails, spec-driven atomic todos, LLM testing patterns, and CLI tool orchestration (gh, vercel, supabase)
 - **[ZhangHanDong/makepad-skills](https://github.com/ZhangHanDong/makepad-skills)** - Makepad UI development skills for Rust apps: setup, patterns, shaders, packaging, and troubleshooting.


### PR DESCRIPTION
Adds one Development and Testing community skill entry:
- [propel-gtm/propel-code-skills](https://github.com/propel-gtm/propel-code-skills)

Description kept short per contribution guidelines.