### PR TITLE
Add enzyme — semantic search for Obsidian vaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -827,6 +827,7 @@ Official Web3 and trading skills from the Binance team. Includes crypto market d
 - **[NeoLabHQ/write-concisely](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/docs/skills/write-concisely)** - Applies the famous *The Elements of Style* book principles to make documentation and writing clearer and more professional by eliminating wordiness and improving structure.
 - **[ReScienceLab/opc-skills](https://github.com/ReScienceLab/opc-skills)** - Agent skills for solopreneurs with SEO, geo, and LLM tools
 - **[SeanZoR/claude-speed-reader](https://github.com/SeanZoR/claude-speed-reader)** - Speed read Claude's responses at 600+ WPM using RSVP with Spritz-style ORP highlighting
+- **[jshph/enzyme-skill](https://github.com/jshph/enzyme-skill)** - Semantic search for Obsidian vaults — surfaces connections between notes by concept using AI-generated catalyst questions anchored to tags, wikilinks, and folders. Self-contained with bundled binary and embedding model.
 
 </details>
 


### PR DESCRIPTION
Adds [enzyme](https://github.com/jshph/enzyme-skill) to the Productivity and Collaboration section.

Enzyme indexes an Obsidian vault's tags, wikilinks, and folders, generates AI-driven "catalyst" questions anchored to each entity, then uses those questions to drive semantic retrieval — surfacing connections between notes by concept rather than keyword.

Self-contained skill with bundled binary and embedding model (no install step needed). Compatible with any agent supporting the [Agent Skills spec](https://agentskills.io).

- [enzyme.garden](https://enzyme.garden)
- [Self-contained skill repo](https://github.com/jshph/enzyme-skill)
- [CLI repo](https://github.com/jshph/enzyme)