### PR TITLE
Add HubSpot Admin Skills — 32 HubSpot CRM administration skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -945,6 +945,7 @@ Official GSAP animation skills covering the full GreenSock ecosystem — core AP
 - **[SHADOWPR0/beautiful_prose](https://github.com/SHADOWPR0/beautiful_prose)** - Hard-edged writing style contract for timeless, forceful English prose without AI tics
 - **[blader/humanizer](https://github.com/blader/humanizer)** - Remove signs of AI-generated writing from text, making it sound more natural and human
 - **[Eronred/aso-skills](https://github.com/Eronred/aso-skills)** - 30+ App Store Optimization skills for keyword research, metadata optimization, competitor analysis, creative optimization, and mobile growth strategies via Appeeky API
+- **[TomGranot/hubspot-admin-skills](https://github.com/TomGranot/hubspot-admin-skills)** - 32 Claude Code skills for auditing, cleaning, enriching, and automating HubSpot CRM. Includes Python scripts, Breeze AI workflow prompts, and a full audit → plan → execute → maintain flow.
 
 </details>
 


### PR DESCRIPTION
## Summary

Adds [HubSpot Admin Skills](https://github.com/TomGranot/hubspot-admin-skills) to the Community Skills > Marketing section.

- 32 Claude Code skills for auditing, cleaning, enriching, and automating HubSpot CRM
- Includes Python scripts, Breeze AI workflow prompts, and a full audit → plan → execute → maintain flow
- Built for B2B marketing/sales ops teams managing HubSpot at scale

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new community skill entry for HubSpot CRM administration featuring 32 Claude Code skills for auditing, cleaning, enriching, and automating workflows, including Python scripts and workflow automation frameworks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->