### PR TITLE
Add skills from: phuryn/pm-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -688,7 +688,7 @@ Official Web3 and trading skills from the Binance team. Includes crypto market d
 <details>
 <summary><h3 style="display:inline">Product Management Skills by Pawel Huryn</h3></summary>
 
-65 product management skills by [Paweł Huryn](https://github.com/phuryn), creator of The Product Compass newsletter (130K+ subscribers). Covers the full PM lifecycle — from discovery and strategy to execution, analytics, and go-to-market — with frameworks from Teresa Torres, Geoffrey Moore, and more.
+65 product management skills by [Paweł Huryn](https://github.com/phuryn), creator of The Product Compass newsletter. Covers the full PM lifecycle — from discovery and strategy to execution, analytics, and go-to-market — with frameworks from Teresa Torres, Geoffrey Moore, and more.
 
 **Data Analytics**
 


### PR DESCRIPTION
65 product management skills across 8 domain plugins (discovery, strategy, execution, analytics, GTM, and more) by Paweł Huryn, creator of [The Product Compass](https://www.productcompass.pm/) newsletter (130K+ subscribers).

Structured as a plugin marketplace similar to Dean Peters' collection — sub-grouped by domain rather than a flat list, since the skills are organized into focused plugins (pm-execution, pm-product-discovery, etc.).

Repository: https://github.com/phuryn/pm-skills — 2,500+ stars in 4 days, actively maintained.