### PR TITLE
Add Human Skill Tree: 31 AI education skills based on cognitive science

### DIFF
--- a/README.md
+++ b/README.md
@@ -824,6 +824,7 @@ Official Web3 and trading skills from the Binance team. Includes crypto market d
 - **[kreuzberg-dev/kreuzberg](https://github.com/kreuzberg-dev/kreuzberg/tree/main/skills/kreuzberg)** - Extract text, tables, and metadata from 62+ document formats
 - **[Paramchoudhary/ResumeSkills](https://github.com/Paramchoudhary/ResumeSkills)** - 20 specialized skills for resume optimization, ATS analysis, interview prep, and career transitions
 - **[RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills)** - Transform docs or codebases into Obsidian StudyVaults with interactive quizzes
+- **[24kchengYe/human-skill-tree](https://github.com/24kchengYe/human-skill-tree)** - 31 AI agent skills for structured, science-backed lifelong learning. Covers K-12, university, research, career, social intelligence. Based on cognitive science (spaced repetition, active recall, Feynman technique)
 - **[NeoLabHQ/write-concisely](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/docs/skills/write-concisely)** - Applies the famous *The Elements of Style* book principles to make documentation and writing clearer and more professional by eliminating wordiness and improving structure.
 - **[ReScienceLab/opc-skills](https://github.com/ReScienceLab/opc-skills)** - Agent skills for solopreneurs with SEO, geo, and LLM tools
 - **[SeanZoR/claude-speed-reader](https://github.com/SeanZoR/claude-speed-reader)** - Speed read Claude's responses at 600+ WPM using RSVP with Spritz-style ORP highlighting


### PR DESCRIPTION
## Add Human Skill Tree

**Name:** [Human Skill Tree](https://github.com/24kchengYe/human-skill-tree)
**Category:** Community Skills (Education / Learning)
**License:** MIT

### Description

31 AI agent skills for structured, science-backed lifelong learning. Transforms ChatGPT, Claude, Gemini, Copilot, or DeepSeek into a learning companion based on cognitive science.

**Covers:**
- K-12 (math, science, languages, humanities, exam systems)
- University (STEM, business, medical, arts)
- Research (methodology, academic writing, literature review, statistics)
- Career (tech, finance, consulting, civil service, interview prep)
- Social intelligence (Chinese 人情世故, cross-cultural, EQ, negotiation)
- Self-development (critical thinking, financial literacy, health, creativity)

**Based on:** Spaced repetition, active recall, Feynman technique, Bloom's taxonomy, Socratic method, and other evidence-based learning science principles.

**References:** Nature Scientific Reports (2025), npj Science of Learning (2025), Dunlosky et al. (2013)

### Compatibility

Works with Claude Code, Cursor, Gemini CLI, ChatGPT Codex, and any tool supporting the Agent Skills standard.