### PR TITLE
feat: add oil-oil/bulkgen skill for bulk AI image generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -919,6 +919,7 @@ Official Web3 and trading skills from the Binance team. Includes crypto market d
 - **[K-Dense-AI/claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)** - Scientific research and analysis skills
 - **[NotMyself/claude-win11-speckit-update-skill](https://github.com/NotMyself/claude-win11-speckit-update-skill)** - Windows 11 system management
 - **[sanjay3290/imagen](https://github.com/sanjay3290/ai-skills/tree/main/skills/imagen)** - Generate images using Google Gemini's API
+- **[oil-oil/bulkgen](https://github.com/oil-oil/bulkgen-skill)** - Bulk AI image generation — one grid request via the BulkGen API returns 9 split-ready AI images for the cost of 1 generation (~89% cost savings). Supports batch, variation, and solo modes.
 - **[jeffersonwarrior/claudisms](https://github.com/jeffersonwarrior/claudisms)** - SMS messaging integration
 - **[SHADOWPR0/security-bluebook-builder](https://github.com/SHADOWPR0/security-bluebook-builder)** - Build security Blue Books for sensitive apps
 - **[obra/defense-in-depth](https://github.com/obra/superpowers/blob/main/skills/defense-in-depth/SKILL.md)** - Multi-layered security approaches


### PR DESCRIPTION
## Summary

Adds [oil-oil/bulkgen](https://github.com/oil-oil/bulkgen-skill) to the Community Skills section alongside other image generation skills.

**What it does:** Bulk AI image generation via the BulkGen API. Generates one grid image and auto-splits it into N separate assets — 9 images for the cost of 1 generation (~89% cost savings vs individual API calls).

- **Modes:** solo, batch (independent prompt per cell), variation (one prompt → multiple creative variants)
- **Grid layouts:** 1×1 up to 4×4
- **Bundled scripts:** `generate.js`, `download_images.js`, `build_preview.js`
- **Auth:** API key via `BULKGEN_API_KEY`

Real-world use cases: campaign asset packs, concept art variations, product shot alternatives.