### PR TITLE
Add autoevolve — evolve strategies through automated self-play

### DIFF
--- a/README.md
+++ b/README.md
@@ -912,7 +912,8 @@ Official Web3 and trading skills from the Binance team. Includes crypto market d
 - **[NoizAI/skills](https://github.com/NoizAI/skills)** - Human-like TTS workflows with local/cloud APIs and app delivery
 - **[Kevin7Qi/codex-collab](https://github.com/Kevin7Qi/codex-collab)** - Collaborate with Codex from Claude Code
 - **[ethos-link/rails-conventions](https://github.com/ethos-link/rails-conventions)** - Rails 8 conventions for consistent production code changes
- 
+- **[MrTsepa/autoevolve](https://github.com/MrTsepa/autoevolve)** - Evolve code, strategies, or prompts through automated self-play with Bradley-Terry ratings and Pareto front selection
+
 </details>
 
 <details>


### PR DESCRIPTION
  Adds [autoevolve](https://github.com/MrTsepa/autoevolve) to the Development and Testing section.

  **autoevolve** lets an AI coding agent improve strategies through automated self-play: mutate a candidate, benchmark it head-to-head against previous versions, rate with Bradley-Terry MLE, and branch from the Pareto front.

  Good fits: game bots, prompt optimization, heuristic policies, trading strategies, adversarial co-evolution.

  Available via:
  - `npx skills add MrTsepa/autoevolve`
  - `claude skill add https://github.com/MrTsepa/autoevolve@v0.1.0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated the Community Skills section with a new entry describing an automated evolution tool for code, strategies, and prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->