### PR TITLE
Add skill: jcoulaud/ship-my-token

### DIFF
--- a/README.md
+++ b/README.md
@@ -674,6 +674,7 @@ Official curated skills from OpenAI's skills repository.
 - **[prompt-security/clawsec](https://github.com/prompt-security/clawsec)** - Security skill suite with drift detection, automated audits, and skill integrity verification
 - **[lawvable/awesome-legal-skills](https://github.com/lawvable/awesome-legal-skills)** - Curated agent skills for automating legal workflows
 - **[peas/genealogy-research](https://paulo.com.br/skills/genealogy-research/SKILL.md)** - Genealogy research agent with OCR, FamilySearch, YAML data, and human-in-the-loop
+- **[jcoulaud/ship-my-token](https://github.com/jcoulaud/shipmytoken-skill)** - Launch Solana tokens on Pump.fun via chat
 
 </details>
 


### PR DESCRIPTION
## Skill

- **[jcoulaud/ship-my-token](https://github.com/jcoulaud/shipmytoken-skill)** - Launch Solana tokens on Pump.fun via chat

## What it does

Ship My Token is an Agent Skill that lets users launch Solana tokens on Pump.fun through natural conversation. It handles the full token lifecycle: creation, creator fee management, fee claiming/sharing, portfolio tracking, and daily recaps.

## Why it belongs here

- **Open source** — [github.com/jcoulaud/shipmytoken-skill](https://github.com/jcoulaud/shipmytoken-skill)
- **Active development** — 15+ releases since initial launch, detailed changelog
- **Documentation** — full docs at [shipmytoken.com](https://shipmytoken.com)
- **Works with all agents** — Claude Code, Cursor, Windsurf, OpenClaw, and any Agent Skills-compatible tool
- **Category**: Added to Specialized Domains (crypto/blockchain domain skill)