### PR TITLE
Add claw-army/claude-node

### DIFF
--- a/README.md
+++ b/README.md
@@ -1015,7 +1015,8 @@ Official GSAP animation skills covering the full GreenSock ecosystem — core AP
 - **[Kevin7Qi/codex-collab](https://github.com/Kevin7Qi/codex-collab)** - Collaborate with Codex from Claude Code
 - **[ethos-link/rails-conventions](https://github.com/ethos-link/rails-conventions)** - Rails 8 conventions for consistent production code changes
 - **[ShunsukeHayashi/agent-skill-bus](https://github.com/ShunsukeHayashi/agent-skill-bus)** - Self-improving task orchestration for AI agent systems
- 
+- **[claw-army/claude-node](https://github.com/claw-army/claude-node)** - Python subprocess bridge for Claude Code CLI, giving Python code direct access to Claude Code native capabilities via stream-json.
+
 </details>
 
 <details>


### PR DESCRIPTION
Add claw-army/claude-node - Python subprocess bridge for Claude Code CLI, giving Python code direct access to Claude Code native capabilities via stream-json.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Expanded the community skills list with a new integration resource for extended capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->