### PR TITLE
Add spawn-tasks — parallel Claude Code session launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -813,6 +813,7 @@ Official Web3 and trading skills from the Binance team. Includes crypto market d
 - **[obra/writing-plans](https://github.com/obra/superpowers/blob/main/skills/writing-plans/SKILL.md)** - Create strategic documentation
 - **[obra/executing-plans](https://github.com/obra/superpowers/blob/main/skills/executing-plans/SKILL.md)** - Implement and run strategic plans
 - **[obra/dispatching-parallel-agents](https://github.com/obra/superpowers/blob/main/skills/dispatching-parallel-agents/SKILL.md)** - Coordinate multiple simultaneous agents
+- **[theradengai/spawn-tasks](https://github.com/theradengai/spawn-tasks)** - Spawn parallel Claude Code sessions from confirmed subtasks, each in its own isolated git worktree with full task context
 - **[obra/sharing-skills](https://github.com/obra/superpowers/blob/main/skills/sharing-skills/SKILL.md)** - Distribute and communicate capabilities
 - **[obra/using-superpowers](https://github.com/obra/superpowers/blob/main/skills/using-superpowers/SKILL.md)** - Leverage core platform capabilities
 - **[op7418/Youtube-clipper-skill](https://github.com/op7418/Youtube-clipper-skill)** - YouTube clip generation and editing with automated workflows


### PR DESCRIPTION
## What this skill does

\`/spawn-tasks\` spawns independent Claude Code sessions from subtasks confirmed in the current conversation. Each session gets its own isolated git worktree and tmux pane — no merge conflicts between parallel sessions.

**Smart spawning:** If tasks have sequential dependencies, Claude says so and recommends running them in order instead of parallelizing blindly.

## Changes

- Added entry to README under **Development and Testing** (after \`dispatching-parallel-agents\`)

## Links

- Repo: https://github.com/theradengai/spawn-tasks
- Demo GIF: https://github.com/theradengai/spawn-tasks/blob/main/demo.gif

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Skills Paths for Other AI Coding Assistants with new documentation on the spawn-tasks capability, enabling parallel session spawning with isolated git worktrees and full task context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->