### PR TITLE
Add harmansidhudev/shipwise — webapp launch lifecycle plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1029,6 +1029,7 @@ Official GSAP animation skills covering the full GreenSock ecosystem — core AP
 - **[Joannis/claude-skills](https://github.com/Joannis/claude-skills)** - Swift Server development guidance with linting tool for best practices
 - **[rudrankriyam/app-store-connect-cli-skills](https://github.com/rudrankriyam/app-store-connect-cli-skills)** - Automate App Store deployments and management using ASC CLI
 - **[rameerez/claude-code-startup-skills](https://github.com/rameerez/claude-code-startup-skills)** - Skills for building and running software startups, apps, and SaaS
+- **[harmansidhudev/shipwise](https://github.com/harmansidhudev/shipwise)** - Webapp launch lifecycle plugin with 15 skills covering idea validation, architecture, security, billing, legal, and growth; includes lifecycle hooks, codebase auditing, experience-level calibration, and multi-agent compatibility.
 - **[zscole/model-hierarchy-skill](https://github.com/zscole/model-hierarchy-skill)** - Cost-optimized model routing based on task complexity
 - **[CloudAI-X/threejs-skills](https://github.com/CloudAI-X/threejs-skills)** - Three.js skills for creating 3D elements and interactive experiences
 - **[Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill)** - High-agency frontend skill that gives AI good taste with tunable design variance, motion intensity, and visual density to stop generic UI slop


### PR DESCRIPTION
## What is Shipwise?

A Claude Code plugin that guides developers through the full webapp launch lifecycle — from idea validation through growth — with 15 domain skills, lifecycle hooks, and a codebase auditor.

**Repo:** https://github.com/harmansidhudev/shipwise
**License:** MIT

## Quality checklist

- [x] Description in third person, capability-focused, matches neighboring entries
- [x] SKILL.md files under 500 lines each
- [x] No absolute paths
- [x] MIT licensed
- [x] Active repo with recent commits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new community skill entry to the Development and Testing section, featuring a webapp launch lifecycle plugin with integrated tools and multi-agent compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->