### PR TITLE
Add agentskill-sh/learn to Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -638,6 +638,7 @@ Official curated skills from OpenAI's skills repository.
 - **[rameerez/claude-code-startup-skills](https://github.com/rameerez/claude-code-startup-skills)** - Skills for building and running software startups, apps, and SaaS
 - **[zscole/model-hierarchy-skill](https://github.com/zscole/model-hierarchy-skill)** - Cost-optimized model routing based on task complexity
 - **[CloudAI-X/threejs-skills](https://github.com/CloudAI-X/threejs-skills)** - Three.js skills for creating 3D elements and interactive experiences
+- **[agentskill-sh/learn](https://github.com/agentskill-sh/learn)** - Search and install agent skills from a 44k+ community catalog with security scanning
 
 </details>
 


### PR DESCRIPTION
Adds [agentskill-sh/learn](https://github.com/agentskill-sh/learn) to the Development and Testing section under Community Skills.

**What it does:** A skill that lets agents search and install skills from the [agentskill.sh](https://agentskill.sh) community catalog (44,000+ indexed skills). Every skill is security-scanned before install (prompt injection, RCE, credential exfiltration, obfuscation detection).

**Cross-platform:** Works with Claude Code, Codex, Cursor, Copilot, Windsurf, Cline, and more.

**Community adoption:** Already listed on multiple awesome lists, referenced in [Zed skills support discussion](https://github.com/zed-industries/zed/issues/49057), and [submitted to OpenAI skills repo](https://github.com/openai/skills/pull/152).