### PR TITLE
Add free-web-search-ultimate: Search-First universal LLM plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -790,6 +790,7 @@ Official Web3 and trading skills from the Binance team. Includes crypto market d
 <summary><h3 style="display:inline">Marketing</h3></summary>
 
 - **[BrianRWagner/ai-marketing-skills](https://github.com/BrianRWagner/ai-marketing-skills)** - 17 marketing frameworks for cold outreach, homepage audit, social cards, and more
+- **[Free Web Search Ultimate](https://github.com/wd041216-bit/free-web-search-ultimate)** - Universal Search-First knowledge acquisition plugin. Transforms any LLM to prioritize real-time web search over training data. Zero-cost, no API key, MCP + OpenClaw compatible.
 - **[AgriciDaniel/claude-seo](https://github.com/AgriciDaniel/claude-seo)** - Universal SEO skill for comprehensive website analysis and optimization
 - **[wshuyi/x-article-publisher-skill](https://github.com/wshuyi/x-article-publisher-skill)** - Publish articles to X/Twitter
 - **[CosmoBlk/email-marketing-bible](https://github.com/CosmoBlk/email-marketing-bible)** - 55K-word email marketing guide as an AI skill


### PR DESCRIPTION
Adds free-web-search-ultimate — a universal Search-First knowledge acquisition plugin for LLMs. Transforms any LLM to prioritize real-time web search over training data. Zero-cost, MCP + OpenClaw compatible. GitHub: https://github.com/wd041216-bit/free-web-search-ultimate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  - Added "Free Web Search Ultimate" entry to the Community Skills section with installation instructions
  - Added "Free Web Search Ultimate" entry to the Marketing section, highlighting it as a universal search-first knowledge acquisition plugin with installation guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->