### PR TITLE
Add skill: andylizf/deep-research-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -998,6 +998,7 @@ Official GSAP animation skills covering the full GreenSock ecosystem — core AP
 - **[sanjay3290/postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres)** - Execute safe read-only SQL queries against PostgreSQL databases
 - **[sanjay3290/deep-research](https://github.com/sanjay3290/ai-skills/tree/main/skills/deep-research)** - Autonomous multi-step research using Gemini Deep Research Agent
 - **[jthack/ffuf-claude-skill](https://github.com/jthack/ffuf_claude_skill)** - Web fuzzing with ffuf
+- **[andylizf/deep-research-skill](https://github.com/andylizf/deep-research-skill)** - Run ChatGPT Deep Research from Claude Code via Playwright
 - **[lackeyjb/playwright-skill](https://github.com/lackeyjb/playwright-skill)** - Browser automation with Playwright
 - **[ibelick/ui-skills](https://github.com/ibelick/ui-skills)** - Opinionated, evolving constraints to guide agents when building interfaces
 - **[muthuishere/hand-drawn-diagrams](https://github.com/muthuishere/hand-drawn-diagrams)** - Generate hand-drawn Excalidraw diagrams from a prompt — animated SVG, hosted edit link, and PNG export. Works with Claude Code, Codex, Gemini CLI, and any agent supporting standard skill paths


### PR DESCRIPTION
## Summary

Adds [deep-research-skill](https://github.com/andylizf/deep-research-skill) to the Development and Testing section.

Run ChatGPT's Deep Research from Claude Code. The skill drives a real headed Chrome via Playwright to navigate ChatGPT's Deep Research mode and returns the full Markdown report. Uses DYLD injection on macOS for zero-flash window management (the browser window never appears on screen).

## Checklist

- [x] Public repo with README and SKILL.md
- [x] CI passing
- [x] Description under 10 words
- [x] Added to appropriate category (Development and Testing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new community skill entry for Deep Research, providing advanced research capabilities with integrated tools to enhance user productivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->