### PR TITLE
Add liepin-jobs skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -817,6 +817,7 @@ Official Web3 and trading skills from the Binance team. Includes crypto market d
 <summary><h3 style="display:inline">Productivity and Collaboration</h3></summary>
 
 - **[PSPDFKit-labs/nutrient-agent-skill](https://github.com/PSPDFKit-labs/nutrient-agent-skill)** - Document processing with Nutrient DWS API: convert (PDF/DOCX/XLSX/PPTX/HTML/images), extract text/tables, OCR (20+ languages), redact PII (pattern + AI), watermark, digital signatures, form filling. [MCP server](https://www.npmjs.com/package/@nutrient-sdk/dws-mcp-server) also available.
+- **[xllinbupt/MCP2skill](https://github.com/xllinbupt/MCP2skill)** - Search jobs on Liepin (猎聘), apply to positions, view and edit resumes. Zero-dependency Python CLI wrapping Liepin's official MCP Server
 - **[notiondevs/Notion Skills for Claude](https://www.notion.so/notiondevs/Notion-Skills-for-Claude-28da4445d27180c7af1df7d8615723d0)** - Skills for working with Notion
 - **[op7418/NanoBanana-PPT-Skills](https://github.com/op7418/NanoBanana-PPT-Skills)** - AI-powered PPT generation with document analysis and styled images
 - **[zarazhangrui/frontend-slides](https://github.com/zarazhangrui/frontend-slides)** - Generate animation-rich HTML presentations with visual style previews


### PR DESCRIPTION
## Summary
- Adds `liepin-jobs` to Productivity and Collaboration section
- Search jobs on Liepin (猎聘), apply to positions, view and edit resumes
- Zero-dependency Python CLI wrapping Liepin's official MCP Server
- Source: https://github.com/xllinbupt/MCP2skill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Documentation**
* Updated documentation to reference a new productivity tool for job search, application management, and resume editing capabilities via a Python CLI solution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->