### PR TITLE
Add skill: kennyzheng-builds/seek-and-analyze-video

### DIFF
--- a/README.md
+++ b/README.md
@@ -933,6 +933,7 @@ Official Web3 and trading skills from the Binance team. Includes crypto market d
 - **[peas/genealogy-research](https://paulo.com.br/skills/genealogy-research/SKILL.md)** - Genealogy research agent with OCR, FamilySearch, YAML data, and human-in-the-loop
 - **[zw008/VMware-AIops](https://github.com/zw008/VMware-AIops)** - AI-powered VMware vCenter/ESXi monitoring and operations: inventory queries, health/alarms, VM lifecycle (create, delete, snapshot, clone, migrate), vSAN management, Aria Operations analytics, and scheduled log scanning. Supports Claude Code, Gemini CLI, Codex, Aider, Trae, Kimi, and MCP.
 - **[video-db/skills](https://github.com/video-db/skills)** - Realtime and batch video workflows: capture screen/audio, ingest URLs/YouTube/RTSP, transcribe, index, search, generate subtitles, edit timelines, and stream HLS output
+- **[kennyzheng-builds/seek-and-analyze-video](https://github.com/kennyzheng-builds/seek-and-analyze-video)** - Seek and analyze video content with persistent AI memory
 - **[materials-simulation-skills](https://github.com/HeshamFS/materials-simulation-skills)** - Agent skills for computational materials science: numerical stability, time-stepping, linear solvers, mesh generation, simulation validation, parameter optimization, and post-processing
 
 </details>


### PR DESCRIPTION
This PR adds the seek-and-analyze-video skill to the Specialized Domains section.

**About the skill:**
A video intelligence skill powered by Memories.ai LVMM (Large Video Multimodal Model) that enables agents to search, import, and analyze video content across multiple platforms including TikTok, YouTube, and Instagram with persistent memory capabilities.

**Repository:** https://github.com/kennyzheng-builds/seek-and-analyze-video

**Key Features:**
- Search and import videos from TikTok, YouTube, and Instagram
- Analyze video content using AI with persistent memory
- Query video content intelligently
- Powered by Memories.ai LVMM technology