### PR TITLE
Add skill: testdino-hq/playwright-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -662,6 +662,7 @@ Official curated skills from OpenAI's skills repository.
 - **[zscole/model-hierarchy-skill](https://github.com/zscole/model-hierarchy-skill)** - Cost-optimized model routing based on task complexity
 - **[CloudAI-X/threejs-skills](https://github.com/CloudAI-X/threejs-skills)** - Three.js skills for creating 3D elements and interactive experiences
 - **[Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill)** - High-agency frontend skill that gives AI good taste with tunable design variance, motion intensity, and visual density to stop generic UI slop
+- **[testdino-hq/playwright-skill](https://github.com/testdino-hq/playwright-skill)** - 70+ production-tested Playwright automation testing patterns: E2E, POM, CI/CD, migrations, CLI
 
 </details>
 


### PR DESCRIPTION
Adds [testdino-hq/playwright-skill](https://github.com/testdino-hq/playwright-skill) to the Community Skills > Development and Testing section.

**What it is:** 70+ production-tested Playwright automation testing patterns organized into 5 packs — core, POM, CI/CD, migrations, and Playwright CLI.

**How it differs from existing Playwright entries:**

| | lackeyjb/playwright-skill | testdino-hq/playwright-skill |
|---|---|---|
| **Type** | Runtime browser automation — generates and executes scripts on-the-fly | Structured knowledge base — 70+ guides that teach agents to write production-grade tests |
| **Scope** | General-purpose browser automation | Testing patterns: E2E, API, component, visual, accessibility, security |
| **CI/CD** | No CI pipeline coverage | 9 guides across GitHub Actions, GitLab CI, CircleCI, Azure DevOps, Jenkins |
| **POM** | Not covered | Dedicated Page Object Model pack |
| **Migrations** | Not covered | Cypress and Selenium migration guides |
| **CLI** | Not covered | 11-guide Playwright CLI pack for token-efficient browser automation |

These two skills are complementary — one runs automation, the other teaches agents how to write better tests.