### PR TITLE
feat: add free-web-search-ultimate v13.0.0 — Search-First universal LLM plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -896,6 +896,7 @@ Official Web3 and trading skills from the Binance team. Includes crypto market d
 - **[NoizAI/skills](https://github.com/NoizAI/skills)** - Human-like TTS workflows with local/cloud APIs and app delivery
 - **[Kevin7Qi/codex-collab](https://github.com/Kevin7Qi/codex-collab)** - Collaborate with Codex from Claude Code
 - **[ethos-link/rails-conventions](https://github.com/ethos-link/rails-conventions)** - Rails 8 conventions for consistent production code changes
+- **[wd041216-bit/free-web-search-ultimate](https://github.com/wd041216-bit/free-web-search-ultimate)** [![MCP](https://img.shields.io/badge/MCP-Ready-purple.svg)](https://glama.ai/mcp/servers/wd041216-bit/free-web-search-ultimate) **v13.0.0** — Zero-cost, privacy-first universal web search MCP server and CLI plugin. Enforces a **Search-First** paradigm: instructs LLMs to retrieve real-time information before answering. Supports 10+ search engines (DuckDuckGo, Bing, Brave, Wikipedia, Arxiv, YouTube, Reddit). No API key required. Install: `pip install free-web-search-ultimate`
  
 </details>
 


### PR DESCRIPTION
## Summary

Adds **[free-web-search-ultimate](https://github.com/wd041216-bit/free-web-search-ultimate) v13.0.0** to the Community Skills — Development and Testing section.

## What is free-web-search-ultimate?

A zero-cost, privacy-first universal web search MCP server and CLI plugin that enforces a **Search-First paradigm** — instructs LLMs to retrieve real-time information before answering, rather than relying on potentially outdated training data.

## Key Features (v13.0.0)

- **Zero cost** — No API key, no subscription required
- **Privacy-first** — Uses DuckDuckGo and other privacy-respecting engines by default
- **10+ search engines** — DuckDuckGo, Bing, Brave, Wikipedia, Arxiv, YouTube, Reddit, and more
- **MCP Ready** — Works with Claude Desktop, Cursor, OpenClaw, and any MCP-compatible client
- **CLI tool** — Also usable as `free-web-search` CLI
- **Search-First paradigm** — Instructs LLMs to search before answering factual questions
- **v13.0.0** — Internationalized codebase with Google-style docstrings

## Installation

```bash
pip install free-web-search-ultimate
```

## Links

- GitHub: https://github.com/wd041216-bit/free-web-search-ultimate
- PyPI: https://pypi.org/project/free-web-search-ultimate/
- Glama MCP: https://glama.ai/mcp/servers/wd041216-bit/free-web-search-ultimate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new community skill entry to the README featuring a web search utility (version v13.0.0) with MCP support, expanding available community-contributed resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->