### PR TITLE
Add metrillm — local LLM benchmarking skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -661,6 +661,7 @@ Official curated skills from OpenAI's skills repository.
 - **[zscole/model-hierarchy-skill](https://github.com/zscole/model-hierarchy-skill)** - Cost-optimized model routing based on task complexity
 - **[CloudAI-X/threejs-skills](https://github.com/CloudAI-X/threejs-skills)** - Three.js skills for creating 3D elements and interactive experiences
 - **[Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill)** - High-agency frontend skill that gives AI good taste with tunable design variance, motion intensity, and visual density to stop generic UI slop
+- **[MetriLLM/metrillm](https://github.com/MetriLLM/metrillm)** - Benchmark local LLM models — measures tok/s, TTFT, memory, quality (reasoning, math, coding, instruction following, structured output, multilingual), and hardware fitness verdict. Works with Ollama.
 
 </details>
 


### PR DESCRIPTION
## New skill: metrillm

**Repository**: https://github.com/MetriLLM/metrillm
**SKILL.md**: https://github.com/MetriLLM/metrillm/blob/main/SKILL.md

### Description

MetriLLM benchmarks local LLM models directly from any AI coding assistant. Measures performance (tok/s, TTFT, memory) and quality (reasoning, math, coding, instruction following, structured output, multilingual). Computes a hardware fitness verdict adapted to your machine.

### Compatible with

Claude Code, Codex, Gemini CLI, Cursor, GitHub Copilot, Windsurf, OpenCode

### Installation

```bash
# Claude Code
cp SKILL.md ~/.claude/skills/metrillm/SKILL.md
```