### PR TITLE
Add skill: adiny/moodtrip-hotel-search

### DIFF
--- a/README.md
+++ b/README.md
@@ -880,6 +880,7 @@ Official Web3 and trading skills from the Binance team. Includes crypto market d
 - **[SeanZoR/claude-speed-reader](https://github.com/SeanZoR/claude-speed-reader)** - Speed read Claude's responses at 600+ WPM using RSVP with Spritz-style ORP highlighting
 - **[Charlie85270/Dorothy](https://github.com/Charlie85270/Dorothy)** - Orchestrate multiple AI CLI agents with automations and MCP servers
 - **[Digidai/product-manager-skills](https://github.com/Digidai/product-manager-skills)** - Senior PM agent with 30+ frameworks and SaaS metrics
+- **[adiny/moodtrip-hotel-search](https://github.com/adiny/moodtrip-hotel-search)** - Hotel search, booking, and price comparison via MCP
 
 </details>
 


### PR DESCRIPTION
Adding moodtrip-hotel-search — Hotel search & booking handoff via MoodTrip.ai MCP server.

## What it does
Enables any agent to search hotels, compare prices, read reviews with AI sentiment analysis, match rooms by photo/description, track pricing trends, and hand off booking links.

## Tools (12)
searchHotelsWithRates, searchHotelsSemanticQuery, quickHotelSearch, findHotels, getHotelDetails, getHotelReviews, askHotelQuestion, searchRooms, summarizeResults, getHotelPriceIndex, getCityPriceIndex, relaxConstraints

## Compatibility
- Claude.ai / Claude Desktop (MCP)
- - ChatGPT (submitted)
- - Any MCP-compatible agent
## License
MIT-0

Repo: https://github.com/adiny/moodtrip-hotel-search

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Added a new community skill entry for hotel search, booking, and price comparison capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->