### PR TITLE
Add Paradigm code architecture skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -912,7 +912,7 @@ Official Web3 and trading skills from the Binance team. Includes crypto market d
 - **[NoizAI/skills](https://github.com/NoizAI/skills)** - Human-like TTS workflows with local/cloud APIs and app delivery
 - **[Kevin7Qi/codex-collab](https://github.com/Kevin7Qi/codex-collab)** - Collaborate with Codex from Claude Code
 - **[ethos-link/rails-conventions](https://github.com/ethos-link/rails-conventions)** - Rails 8 conventions for consistent production code changes
-- **[useparadigm/skill_a_thon](https://github.com/useparadigm/skill_a_thon)** - Cross-system blast radius analysis for code review: map call graphs, remote calls (HTTP, Kafka, gRPC), DB access, and propagation chains across your entire codebase via Paradigm MCP
+- **[useparadigm/skill_a_thon](https://github.com/useparadigm/skill_a_thon)** - Understand your codebase architecture with Paradigm: call graphs, cross-system dependencies, remote calls, and database access patterns via MCP
 
 </details>
 


### PR DESCRIPTION
Adds [useparadigm/skill_a_thon](https://github.com/useparadigm/skill_a_thon) to the Development and Testing section.

**What it does:** Claude Code skill that connects to [Paradigm](https://useparadigm.app) via MCP to give agents (and developers) a full picture of their codebase architecture — call graphs, cross-file dependencies, remote calls (HTTP, Kafka, gRPC), database access patterns, and change propagation maps.

**Skills included:**
- `/paradigm` — Get started with Paradigm: what it sees, how to use `analyze_task`, MCP setup
- `/blast-radius` — Map cross-system impact of a code change
- `/impact-report` — Quick dependency scan
- `/deep-check` — Verify a specific cross-system finding

Note: CodeRabbit flagged this as non-existent repo — it was created today and is live and public: https://github.com/useparadigm/skill_a_thon

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new community skill entry for cross-system blast‑radius analysis, describing architectural review of call graphs, remote interactions, and database access patterns to aid development and testing.
  * Performed a minor cleanup of the community skills list by removing a placeholder line for clearer navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->