### PR TITLE
Add skill: efeumutaslan/SAP-SKILLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1101,6 +1101,7 @@ Official GSAP animation skills covering the full GreenSock ecosystem — core AP
 - **[takechanman1228/claude-ecom](https://github.com/takechanman1228/claude-ecom)** - Ecommerce CSV to business review with KPI decomposition
 - **[helius-labs/helius-skills](https://github.com/helius-labs/core-ai/tree/main/helius-skills)** - Ship Solana apps end-to-end; transaction sending, asset queries, real-time streaming, token swaps, prediction markets, browser wallets, and deep research into protocol internals all powered by Helius APIs, DFlow trading, and Phantom wallet integrations
 - **[meodai/skill.color-expert](https://github.com/meodai/skill.color-expert)** - Color science expert skill with 286K words of reference material covering OKLCH/OKLAB, palette generation, accessibility/contrast, color naming, pigment mixing, and historical color theory
+- **[efeumutaslan/SAP-SKILLS](https://github.com/efeumutaslan/SAP-SKILLS)** - 23 SAP skills for ABAP, RAP, CAP, Fiori, BTP, HANA, and Integration Suite
 
 </details>
 


### PR DESCRIPTION
## Add SAP-SKILLS to Specialized Domains

**[efeumutaslan/SAP-SKILLS](https://github.com/efeumutaslan/SAP-SKILLS)** — 23 SAP skills for ABAP, RAP, CAP, Fiori, BTP, HANA, and Integration Suite.

### What's included

- **23 skills** — ABAP Cloud, RAP, CDS, CAP, Fiori, BTP security, HANA Cloud, S/4HANA extensibility, Integration Suite, Event Mesh, Kyma, Signavio, SuccessFactors, Build Apps, Ariba, Joule/Business AI, and more
- **33 reference documents** — syntax guides, API references, checklists
- **19 templates** — copy-paste ready code and config templates
- **4 validation scripts** — automated compliance checks
- **4 MCP server configs** — pre-configured SAP MCP server setups

### Why it fits Specialized Domains

- First SAP/ERP entry in awesome-agent-skills — fills a major enterprise gap
- Follows the Agent Skills Specification (agentskills.io) with SKILL.md format
- MIT licensed, fully open source
- Progressive disclosure: metadata (~100 tokens) → instructions (<5000 tokens) → resources (on demand)

### Checklist

- [x] Public repository with documentation
- [x] Author prefix in skill name (efeumutaslan/SAP-SKILLS)
- [x] Entry appended to end of Specialized Domains section
- [x] Description under 10 words in the list entry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new community skill resource documenting 23 SAP competencies, including ABAP, RAP, CAP, Fiori, BTP, HANA, and Integration Suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->