### PR TITLE
Add shmlkv/dna-claude-analysis — personal genome analysis toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -688,6 +688,7 @@ Official curated skills from OpenAI's skills repository.
 - **[SHADOWPR0/security-bluebook-builder](https://github.com/SHADOWPR0/security-bluebook-builder)** - Build security Blue Books for sensitive apps
 - **[obra/defense-in-depth](https://github.com/obra/superpowers/blob/main/skills/defense-in-depth/SKILL.md)** - Multi-layered security approaches
 - **[huifer/Claude-Ally-Health](https://github.com/huifer/Claude-Ally-Health)** - A health assistant skill for medical information analysis, symptom tracking, and wellness guidance.
+- **[shmlkv/dna-claude-analysis](https://github.com/shmlkv/dna-claude-analysis)** - Personal genome analysis toolkit with Python scripts analyzing raw DNA data across 17 categories (health risks, ancestry, pharmacogenomics, nutrition, psychology, and more) and generating a terminal-style single-page HTML visualization.
 - **[frmoretto/clarity-gate](https://github.com/frmoretto/clarity-gate)** - Epistemic quality verification for RAG systems
 - **[zechenzhangAGI/AI-research-SKILLs](https://github.com/zechenzhangAGI/AI-research-SKILLs)** - 77 AI research skills for model training, inference, and MLOps
 - **[Orchestra-Research/AI-research-SKILLs](https://github.com/Orchestra-Research/AI-research-SKILLs)** - 20-module AI research skill library for model architecture, training, and ML paper writing


### PR DESCRIPTION
## What this adds

**[shmlkv/dna-claude-analysis](https://github.com/shmlkv/dna-claude-analysis)** — Personal genome analysis toolkit with Python scripts analyzing raw DNA data across 17 categories (health risks, ancestry, pharmacogenomics, nutrition, psychology, and more) and generating a terminal-style single-page HTML visualization.

## Section

Added to **Specialized Domains** alongside other health and science skills.

## Checklist

- [x] Entry follows the existing format: `**[user/repo](url)** - Description`
- [x] Description is concise and specific about what the skill does
- [x] Placed alphabetically within the section
- [x] Project is publicly accessible on GitHub