### PR TITLE
Add skill: cwinvestments/memstack

### DIFF
--- a/README.md
+++ b/README.md
@@ -849,6 +849,7 @@ Official Web3 and trading skills from the Binance team. Includes crypto market d
 - **[muratcankoylan/evaluation](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/evaluation)** - Build evaluation frameworks for agent systems
 - **[k-kolomeitsev/data-structure-protocol](https://github.com/k-kolomeitsev/data-structure-protocol)** - Graph-based long-term memory skill for AI (LLM) coding agents — faster context, fewer tokens, safer refactors
 - **[NeoLabHQ/prompt-engineering](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/customaize-agent/skills/prompt-engineering)** - Widely used prompt engineering techniques and patterns, including Anthropic best practices and agent persuasion principles.
+- **[cwinvestments/memstack](https://github.com/cwinvestments/memstack)** - Skill framework with session memory, auto-triggers, and context persistence
 
 </details>
 


### PR DESCRIPTION
Adding [MemStack](https://github.com/cwinvestments/memstack) to Context Engineering.

**What it does:** Structured skill framework for Claude Code with 47 auto-trigger skills, SQLite-backed session memory (diary + echo recall), progress tracking, and context persistence across sessions. Skills use YAML frontmatter and activate automatically based on natural language triggers.

**Category:** Context Engineering — session memory, context persistence, and structured skill methodology.

**Production usage:** Actively used across 35+ projects over 3+ months of continuous development and iteration.

**Requirements check:**
- ✅ Public repo with working skills
- ✅ Documentation (README + SKILL.md files with YAML frontmatter)
- ✅ MIT license
- ✅ Community usage across 35+ projects