### PR TITLE
Add skill: shimo4228/claude-skill-search-first

### DIFF
--- a/README.md
+++ b/README.md
@@ -638,6 +638,7 @@ Official curated skills from OpenAI's skills repository.
 - **[rameerez/claude-code-startup-skills](https://github.com/rameerez/claude-code-startup-skills)** - Skills for building and running software startups, apps, and SaaS
 - **[zscole/model-hierarchy-skill](https://github.com/zscole/model-hierarchy-skill)** - Cost-optimized model routing based on task complexity
 - **[CloudAI-X/threejs-skills](https://github.com/CloudAI-X/threejs-skills)** - Three.js skills for creating 3D elements and interactive experiences
+- **[shimo4228/claude-skill-search-first](https://github.com/shimo4228/claude-skill-search-first)** - Research-before-coding workflow with adopt/extend/build decisions
 
 </details>
 


### PR DESCRIPTION
Adds [shimo4228/claude-skill-search-first](https://github.com/shimo4228/claude-skill-search-first) to the Development and Testing section.

**What it does:** Research-before-coding workflow — searches npm/PyPI, MCP servers, GitHub, and existing skills before writing custom code. Makes an informed adopt/extend/build decision.

**Category:** Development and Testing (Community Skills)