### PR TITLE
Add hand-drawn-diagrams: Excalidraw diagram skill with animation and hosted edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -898,6 +898,7 @@ Official Web3 and trading skills from the Binance team. Includes crypto market d
 - **[jthack/ffuf-claude-skill](https://github.com/jthack/ffuf_claude_skill)** - Web fuzzing with ffuf
 - **[lackeyjb/playwright-skill](https://github.com/lackeyjb/playwright-skill)** - Browser automation with Playwright
 - **[ibelick/ui-skills](https://github.com/ibelick/ui-skills)** - Opinionated, evolving constraints to guide agents when building interfaces
+- **[muthuishere/hand-drawn-diagrams](https://github.com/muthuishere/hand-drawn-diagrams)** - Generate hand-drawn Excalidraw diagrams from a prompt — animated SVG, hosted edit link, and PNG export. Works with Claude Code, Codex, Gemini CLI, and any agent supporting standard skill paths
 - **[nextlevelbuilder/ui-ux-pro-max-skill](https://github.com/nextlevelbuilder/ui-ux-pro-max-skill)** - UI/UX design patterns and best practices
 - **[ehmo/platform-design-skills](https://github.com/ehmo/platform-design-skills)** - 300+ design rules from Apple HIG, Material Design 3, and WCAG 2.2 for cross-platform apps
 - **[scarletkc/vexor](https://github.com/scarletkc/vexor)** - Vector-powered CLI for semantic file search with a Claude/Codex skill


### PR DESCRIPTION
## Add hand-drawn-diagrams

**Repo:** https://github.com/muthuishere/hand-drawn-diagrams  
**Author:** Muthukumaran Navaneethakrishnan ([@muthuishere](https://github.com/muthuishere))

### What it does

An agent skill that generates hand-drawn Excalidraw diagrams from a natural language prompt. It picks the right diagram type (architecture, UX flows, teaching diagrams, funnels, wireframes…), lays out the elements, and delivers:

- A hosted edit link — opens in Excalidraw editor in the browser, no app install needed
- An animated SVG that draws itself stroke by stroke
- PNG export on request

Works with Claude Code, Codex, Gemini CLI, and any agent supporting standard skill paths.

### Why it fits here

Added to **Development and Testing** — community skill for developers, architects, and designers who want diagrams without starting from a blank canvas. Complements existing UI/UX skills in the section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new community skill to generate hand-drawn Excalidraw diagrams from text prompts, featuring animated SVG output, editable hosted links, and PNG export functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->