### PR TITLE
Add using-muti-skills: parallel multi-skill analysis + cross-validation debate

### DIFF
--- a/README.md
+++ b/README.md
@@ -880,6 +880,7 @@ Official Web3 and trading skills from the Binance team. Includes crypto market d
 - **[SeanZoR/claude-speed-reader](https://github.com/SeanZoR/claude-speed-reader)** - Speed read Claude's responses at 600+ WPM using RSVP with Spritz-style ORP highlighting
 - **[Charlie85270/Dorothy](https://github.com/Charlie85270/Dorothy)** - Orchestrate multiple AI CLI agents with automations and MCP servers
 - **[Digidai/product-manager-skills](https://github.com/Digidai/product-manager-skills)** - Senior PM agent with 30+ frameworks and SaaS metrics
+- **[Ginning-ZDZQ/using-muti-skills](https://github.com/Ginning-ZDZQ/using-muti-skills)** - Orchestrate multiple skills simultaneously on the same problem — each agent invokes a real skill pipeline with independent research, then cross-validates findings through structured adversarial debate rounds, producing emergent insights no single skill could discover alone
 
 </details>
 


### PR DESCRIPTION
## What is this skill?

A meta-orchestrator that runs 2-6 analysis skills in parallel on the same problem, forces each agent to invoke the full skill pipeline with independent research, then facilitates up to 3 rounds of structured adversarial debate to cross-validate findings and extract emergent insights.

## Key features
- Forced skill invocation (not just "thinking in style") with dispatcher verification
- Independent research requirement (3+ new data points per agent)
- 4-type claim clustering (corroborating / contradictory / complementary / isolated)
- Anti-false-consensus detection
- Adversarial tension calibration (prevents premature capitulation)
- Emergent insight mining in synthesis phase

## Link
https://github.com/Ginning-ZDZQ/using-muti-skills

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new community skill entry to the Community Skills list, showcasing orchestration of multiple skills with research and cross-validation capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->