### PR TITLE
Add skill: cluesmith/multisage-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -933,6 +933,7 @@ Official Web3 and trading skills from the Binance team. Includes crypto market d
 - **[zw008/VMware-AIops](https://github.com/zw008/VMware-AIops)** - AI-powered VMware vCenter/ESXi monitoring and operations: inventory queries, health/alarms, VM lifecycle (create, delete, snapshot, clone, migrate), vSAN management, Aria Operations analytics, and scheduled log scanning. Supports Claude Code, Gemini CLI, Codex, Aider, Trae, Kimi, and MCP.
 - **[video-db/skills](https://github.com/video-db/skills)** - Realtime and batch video workflows: capture screen/audio, ingest URLs/YouTube/RTSP, transcribe, index, search, generate subtitles, edit timelines, and stream HLS output
 - **[materials-simulation-skills](https://github.com/HeshamFS/materials-simulation-skills)** - Agent skills for computational materials science: numerical stability, time-stepping, linear solvers, mesh generation, simulation validation, parameter optimization, and post-processing
+- **[cluesmith/multisage-skill](https://github.com/cluesmith/multisage-skill)** - Query Claude, GPT, and Gemini simultaneously for synthesized multi-expert answers
 
 </details>
 


### PR DESCRIPTION
Adds [cluesmith/multisage-skill](https://github.com/cluesmith/multisage-skill) to the Specialized Domains section under Community Skills.

**What it does:** Query Claude, GPT, and Gemini simultaneously and get a synthesized multi-expert answer. Supports standard queries and deep research mode.

**Checklist:**
- [x] Public repository with a working skill
- [x] Has documentation (README)
- [x] Author/org prefix included in the name
- [x] Description is short (10 words or fewer)
- [x] Added to the end of the relevant category