### PR TITLE
Add skill: Anoxxx/skillcache

### DIFF
--- a/README.md
+++ b/README.md
@@ -963,6 +963,7 @@ Official Web3 and trading skills from the Binance team. Includes crypto market d
 - **[muratcankoylan/evaluation](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/evaluation)** - Build evaluation frameworks for agent systems
 - **[k-kolomeitsev/data-structure-protocol](https://github.com/k-kolomeitsev/data-structure-protocol)** - Graph-based long-term memory skill for AI (LLM) coding agents — faster context, fewer tokens, safer refactors
 - **[NeoLabHQ/prompt-engineering](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/customaize-agent/skills/prompt-engineering)** - Widely used prompt engineering techniques and patterns, including Anthropic best practices and agent persuasion principles.
+- **[Anoxxx/skillcache](https://github.com/Anoxxx/skillcache)** - MRU attention protocol for skills that learn from use
 
 </details>
 


### PR DESCRIPTION
Adds [Anoxxx/skillcache](https://github.com/Anoxxx/skillcache) to Context Engineering.

**Entry:**
- **[Anoxxx/skillcache](https://github.com/Anoxxx/skillcache)** - MRU attention protocol for skills that learn from use

---

First off — huge respect for this list. It's been the single best resource for discovering quality skills, and the curation standard here is something we genuinely admire.

We know SkillCache is brand new, and we totally understand if the timing isn't right. But the mechanism felt interesting enough that we couldn't resist sharing it here — even if just to get it on the radar.

**What it does:** SkillCache is a meta-skill that adds a companion `HEURISTICS.md` alongside any existing `SKILL.md`. Skills accumulate lessons from real use via an MRU (Most Recently Used) attention mechanism — useful lessons stay hot at the top, stale ones naturally get evicted. The insight is that this is structurally isomorphic to attention in transformers, but achieved through cache replacement policy instead of gradient descent.

Two types of heuristics accumulate:
- **Technical**: environment quirks, failure modes, workarounds (e.g. "Headless Chrome in Docker needs `--no-sandbox`")
- **Personalization**: user preferences, style, tone, boundaries (e.g. "User wants bullet points, not prose. Max 500 words.")

**What's in the repo:**
- Open protocol spec (HEURISTICS.md format + MRU rules)
- Activator skill + `inject.py` script (scan → activate → verify)
- 4 worked examples: webapp-testing, mcp-builder, skill-creator, internal-comms
- 96 passing tests (protocol compliance + functional)
- Related work analysis (positions against [MCE](https://arxiv.org/abs/2601.21557), Peking University 2026)

Works with Claude Code, Codex, OpenClaw, Cursor, Gemini CLI.

**Checklist:**
- [x] Public repository with a working skill
- [x] Has documentation (README + SKILL.md + PROTOCOL.md)
- [x] Author/org prefix included in the name
- [x] Description is 10 words or fewer
- [x] Links verified
- [x] MIT licensed, protocol spec CC BY 4.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new Community Context Engineering skill entry providing access to MRU attention protocol capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->