### PR TITLE
Add Cortex - Memory Skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -972,7 +972,7 @@ Official GSAP animation skills covering the full GreenSock ecosystem — core AP
 - **[wrsmith108/linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill)** - Manage Linear issues, projects, and teams
 - **[Shpigford/readme](https://github.com/Shpigford/skills/tree/main/readme)** - Generate comprehensive project documentation
 - **[hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill)** - Minimal, low-friction hierarchical memory system with background agents and filesystem-based persistence
-- **[SKULLFIRE07/cortex-memory](https://github.com/SKULLFIRE07/cortex-memory)** - Persistent AI memory for coding assistants. Auto-captures decisions, patterns, and context. VSCode extension + CLI + MCP server. Free.
+- **[SKULLFIRE07/cortex-memory](https://github.com/SKULLFIRE07/cortex-memory)** - Persistent AI memory for coding assistants. Auto-captures decisions, patterns, and context. 3-layer memory (working/episodic/semantic). VSCode extension + CLI + MCP server. Free.
 - **[kreuzberg-dev/kreuzberg](https://github.com/kreuzberg-dev/kreuzberg/tree/main/skills/kreuzberg)** - Extract text, tables, and metadata from 62+ document formats
 - **[Paramchoudhary/ResumeSkills](https://github.com/Paramchoudhary/ResumeSkills)** - 20 specialized skills for resume optimization, ATS analysis, interview prep, and career transitions
 - **[RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills)** - Transform docs or codebases into Obsidian StudyVaults with interactive quizzes


### PR DESCRIPTION
Cortex gives AI coding assistants persistent memory across sessions.

- GitHub: https://github.com/SKULLFIRE07/cortex-memory
- Marketplace: https://marketplace.visualstudio.com/items?itemName=cortex-dev.cortex-ai-memory
- MIT licensed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Community Skills section in the README with a new skill entry, including its description and GitHub repository link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->