### PR TITLE
Add patchright-cli — anti-detect browser skill for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -961,7 +961,7 @@ Official GSAP animation skills covering the full GreenSock ecosystem — core AP
 - **[sanjay3290/deep-research](https://github.com/sanjay3290/ai-skills/tree/main/skills/deep-research)** - Autonomous multi-step research using Gemini Deep Research Agent
 - **[jthack/ffuf-claude-skill](https://github.com/jthack/ffuf_claude_skill)** - Web fuzzing with ffuf
 - **[lackeyjb/playwright-skill](https://github.com/lackeyjb/playwright-skill)** - Browser automation with Playwright
-- **[AhaiMk01/patchright-cli](https://github.com/AhaiMk01/patchright-cli)** - Anti-detect browser automation CLI using Patchright (undetected Playwright fork). Bypasses Akamai, Cloudflare and other anti-bot systems. Same command interface as playwright-cli.
+- **[AhaiMk01/patchright-cli](https://github.com/AhaiMk01/patchright-cli)** - Browser automation CLI built on Patchright (undetected Playwright fork) with enhanced site compatibility. Same command interface as playwright-cli.
 - **[ibelick/ui-skills](https://github.com/ibelick/ui-skills)** - Opinionated, evolving constraints to guide agents when building interfaces
 - **[muthuishere/hand-drawn-diagrams](https://github.com/muthuishere/hand-drawn-diagrams)** - Generate hand-drawn Excalidraw diagrams from a prompt — animated SVG, hosted edit link, and PNG export. Works with Claude Code, Codex, Gemini CLI, and any agent supporting standard skill paths
 - **[nextlevelbuilder/ui-ux-pro-max-skill](https://github.com/nextlevelbuilder/ui-ux-pro-max-skill)** - UI/UX design patterns and best practices


### PR DESCRIPTION
## Addition

Added to **Community Skills > Development and Testing**:

- **[AhaiMk01/patchright-cli](https://github.com/AhaiMk01/patchright-cli)** - Anti-detect browser automation CLI using Patchright (undetected Playwright fork). Bypasses Akamai, Cloudflare and other anti-bot systems. Same command interface as playwright-cli.

## About

patchright-cli provides the same command interface as Microsoft's playwright-cli but uses Patchright for stealth browser automation. Includes a SKILL.md that works with Claude Code, OpenClaw, Codex CLI, Gemini CLI, Cursor, Windsurf, OpenCode, and Aider.

- [PyPI](https://pypi.org/project/patchright-cli/)
- [SKILL.md](https://github.com/AhaiMk01/patchright-cli/blob/main/skills/patchright-cli/SKILL.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new community resource entry describing a browser-automation CLI with enhanced site compatibility and a command interface compatible with Playwright CLI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->