### PR TITLE
Add Agent Cards skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -951,3 +951,4 @@ MIT License - see [LICENSE](LICENSE)
 This is a curated list. Skills listed here are created and maintained by their respective authors and teams, not by us. We select community-adopted, proven skills and do not audit, endorse, or guarantee the security or correctness of listed projects. They are not security-audited and should be reviewed before production use.
 
 If you find an issue with a listed skill or want your skill removed, please [open an issue](https://github.com/VoltAgent/awesome-agent-skills/issues) and we'll take care of it promptly.
+| [agent-cards-skill](https://github.com/agent-cards/skill) | Manage prepaid virtual Visa cards for AI agents. Create cards, check balances, view credentials, close cards, and get support via MCP tools. |


### PR DESCRIPTION
## Summary

Adds [agent-cards/skill](https://github.com/agent-cards/skill) to the list.

**Agent Cards** lets AI agents create and spend prepaid virtual Visa cards — each with a fixed budget, real card credentials, and full MCP integration. The skill teaches agents how to:

- **Create cards** — set a dollar amount, complete Stripe Checkout, get a card back
- **Check balances** — quick balance lookup
- **View card credentials** — full card number, CVV, expiry (with email approval)
- **Close cards** — permanent closure with user confirmation
- **Get support** — open and manage support conversations

Works with Claude Code, Codex, and any agent that supports SKILL.md.

- **Repo:** https://github.com/agent-cards/skill
- **Product:** https://agentcard.sh
- **Install:** `npx skills add agent-cards/skill`