### PR TITLE
Add skill: Kevin7Qi/codex-collab

### DIFF
--- a/README.md
+++ b/README.md
@@ -893,6 +893,7 @@ Official Web3 and trading skills from the Binance team. Includes crypto market d
 - **[wrsmith108/varlock-claude-skill](https://github.com/wrsmith108/varlock-claude-skill)** - Secure environment variable management ensuring secrets are never exposed in Claude sessions, terminals, logs, or git commits
 - **[Skill_Seekers](https://github.com/yusufkaraaslan/Skill_Seekers)** - Automatically convert documentation websites, GitHub repositories, and PDFs into Claude AI skills in minutes
 - **[NoizAI/skills](https://github.com/NoizAI/skills)** - Human-like TTS workflows with local/cloud APIs and app delivery
+- **[Kevin7Qi/codex-collab](https://github.com/Kevin7Qi/codex-collab)** - Collaborate with Codex from Claude Code
 
 </details>
 


### PR DESCRIPTION
Adds [Kevin7Qi/codex-collab](https://github.com/Kevin7Qi/codex-collab) to the Development and Testing category.

**Entry:**
- **[Kevin7Qi/codex-collab](https://github.com/Kevin7Qi/codex-collab)** - Collaborate with Codex from Claude Code

**What it does:** Claude Code skill that lets Claude delegate tasks to OpenAI Codex — code review, implementation, research, and parallel development — via the Codex app-server JSON-RPC protocol.

**Checklist:**
- [x] Public repository with a working skill
- [x] Has documentation (README + SKILL.md)
- [x] Author/org prefix included in the name
- [x] Description is 10 words or fewer
- [x] Links verified

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new Claude Skill to the official list enabling collaborative code development features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->