### PR TITLE
Add claude-code-power-stack to community skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -896,6 +896,8 @@ Official GSAP animation skills covering the full GreenSock ecosystem — core AP
 
 ### Community Skills
 
+| [Claude Code Power Stack](https://github.com/bluzername/claude-code-power-stack) | Curated toolkit bundling Ghost (persistent memory), cc-conversation-search, session naming, and Manus-style file-based planning into one-command install with cheat sheet PDF |
+
 <details>
 <summary><h3 style="display:inline">Marketing</h3></summary>
 


### PR DESCRIPTION
Hey, wanted to add my project claude-code-power-stack here. I build this toolkit that bundles together Ghost memory, conversation search across projects, session naming and Manus-style planning - all with one command install. It also comes with cheat sheet PDF which is handy for quick reference. Hope it can be useful for other people working with Claude Code too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new Community Skills entry that links to and describes a bundled toolkit for persistent memory, cross-session search, session naming, file-based planning, one-command installation, and an accompanying cheat-sheet PDF.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->