### PR TITLE
Add Twitter/X skills (claude-skill-twitter)

### DIFF
--- a/README.md
+++ b/README.md
@@ -560,6 +560,7 @@ Official curated skills from OpenAI's skills repository.
 - **[ComposioHQ/competitive-ads-extractor](https://github.com/ComposioHQ/awesome-claude-skills/tree/master/competitive-ads-extractor)** - Analyze competitor advertising
 - **[wshuyi/x-article-publisher-skill](https://github.com/wshuyi/x-article-publisher-skill)** - Publish articles to X/Twitter
 - **[CosmoBlk/email-marketing-bible](https://github.com/CosmoBlk/email-marketing-bible)** - 55K-word email marketing guide as an AI skill
+- **[PHY041/claude-skill-twitter](https://github.com/PHY041/claude-skill-twitter)** - 3 Twitter/X skills for account growth, keyword search (200+ tweets), and content strategy. Powered by rnet (bypasses Cloudflare) — no API key needed, just browser cookies
 
 </details>
 


### PR DESCRIPTION
## Summary

- Adds [claude-skill-twitter](https://github.com/PHY041/claude-skill-twitter) to the **Marketing** category under Community Skills
- 3 skills for Twitter/X automation:
  - **twitter-cultivate**: Account growth, TweepCred health scoring, shadowban check
  - **twitter-intel**: Keyword search (200+ tweets per query), engagement filtering, trend analysis
  - **twitter-x-gtm**: Content strategy, hook formulas, thread templates
- Core tech: `rnet_twitter.py` — async GraphQL client powered by [rnet](https://github.com/penumbra-x/rnet) (Rust HTTP client that bypasses Cloudflare TLS fingerprinting)
- No API key needed — uses browser cookies only

## Why it fits Marketing

These skills automate Twitter/X growth and content strategy workflows, similar to existing entries like `x-article-publisher-skill` and `marketingskills` in the Marketing section.

## Test plan

- [ ] Entry format matches existing Marketing section entries
- [ ] Link resolves to valid GitHub repo
- [ ] Description is concise and accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)