### PR TITLE
Add skill: AppDeploy-AI/skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -639,6 +639,7 @@ Official curated skills from OpenAI's skills repository.
 - **[zscole/model-hierarchy-skill](https://github.com/zscole/model-hierarchy-skill)** - Cost-optimized model routing based on task complexity
 - **[CloudAI-X/threejs-skills](https://github.com/CloudAI-X/threejs-skills)** - Three.js skills for creating 3D elements and interactive experiences
 - **[Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill)** - High-agency frontend skill that gives AI good taste with tunable design variance, motion intensity, and visual density to stop generic UI slop
+- **[AppDeploy-AI/skills](https://github.com/AppDeploy-AI/skills)** - Chat-native deployment: get a live URL from your AI chat in seconds
 
 </details>
 


### PR DESCRIPTION
Adds [AppDeploy-AI/skills](https://github.com/AppDeploy-AI/skills) to the Development and Testing section.

Chat-native deployment: get a live URL from your AI chat in seconds. Supports frontend, backend, cron jobs, database, file storage, AI capabilities, auth, and notifications.

- Skill repo: https://github.com/AppDeploy-AI/skills
- Website: https://appdeploy.ai