### PR TITLE
Add skill: nextauralabs/shelter-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -591,6 +591,7 @@ Official curated skills from OpenAI's skills repository.
 - **[hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill)** - Minimal, low-friction hierarchical memory system with background agents and filesystem-based persistence
 - **[kreuzberg-dev/kreuzberg](https://github.com/kreuzberg-dev/kreuzberg/tree/main/skills/kreuzberg)** - Extract text, tables, and metadata from 62+ document formats
 - **[Paramchoudhary/ResumeSkills](https://github.com/Paramchoudhary/ResumeSkills)** - 20 specialized skills for resume optimization, ATS analysis, interview prep, and career transitions
+- **[nextauralabs/shelter-skill](https://github.com/nextauralabs/shelter-skill)** - Connect agents to real bank data for spending, forecasting, and coaching
 
 </details>
 


### PR DESCRIPTION
## Skill

- **[nextauralabs/shelter-skill](https://github.com/nextauralabs/shelter-skill)** - Connect agents to real bank data for spending, forecasting, and coaching

## Category

Productivity and Collaboration (alongside other financial tools like charlie-cfo-skill)

## What it does

[Shelter](https://shelter.money) connects bank accounts via Plaid and tells you when you'll run out of money before it happens. This skill gives AI agents read-only access to that data — safe-to-spend, cash forecasts, zombie subscriptions, affordability checks, and AI coaching.

Users sign up at [shelter.money](https://shelter.money), connect their bank, and generate a scoped API key. The skill handles endpoint selection, response interpretation, and coaching tone automatically.

## Checklist

- [x] Public repository with working skill
- [x] SKILL.md with documentation
- [x] README with install instructions
- [x] Added to end of matching subcategory
- [x] Description is 10 words or fewer