### PR TITLE
Add CoinPaprika & DexPaprika crypto data skills to Specialized Domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -1103,6 +1103,7 @@ Official GSAP animation skills covering the full GreenSock ecosystem — core AP
 - **[helius-labs/helius-skills](https://github.com/helius-labs/core-ai/tree/main/helius-skills)** - Ship Solana apps end-to-end; transaction sending, asset queries, real-time streaming, token swaps, prediction markets, browser wallets, and deep research into protocol internals all powered by Helius APIs, DFlow trading, and Phantom wallet integrations
 - **[meodai/skill.color-expert](https://github.com/meodai/skill.color-expert)** - Color science expert skill with 286K words of reference material covering OKLCH/OKLAB, palette generation, accessibility/contrast, color naming, pigment mixing, and historical color theory
 - **[bitwize-music-studio/claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills)** - Full-lifecycle AI music album production
+- **[coinpaprika/skills](https://github.com/coinpaprika/skills)** - Two crypto data skills: CoinPaprika (12K+ coins, 350+ exchanges, tickers, OHLCV, historical prices) and DexPaprika (34 chains, 30M+ DEX pools, 27M+ tokens, real-time SSE streaming). Free, no API key. Install: `npx skills add github.com/coinpaprika/skills`
 
 </details>
 


### PR DESCRIPTION
Adds CoinPaprika & DexPaprika skills to the Specialized Domains section.

Two crypto data skills from one repo: CoinPaprika (12K+ coins, 350+ exchanges, OHLCV) and DexPaprika (34 chains, 30M+ pools, real-time SSE streaming). Free, no API key. Cross-platform (Claude Code, Codex, Cursor, Gemini).

Install: `npx skills add github.com/coinpaprika/skills`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added community skills documentation for cryptocurrency data services, including coin, exchange, ticker, and historical price information alongside DEX pool and token data with real-time streaming capabilities, available without API key requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->