### PR TITLE
Add Schliff — autonomous skill improvement engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -1002,7 +1002,8 @@ Official GSAP animation skills covering the full GreenSock ecosystem — core AP
 - **[Kevin7Qi/codex-collab](https://github.com/Kevin7Qi/codex-collab)** - Collaborate with Codex from Claude Code
 - **[ethos-link/rails-conventions](https://github.com/ethos-link/rails-conventions)** - Rails 8 conventions for consistent production code changes
 - **[ShunsukeHayashi/agent-skill-bus](https://github.com/ShunsukeHayashi/agent-skill-bus)** - Self-improving task orchestration for AI agent systems
- 
+- **[Zandereins/schliff](https://github.com/Zandereins/schliff)** - The finishing cut for Claude Code skills — autonomous improvement engine with 7-dimension scoring, deterministic patches, and cross-session memory
+
 </details>
 
 <details>


### PR DESCRIPTION
## What is Schliff?

[Schliff](https://github.com/Zandereins/schliff) is an autonomous improvement engine for Claude Code skills. It scores SKILL.md files across 7 dimensions (structure, triggers, quality, edges, efficiency, composability, clarity), applies deterministic patches (60-70% rule-based, no LLM hallucinations), and grinds skills from D-grade to S-grade overnight.

Inspired by [Karpathy's autoresearch](https://github.com/karpathy/autoresearch) pattern.

- 120 unit tests, 40 security fixes
- Zero external Python dependencies
- MIT licensed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new community-developed skill resource for development and testing to the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->