### PR TITLE
Add skill: dazuiba/xcode-cli-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -838,7 +838,7 @@ Official Web3 and trading skills from the Binance team. Includes crypto market d
 - **[antonbabenko/terraform-skill](https://github.com/antonbabenko/terraform-skill)** - Terraform infrastructure as code best practices
 - **[zxkane/aws-skills](https://github.com/zxkane/aws-skills)** - AWS development with infrastructure automation and cloud architecture patterns
 - **[Rootly-AI-Labs/rootly-incident-responder](https://github.com/Rootly-AI-Labs/Rootly-MCP-server/blob/main/examples/skills/rootly-incident-responder.md)** - AI-powered incident response with ML similarity matching, solution suggestions, and on-call coordination. Requires [Rootly MCP Server](https://github.com/Rootly-AI-Labs/Rootly-MCP-server)
-- **[dazuiba/xcode-cli-skill](https://github.com/dazuiba/xcode-cli-skill)** - Persistent Xcode MCP bridge and reusable Xcode skill
+- **[dazuiba/xcode-cli-skill](https://github.com/dazuiba/xcode-cli-skill)** - CLI + Skill wrapper for the official Xcode 26.3+ MCP tools
 - **[conorluddy/ios-simulator-skill](https://github.com/conorluddy/ios-simulator-skill)** - Control iOS Simulator
 - **[ramzesenok/iOS-Accessibility-Audit-Skill](https://github.com/ramzesenok/iOS-Accessibility-Audit-Skill)** - Audit iOS App against Accessibility norms
 - **[sanjay3290/postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres)** - Execute safe read-only SQL queries against PostgreSQL databases


### PR DESCRIPTION
## Summary
- add `dazuiba/xcode-cli-skill` to the Development and Testing section
- place it before the existing `ios-simulator-skill` entry

## Why this fits
- CLI + Skill wrapper for the official Xcode 26.3+ MCP tools
- public repository with documented usage
- relevant to Xcode and iOS development workflows
