### PR TITLE
Add skill: bitwize-music-studio/claude-ai-music-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1101,6 +1101,7 @@ Official GSAP animation skills covering the full GreenSock ecosystem — core AP
 - **[takechanman1228/claude-ecom](https://github.com/takechanman1228/claude-ecom)** - Ecommerce CSV to business review with KPI decomposition
 - **[helius-labs/helius-skills](https://github.com/helius-labs/core-ai/tree/main/helius-skills)** - Ship Solana apps end-to-end; transaction sending, asset queries, real-time streaming, token swaps, prediction markets, browser wallets, and deep research into protocol internals all powered by Helius APIs, DFlow trading, and Phantom wallet integrations
 - **[meodai/skill.color-expert](https://github.com/meodai/skill.color-expert)** - Color science expert skill with 286K words of reference material covering OKLCH/OKLAB, palette generation, accessibility/contrast, color naming, pigment mixing, and historical color theory
+- **[bitwize-music-studio/claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills)** - Full-lifecycle AI music album production
 
 </details>
 


### PR DESCRIPTION
Adds [claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills) to the Specialized Domains section under Community Skills.

Claude Code plugin for full-lifecycle AI music album production — concept planning, investigative research, lyric writing, Suno style prompts, per-stem mixing, mastering, and release distribution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new skill entry for AI music album production in the Specialized Domains section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->