### PR TITLE
Add skill: readtheskill/readtheskill

### DIFF
--- a/README.md
+++ b/README.md
@@ -794,6 +794,7 @@ Official Web3 and trading skills from the Binance team. Includes crypto market d
 - **[Xquik-dev/x-twitter-scraper](https://github.com/Xquik-dev/x-twitter-scraper)** - X/Twitter data platform: extractions, monitoring, draws, MCP server
 - **[SHADOWPR0/beautiful_prose](https://github.com/SHADOWPR0/beautiful_prose)** - Hard-edged writing style contract for timeless, forceful English prose without AI tics
 - **[blader/humanizer](https://github.com/blader/humanizer)** - Remove signs of AI-generated writing from text, making it sound more natural and human
+- **[readtheskill/readtheskill](https://github.com/readtheskill/readtheskill)** - AI agent propagation experiment tracking skill file spread on Solana
 
 </details>
 


### PR DESCRIPTION
## Summary

- Adds [readtheskill](https://github.com/readtheskill/readtheskill) to the **Marketing** community skills section
- An open-source AI agent skill propagation experiment on Solana
- Measures how SKILL.md files spread through agent networks with a live dashboard at [readtheskill.com](https://readtheskill.com)
- Published on [skills.sh](https://skills.sh) and [ClawHub](https://clawhub.ai)
- Has a proper SKILL.md with name and description frontmatter