### PR TITLE
Add Design Auditor skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -914,6 +914,7 @@ Official Web3 and trading skills from the Binance team. Includes crypto market d
 <summary><h3 style="display:inline">Specialized Domains</h3></summary>
 
 - **[raintree-technology/apple-hig-skills](https://github.com/raintree-technology/apple-hig-skills)** - Apple Human Interface Guidelines as 14 agent skills covering platforms, foundations, components, patterns, inputs, and technologies for iOS, macOS, visionOS, watchOS, and tvOS
+- **[Ashutos1997/claude-design-auditor-skill](https://github.com/Ashutos1997/claude-design-auditor-skill)** - Audits designs against 17 professional rules: typography, WCAG contrast, spacing, iconography, navigation, design tokens + more. Scores out of 100. Supports English and Korean.
 - **[K-Dense-AI/claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)** - Scientific research and analysis skills
 - **[NotMyself/claude-win11-speckit-update-skill](https://github.com/NotMyself/claude-win11-speckit-update-skill)** - Windows 11 system management
 - **[sanjay3290/imagen](https://github.com/sanjay3290/ai-skills/tree/main/skills/imagen)** - Generate images using Google Gemini's API


### PR DESCRIPTION
Adds Design Auditor — a Claude skill that audits designs against 17 
professional rules with a scored, actionable report.

**What it does:**
- Scores designs out of 100 (deterministic: 🔴 −8pts, 🟡 −4pts, 🟢 −1pt)
- Audits 17 categories: typography, WCAG contrast, spacing, accessibility,
  iconography, navigation, design tokens + more
- Works with Figma MCP, HTML/CSS/React/Vue, and screenshots
- Supports English and Korean

**Community adoption:**
- Listed on BehiSecc/awesome-claude-skills (7.1k stars) ✅
- PR open on anthropics/skills (official Anthropic repo) ✅
- PR open on ComposioHQ/awesome-claude-skills ✅

GitHub: https://github.com/Ashutos1997/claude-design-auditor-skill