### PR TITLE
Add skill: coderabbitai/skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -995,6 +995,7 @@ Official GSAP animation skills covering the full GreenSock ecosystem — core AP
 - **[conorluddy/ios-simulator-skill](https://github.com/conorluddy/ios-simulator-skill)** - Control iOS Simulator
 - **[ramzesenok/iOS-Accessibility-Audit-Skill](https://github.com/ramzesenok/iOS-Accessibility-Audit-Skill)** - Audit iOS App against Accessibility norms
 - **[truongduy2611/app-store-preflight-skills](https://github.com/truongduy2611/app-store-preflight-skills)** - Scan iOS/macOS projects to catch common mistakes that lead to App Store rejection before submission
+- **[coderabbitai/skills](https://github.com/coderabbitai/skills)** - Code review and PR autofix workflows for coding agents
 - **[sanjay3290/postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres)** - Execute safe read-only SQL queries against PostgreSQL databases
 - **[sanjay3290/deep-research](https://github.com/sanjay3290/ai-skills/tree/main/skills/deep-research)** - Autonomous multi-step research using Gemini Deep Research Agent
 - **[jthack/ffuf-claude-skill](https://github.com/jthack/ffuf_claude_skill)** - Web fuzzing with ffuf


### PR DESCRIPTION
## Summary
- add `coderabbitai/skills` under Community Skills > Development and Testing
- use a short description focused on code review and PR autofix workflows

## Links
- Repo: https://github.com/coderabbitai/skills
- Website: https://www.coderabbit.ai/

## Why
- public repo with 46 GitHub stars
- clear SKILL.md-based implementation and documentation
- established community usage and a practical development workflow fit
