### PR TITLE
Add skill: fogarasy/close-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -828,6 +828,7 @@ Official Web3 and trading skills from the Binance team. Includes crypto market d
 - **[ReScienceLab/opc-skills](https://github.com/ReScienceLab/opc-skills)** - Agent skills for solopreneurs with SEO, geo, and LLM tools
 - **[SeanZoR/claude-speed-reader](https://github.com/SeanZoR/claude-speed-reader)** - Speed read Claude's responses at 600+ WPM using RSVP with Spritz-style ORP highlighting
 - **[Charlie85270/Dorothy](https://github.com/Charlie85270/Dorothy)** - Orchestrate multiple AI CLI agents with automations and MCP servers
+- **[fogarasy/close-skill](https://github.com/fogarasy/close-skill)** - Session-closing ritual that cleans up markdown and writes a handoff
 
 </details>
 


### PR DESCRIPTION
Adds close-skill to the Productivity and Collaboration section.

A single-file Claude Code slash command that runs a session-closing ritual: scans for stale markdown, updates memory, catches missed edits, flags dirty state, and writes a structured handoff for the next session. Markdown-scoped, no git commands, safe by default.

https://github.com/fogarasy/close-skill