### PR TITLE
Add skill: meshy-dev/meshy-3d-agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-<a href="https://github.com/VoltAgent/voltagent">
      <img width="1500" height="801" alt="claude-skills" src="https://github.com/user-attachments/assets/3a9d4cb3-04bd-4fb1-9146-fd3b53d26961" />
 </a>
 
@@ -938,6 +937,7 @@ Official Web3 and trading skills from the Binance team. Includes crypto market d
 - **[video-db/skills](https://github.com/video-db/skills)** - Realtime and batch video workflows: capture screen/audio, ingest URLs/YouTube/RTSP, transcribe, index, search, generate subtitles, edit timelines, and stream HLS output
 - **[materials-simulation-skills](https://github.com/HeshamFS/materials-simulation-skills)** - Agent skills for computational materials science: numerical stability, time-stepping, linear solvers, mesh generation, simulation validation, parameter optimization, and post-processing
 - **[takechanman1228/claude-ecom](https://github.com/takechanman1228/claude-ecom)** - Ecommerce CSV to business review with KPI decomposition
+- **[meshy-dev/meshy-3d-agent](https://github.com/meshy-dev/meshy-3d-agent)** - Full 3D generation pipeline via Meshy AI: text/image-to-3D, retexture, rig, animate, and 3D print preparation with Bambu Studio integration
 
 </details>
 


### PR DESCRIPTION
Adds `meshy-dev/meshy-3d-agent` to the **Specialized Domains** section.

**What it does:**
- Full 3D generation pipeline via the [Meshy AI](https://www.meshy.ai) API
- Text-to-3D, image-to-3D (single + multi-image), retexture, remesh, auto-rig, animate
- 3D printing workflow: OBJ download + Bambu Studio URL scheme integration
- Pure Markdown skill — no server, no build step required

**Install:**
```bash
npx skills add meshy-dev/meshy-3d-agent
```

→ https://github.com/meshy-dev/meshy-3d-agent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Made the hero image non-clickable
  * Added meshy-3d-agent to Community Skills and Specialized Domains sections

<!-- end of auto-generated comment: release notes by coderabbit.ai -->