### PR TITLE
Add skill: Vers-Labs/gentik-domains-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1002,7 +1002,8 @@ Official GSAP animation skills covering the full GreenSock ecosystem — core AP
 - **[Kevin7Qi/codex-collab](https://github.com/Kevin7Qi/codex-collab)** - Collaborate with Codex from Claude Code
 - **[ethos-link/rails-conventions](https://github.com/ethos-link/rails-conventions)** - Rails 8 conventions for consistent production code changes
 - **[ShunsukeHayashi/agent-skill-bus](https://github.com/ShunsukeHayashi/agent-skill-bus)** - Self-improving task orchestration for AI agent systems
- 
+- **[Vers-Labs/gentik-domains-skill](https://github.com/Vers-Labs/gentik-domains-skill)** - Register and manage domains for AI agents via Ed25519-authenticated API with human payment flow
+
 </details>
 
 <details>


### PR DESCRIPTION
Adds [Vers-Labs/gentik-domains-skill](https://github.com/Vers-Labs/gentik-domains-skill) to the Development and Testing section.

**What it does:** Claude Code skill for registering and managing domains for AI agents via the [AgentDomains](https://agentdomains.dev) API. Covers Ed25519 challenge-response auth, domain registration with human payment flow, DNS management, email forwarding, and auto-renewal.

**Repo contents:**
- `SKILL.md` — Core skill with YAML frontmatter
- `references/api-reference.md` — Full endpoint reference
- `README.md` — Installation instructions
- MIT licensed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new community skill entry to the skills reference documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->