### PR TITLE
Add skill: uucz/moyu

### DIFF
--- a/README.md
+++ b/README.md
@@ -993,6 +993,7 @@ Official GSAP animation skills covering the full GreenSock ecosystem — core AP
 - **[hamelsmu/write-judge-prompt](https://github.com/hamelsmu/prompts/tree/main/evals-skills/skills/write-judge-prompt)** - Design LLM-as-Judge evaluators for subjective criteria
 - **[hamelsmu/validate-evaluator](https://github.com/hamelsmu/prompts/tree/main/evals-skills/skills/validate-evaluator)** - Calibrate LLM judges against human labels
 - **[hamelsmu/evaluate-rag](https://github.com/hamelsmu/prompts/tree/main/evals-skills/skills/evaluate-rag)** - Evaluate RAG retrieval and generation quality
+- **[uucz/moyu](https://github.com/uucz/moyu)** - Anti-over-engineering skill with 5 variants and 10 platforms
 - **[hamelsmu/build-review-interface](https://github.com/hamelsmu/prompts/tree/main/evals-skills/skills/build-review-interface)** - Build annotation interfaces for reviewing LLM traces
 - **[mattpocock/skills](https://github.com/mattpocock/skills)** - 17 dev workflow skills: PRD writing, TDD, codebase architecture, git guardrails, issue triage, refactoring plans, and more
 - **[mukul975/Anthropic-Cybersecurity-Skills](https://github.com/mukul975/Anthropic-Cybersecurity-Skills)** - 753 cybersecurity skills across 38 domains: cloud security, pentesting, red teaming, DFIR, malware analysis, threat intel, and more (MITRE ATT&CK mapped)


### PR DESCRIPTION
Adds [moyu](https://github.com/uucz/moyu) to the Development and Testing community skills.

Anti-over-engineering skill that teaches AI coding agents restraint. 5 variants (zh/en/ja/lite/strict), 10 platforms. Benchmarked: 66% code reduction vs baseline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new community skill entry to the README, expanding the Community Skills section with a skill offering multiple variants and platform support options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->