### PR TITLE
Add skill: RoundTable02/tutor-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -591,6 +591,7 @@ Official curated skills from OpenAI's skills repository.
 - **[hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill)** - Minimal, low-friction hierarchical memory system with background agents and filesystem-based persistence
 - **[kreuzberg-dev/kreuzberg](https://github.com/kreuzberg-dev/kreuzberg/tree/main/skills/kreuzberg)** - Extract text, tables, and metadata from 62+ document formats
 - **[Paramchoudhary/ResumeSkills](https://github.com/Paramchoudhary/ResumeSkills)** - 20 specialized skills for resume optimization, ATS analysis, interview prep, and career transitions
+- **[RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills)** - Transform docs or codebases into Obsidian StudyVaults with interactive quizzes
 
 </details>
 


### PR DESCRIPTION
## What

Adds [RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills) to the **Productivity and Collaboration** subcategory under Community Skills.

## About the skill

Tutor Skills is a two-part Obsidian StudyVault skill set:

1. **tutor-setup** — Transforms knowledge sources (PDFs, text, web pages, or entire codebases) into structured Obsidian vaults with study notes and practice questions.
2. **tutor** — Interactive quiz tutor that runs diagnostic assessments, drills weak areas, and tracks learning progress within the generated vault.

- **Install:** `claude install-skill https://github.com/RoundTable02/tutor-skills`
- **License:** MIT