### PR TITLE
Add AceDataCloud Agent Skills to Specialized Domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -992,6 +992,7 @@ Official Web3 and trading skills from the Binance team. Includes crypto market d
 - **[materials-simulation-skills](https://github.com/HeshamFS/materials-simulation-skills)** - Agent skills for computational materials science: numerical stability, time-stepping, linear solvers, mesh generation, simulation validation, parameter optimization, and post-processing
 - **[takechanman1228/claude-ecom](https://github.com/takechanman1228/claude-ecom)** - Ecommerce CSV to business review with KPI decomposition
 - **[helius-labs/helius-skills](https://github.com/helius-labs/core-ai/tree/main/helius-skills)** - Ship Solana apps end-to-end; transaction sending, asset queries, real-time streaming, token swaps, prediction markets, browser wallets, and deep research into protocol internals all powered by Helius APIs, DFlow trading, and Phantom wallet integrations
+- **[AceDataCloud/Skills](https://github.com/AceDataCloud/Skills)** - 18 production-ready skills for AI-powered services: music generation (Suno, Producer, Fish Audio), image generation (Midjourney, Flux, Seedream, NanoBanana), video synthesis (Luma, Sora, Veo, Kling, Hailuo, Seedance), LLM chat (50+ models including GPT, Claude, Gemini, Grok, DeepSeek), and web search. Each skill pairs with MCP servers published to PyPI and hosted MCP endpoints
 
 </details>
 


### PR DESCRIPTION
Adds AceDataCloud Agent Skills (https://github.com/AceDataCloud/Skills) to the Specialized Domains section. 18 production-ready skills for AI-powered services: music generation (Suno, Producer, Fish Audio), image generation (Midjourney, Flux, Seedream, NanoBanana), video synthesis (Luma, Sora, Veo, Kling, Hailuo, Seedance), LLM chat (50+ models), and web search. Each skill pairs with MCP servers published to PyPI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to include information about specialized AI-powered skills spanning music generation, image generation, video synthesis, LLM chat across multiple models, and web search capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->