### PR TITLE
Add skill: localheroai/agent-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -912,7 +912,8 @@ Official Web3 and trading skills from the Binance team. Includes crypto market d
 - **[NoizAI/skills](https://github.com/NoizAI/skills)** - Human-like TTS workflows with local/cloud APIs and app delivery
 - **[Kevin7Qi/codex-collab](https://github.com/Kevin7Qi/codex-collab)** - Collaborate with Codex from Claude Code
 - **[ethos-link/rails-conventions](https://github.com/ethos-link/rails-conventions)** - Rails 8 conventions for consistent production code changes
- 
+- **[localheroai/agent-skill](https://github.com/localheroai/agent-skill)** - Brand-aware i18n workflow for agents and automatic translation
+
 </details>
 
 <details>


### PR DESCRIPTION
Adds localheroai/agent-skill to Development and Testing.

LocalHero.ai helps product teams automate i18n translations. The skill injects project glossary, style, and settings into the agent's context so it writes source strings with correct terminology. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved formatting in the community skills section.
  * Added documentation for a new brand-aware internationalization workflow solution for agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->