### PR TITLE
Add skill: sbounmy/bitcoin-companies-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -937,6 +937,7 @@ Official Web3 and trading skills from the Binance team. Includes crypto market d
 - **[video-db/skills](https://github.com/video-db/skills)** - Realtime and batch video workflows: capture screen/audio, ingest URLs/YouTube/RTSP, transcribe, index, search, generate subtitles, edit timelines, and stream HLS output
 - **[materials-simulation-skills](https://github.com/HeshamFS/materials-simulation-skills)** - Agent skills for computational materials science: numerical stability, time-stepping, linear solvers, mesh generation, simulation validation, parameter optimization, and post-processing
 - **[takechanman1228/claude-ecom](https://github.com/takechanman1228/claude-ecom)** - Ecommerce CSV to business review with KPI decomposition
+- **[sbounmy/bitcoin-companies-skills](https://github.com/sbounmy/bitcoin-companies-skills)** - Search Bitcoin company treasuries, browse the leaderboard, and generate reports
 
 </details>
 


### PR DESCRIPTION
Adds [bitcoin-companies-skills](https://github.com/sbounmy/bitcoin-companies-skills) to the Specialized Domains section.

**What it does:** Claude Code skill to query Bitcoin company treasury data from the [Bitcoin Companies API](https://bitcoincompanies.co/api-docs). Search companies by name or domain, browse the leaderboard with filters (category, country, tier), and generate aggregate reports.

- Free API, no auth required
- Stripe-style JSON responses
- Covers 629 companies across 60+ countries

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added reference to a specialized tool for searching Bitcoin company treasuries, browsing leaderboards, and generating reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->