### PR TITLE
Add LinkedIn automation skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -591,6 +591,7 @@ Official curated skills from OpenAI's skills repository.
 - **[hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill)** - Minimal, low-friction hierarchical memory system with background agents and filesystem-based persistence
 - **[kreuzberg-dev/kreuzberg](https://github.com/kreuzberg-dev/kreuzberg/tree/main/skills/kreuzberg)** - Extract text, tables, and metadata from 62+ document formats
 - **[Paramchoudhary/ResumeSkills](https://github.com/Paramchoudhary/ResumeSkills)** - 20 specialized skills for resume optimization, ATS analysis, interview prep, and career transitions
+- **[Linked-API/linkedin-skills](https://github.com/Linked-API/linkedin-skills/tree/main/linkedin)** - CLI-based LinkedIn automation for profiles, searches, messaging, connections, posts, and Sales Navigator
 
 </details>
 


### PR DESCRIPTION
Adds [Linked-API/linkedin-skills](https://github.com/Linked-API/linkedin-skills/tree/main/linkedin) to the **Productivity and Collaboration** section.

**What it does:** CLI-based LinkedIn automation — fetch profiles, search people/companies, send messages, manage connections, create posts, and use Sales Navigator.

**Skill format:** Standard SKILL.md  
**Dependency:** `@linkedapi/linkedin-cli` npm package  
**License:** MIT