### PR TITLE
Add AIGNE-io/doc-smith-skills to Productivity and Collaboration

### DIFF
--- a/README.md
+++ b/README.md
@@ -827,6 +827,7 @@ Official Web3 and trading skills from the Binance team. Includes crypto market d
 - **[NeoLabHQ/write-concisely](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/docs/skills/write-concisely)** - Applies the famous *The Elements of Style* book principles to make documentation and writing clearer and more professional by eliminating wordiness and improving structure.
 - **[ReScienceLab/opc-skills](https://github.com/ReScienceLab/opc-skills)** - Agent skills for solopreneurs with SEO, geo, and LLM tools
 - **[SeanZoR/claude-speed-reader](https://github.com/SeanZoR/claude-speed-reader)** - Speed read Claude's responses at 600+ WPM using RSVP with Spritz-style ORP highlighting
+- **[AIGNE-io/doc-smith-skills](https://github.com/AIGNE-io/doc-smith-skills)** - Generate documentation sites from code with AI diagrams and multi-language support
 
 </details>
 


### PR DESCRIPTION
Adds DocSmith to the Productivity and Collaboration section.

DocSmith is a skill suite that analyzes codebases and generates structured, multi-language HTML documentation sites with AI-created diagrams.

- **Install:** `npx skills add AIGNE-io/doc-smith-skills`
- **Website:** https://docsmith.aigne.io
- **Showcase:** https://docsmith.aigne.io/en/showcase