### PR TITLE
Add skill: shimo4228/claude-skill-stocktake

### DIFF
--- a/README.md
+++ b/README.md
@@ -638,6 +638,7 @@ Official curated skills from OpenAI's skills repository.
 - **[rameerez/claude-code-startup-skills](https://github.com/rameerez/claude-code-startup-skills)** - Skills for building and running software startups, apps, and SaaS
 - **[zscole/model-hierarchy-skill](https://github.com/zscole/model-hierarchy-skill)** - Cost-optimized model routing based on task complexity
 - **[CloudAI-X/threejs-skills](https://github.com/CloudAI-X/threejs-skills)** - Three.js skills for creating 3D elements and interactive experiences
+- **[shimo4228/claude-skill-stocktake](https://github.com/shimo4228/claude-skill-stocktake)** - Audit agent skills for quality with checklist + AI judgment
 
 </details>
 


### PR DESCRIPTION
Adds [shimo4228/claude-skill-stocktake](https://github.com/shimo4228/claude-skill-stocktake) to the Development and Testing section.

**What it does:** Audits all agent skills for quality using a checklist + AI holistic judgment. Produces Keep/Improve/Update/Retire/Merge verdicts. Includes Quick Scan (changed only) and Full Stocktake modes with shell scripts for inventory and diff detection.

**Category:** Development and Testing (Community Skills)