### PR TITLE
Add SpecFusion - Search 15 Chinese platform API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1016,7 +1016,8 @@ Official GSAP animation skills covering the full GreenSock ecosystem — core AP
 - **[Kevin7Qi/codex-collab](https://github.com/Kevin7Qi/codex-collab)** - Collaborate with Codex from Claude Code
 - **[ethos-link/rails-conventions](https://github.com/ethos-link/rails-conventions)** - Rails 8 conventions for consistent production code changes
 - **[ShunsukeHayashi/agent-skill-bus](https://github.com/ShunsukeHayashi/agent-skill-bus)** - Self-improving task orchestration for AI agent systems
- 
+- **[wxkingstar/SpecFusion](https://github.com/wxkingstar/SpecFusion)** - Search 15 Chinese open platform API docs (WeChat Work, Feishu, DingTalk, Taobao, Douyin, WeChat Pay, Alipay, JD, etc.) directly in your AI coding tool. 26,840+ docs with Chinese full-text search, zero config.
+
 </details>
 
 <details>


### PR DESCRIPTION
## Summary

- Adds [SpecFusion](https://github.com/wxkingstar/SpecFusion) to the **Development and Testing** section under Community Skills
- SpecFusion is a Claude Code skill that lets you search 15 Chinese open platform API docs (WeChat Work, Feishu, DingTalk, Taobao, Douyin, WeChat Pay, Alipay, JD, etc.) directly in your AI coding tool
- 26,840+ indexed docs with Chinese full-text search (jieba + FTS5), zero config — cloud-hosted, no local setup needed

## Checklist

- [x] Added to the appropriate category (Development and Testing)
- [x] Follows the existing entry format
- [x] Link points to a valid public repository with SKILL.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new community skill entry to the GSAP Skills section, featuring a tool for searching Chinese open platform API documentation via full-text search.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->