### PR TITLE
Add skill: DevOps Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -948,6 +948,7 @@ Official Web3 and trading skills from the Binance team. Includes crypto market d
 - **[Kevin7Qi/codex-collab](https://github.com/Kevin7Qi/codex-collab)** - Collaborate with Codex from Claude Code
 - **[ethos-link/rails-conventions](https://github.com/ethos-link/rails-conventions)** - Rails 8 conventions for consistent production code changes
  
+- **[fullstackcrew-alpha/skill-devops-agent](https://github.com/fullstackcrew-alpha/skill-devops-agent)** - One-click deploy, monitoring setup (Prometheus+Grafana), scheduled backups, and fault diagnosis with safety-first design including confirmation prompts, dry-run, and snapshot rollback
 </details>
 
 <details>


### PR DESCRIPTION
## New Skill: DevOps Agent

**DevOps Agent** — One-click deploy, monitoring setup (Prometheus+Grafana), scheduled backups, and fault diagnosis with safety-first design including confirmation prompts, dry-run, and snapshot rollback

- **GitHub**: https://github.com/fullstackcrew-alpha/skill-devops-agent
- **ClawHub**: https://clawhub.ai/s/devops-agent
- **Install**: `clawhub install devops-agent`
- **License**: MIT

Published by [FullStackCrew](https://github.com/fullstackcrew-alpha).