### PR TITLE
Add chrome-store-publish - Chrome Web Store publishing automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -639,6 +639,7 @@ Official curated skills from OpenAI's skills repository.
 - **[zscole/model-hierarchy-skill](https://github.com/zscole/model-hierarchy-skill)** - Cost-optimized model routing based on task complexity
 - **[CloudAI-X/threejs-skills](https://github.com/CloudAI-X/threejs-skills)** - Three.js skills for creating 3D elements and interactive experiences
 - **[Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill)** - High-agency frontend skill that gives AI good taste with tunable design variance, motion intensity, and visual density to stop generic UI slop
+- **[ofelipelourenco/chrome-store-publish](https://github.com/ofelipelourenco/chrome-store-publish)** - Automates Chrome extension preparation for Chrome Web Store publishing with 7-phase workflow (audit, cleanup, build, legal, listing, assets, validation)
 
 </details>
 


### PR DESCRIPTION
## chrome-store-publish

**Description:** Claude Code skill that automates Chrome extension preparation for Chrome Web Store publishing. 7-phase workflow from permission audit to submission-ready package.

**Repository:** https://github.com/ofelipelourenco/chrome-store-publish

**Key Features:**
- Automatic permission audit (flags unused APIs)
- MV3 compliance enforcement
- Clean production ZIP builder
- Privacy policy generator (GDPR-aware)
- Store listing copy writer
- Screenshot/asset generator (HTML → PNG via Playwright)
- 17-point pre-submission validation

**Use Case:** Chrome extension developers preparing for Chrome Web Store submission.

**Status:** Stable, fully documented, Apache 2.0 licensed.