### PR TITLE
Add skill: hamelsmu/evals-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -791,6 +791,13 @@ Official Web3 and trading skills from the Binance team. Includes crypto market d
 - **[NeoLabHQ/ddd](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/ddd)** - Domain-driven development skills that also include Clean Architecture, SOLID principles, and design patterns.
 - **[NeoLabHQ/sadd](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/sadd)** - Dispatches independent subagents for individual tasks with code review checkpoints between iterations for rapid, controlled development.
 - **[NeoLabHQ/kaizen](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/kaizen)** - Applies continuous improvement methodology with multiple analytical approaches, based on Japanese Kaizen philosophy and Lean methodology.
+- **[hamelsmu/eval-audit](https://github.com/hamelsmu/prompts/tree/main/evals-skills/skills/eval-audit)** - Audit LLM eval pipelines and surface problems
+- **[hamelsmu/error-analysis](https://github.com/hamelsmu/prompts/tree/main/evals-skills/skills/error-analysis)** - Systematically identify failure modes in LLM pipelines
+- **[hamelsmu/generate-synthetic-data](https://github.com/hamelsmu/prompts/tree/main/evals-skills/skills/generate-synthetic-data)** - Create diverse synthetic test inputs for LLM evals
+- **[hamelsmu/write-judge-prompt](https://github.com/hamelsmu/prompts/tree/main/evals-skills/skills/write-judge-prompt)** - Design LLM-as-Judge evaluators for subjective criteria
+- **[hamelsmu/validate-evaluator](https://github.com/hamelsmu/prompts/tree/main/evals-skills/skills/validate-evaluator)** - Calibrate LLM judges against human labels
+- **[hamelsmu/evaluate-rag](https://github.com/hamelsmu/prompts/tree/main/evals-skills/skills/evaluate-rag)** - Evaluate RAG retrieval and generation quality
+- **[hamelsmu/build-review-interface](https://github.com/hamelsmu/prompts/tree/main/evals-skills/skills/build-review-interface)** - Build annotation interfaces for reviewing LLM traces
 
 </details>
 


### PR DESCRIPTION
## Summary

Adds 7 LLM evaluation skills from [hamelsmu/prompts/evals-skills](https://github.com/hamelsmu/prompts/tree/main/evals-skills) to the **Development and Testing** section. These skills guide AI coding agents through building trustworthy LLM evaluations, based on patterns from helping 50+ companies and the [AI Evals course](https://maven.com/parlance-labs/fine-tuning).

**Skills added:**
- **eval-audit** - Audit LLM eval pipelines and surface problems
- **error-analysis** - Systematically identify failure modes in LLM pipelines
- **generate-synthetic-data** - Create diverse synthetic test inputs for LLM evals
- **write-judge-prompt** - Design LLM-as-Judge evaluators for subjective criteria
- **validate-evaluator** - Calibrate LLM judges against human labels
- **evaluate-rag** - Evaluate RAG retrieval and generation quality
- **build-review-interface** - Build annotation interfaces for reviewing LLM traces

## Context

This was prompted by @omerfarukaplak's [invitation on X](https://x.com/omerfarukaplak/status/2029270930552439281) in response to the [evals-skills announcement](https://x.com/HamelHusain/status/2029222891854811296).

🤖 Generated with [Claude Code](https://claude.com/claude-code)