### PR TITLE
Add skill: Xquik-dev/tweetclaw

### DIFF
--- a/README.md
+++ b/README.md
@@ -791,7 +791,7 @@ Official Web3 and trading skills from the Binance team. Includes crypto market d
 - **[wshuyi/x-article-publisher-skill](https://github.com/wshuyi/x-article-publisher-skill)** - Publish articles to X/Twitter
 - **[CosmoBlk/email-marketing-bible](https://github.com/CosmoBlk/email-marketing-bible)** - 55K-word email marketing guide as an AI skill
 - **[smixs/creative-director-skill](https://github.com/smixs/creative-director-skill)** - AI creative director with recursive self-assessment: 20+ methodologies (SIT, TRIZ, Bisociation, SCAMPER, Synectics), 3-axis evaluation calibrated against Cannes/D&AD/HumanKind, 5-phase process from brief to presentation
-- **[Xquik-dev/tweetclaw](https://github.com/Xquik-dev/tweetclaw)** - 40+ X/Twitter actions: post, extract, monitor, draw
+- **[Xquik-dev/tweetclaw](https://github.com/Xquik-dev/tweetclaw)** - 40+ X/Twitter actions: post, extract, monitor, compose
 - **[SHADOWPR0/beautiful_prose](https://github.com/SHADOWPR0/beautiful_prose)** - Hard-edged writing style contract for timeless, forceful English prose without AI tics
 - **[blader/humanizer](https://github.com/blader/humanizer)** - Remove signs of AI-generated writing from text, making it sound more natural and human
 


### PR DESCRIPTION
Updates the existing Xquik-dev entry in the Marketing community skills section.

- **Name**: Xquik-dev/tweetclaw
- **URL**: https://github.com/Xquik-dev/tweetclaw
- **Category**: Community Skills > Marketing
- **Description**: 40+ X/Twitter actions: post, extract, monitor, draw

Replaces the previous `x-twitter-scraper` entry with the new `tweetclaw` repo (rebranded, same maintainer).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Community Skills section in the README: replaced the X/Twitter scraper recommendation with "tweetclaw" and updated its project link and description.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->