### PR TITLE
Add VMware-AIops skill to Specialized Domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -694,6 +694,7 @@ Official curated skills from OpenAI's skills repository.
 - **[prompt-security/clawsec](https://github.com/prompt-security/clawsec)** - Security skill suite with drift detection, automated audits, and skill integrity verification
 - **[lawvable/awesome-legal-skills](https://github.com/lawvable/awesome-legal-skills)** - Curated agent skills for automating legal workflows
 - **[peas/genealogy-research](https://paulo.com.br/skills/genealogy-research/SKILL.md)** - Genealogy research agent with OCR, FamilySearch, YAML data, and human-in-the-loop
+- **[zw008/VMware-AIops](https://github.com/zw008/VMware-AIops)** - AI-powered VMware vCenter/ESXi monitoring and operations: inventory queries, health/alarms, VM lifecycle (create, delete, snapshot, clone, migrate), vSAN management, Aria Operations analytics, and scheduled log scanning. Supports Claude Code, Gemini CLI, Codex, Aider, Trae, Kimi, and MCP.
 
 </details>
 


### PR DESCRIPTION
## Summary

- Add [VMware-AIops](https://github.com/zw008/VMware-AIops) to the **Specialized Domains** section

## About the Skill

AI-powered VMware vCenter/ESXi monitoring and operations tool that enables natural language infrastructure management:

- **Inventory**: VMs, hosts, datastores, clusters, networks
- **Health**: Alarms, events, hardware sensors, host services
- **VM Lifecycle**: Power, create, delete, snapshot, clone, vMotion
- **vSAN**: Health, capacity, disk groups, performance
- **Aria Operations**: Historical metrics, anomaly detection, capacity planning
- **VKS**: Kubernetes cluster management
- **Scanning**: Scheduled log scanning with Slack/Discord webhooks

## Platform Support

Supports 9+ AI platforms: Claude Code, Gemini CLI, Codex, Aider, Continue, Trae IDE, Kimi, MCP Server, and standalone CLI.

## Links

- GitHub: https://github.com/zw008/VMware-AIops
- Skills.sh: https://skills.sh/zw008/vmware-aiops/vmware-aiops
- License: MIT