### PR TITLE
Add skill: altmbr/research-orchestrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -794,6 +794,7 @@ Official Web3 and trading skills from the Binance team. Includes crypto market d
 - **[hamelsmu/build-review-interface](https://github.com/hamelsmu/prompts/tree/main/evals-skills/skills/build-review-interface)** - Build annotation interfaces for reviewing LLM traces
 - **[wrsmith108/varlock-claude-skill](https://github.com/wrsmith108/varlock-claude-skill)** - Secure environment variable management ensuring secrets are never exposed in Claude sessions, terminals, logs, or git commits
 - **[Skill_Seekers](https://github.com/yusufkaraaslan/Skill_Seekers)** - Automatically convert documentation websites, GitHub repositories, and PDFs into Claude AI skills in minutes
+- **[altmbr/research-orchestrator](https://github.com/altmbr/claude-research-skill)** - Multi-agent research with parallel workstreams and cited synthesis
 
 </details>
 


### PR DESCRIPTION
## Summary

Adds [altmbr/research-orchestrator](https://github.com/altmbr/claude-research-skill) to the **Community Skills > Development and Testing** section.

This skill enables Claude Code to decompose complex research questions into parallel sub-agent workstreams, monitor progress across agents, and synthesize results into a final report with inline citations. It follows the orchestrator pattern similar to existing entries like sanjay3290/deep-research and NeoLabHQ/sadd.

## Entry

```
- **[altmbr/research-orchestrator](https://github.com/altmbr/claude-research-skill)** - Multi-agent research with parallel workstreams and cited synthesis
```

## Checklist

- [x] Public repository with working skill
- [x] Documentation included (README / SKILL.md)
- [x] Author prefix included in name
- [x] Description is 10 words or fewer
- [x] Added to end of matching subcategory
- [x] Links verified and working

## Notes for Reviewers

- Placed in Development and Testing alongside other multi-agent and research skills.
- Could alternatively fit in Productivity and Collaboration if reviewers prefer.