### PR TITLE
Add skill: PHY041/design-qa

### DIFF
--- a/README.md
+++ b/README.md
@@ -1032,6 +1032,7 @@ Official GSAP animation skills covering the full GreenSock ecosystem — core AP
 - **[zscole/model-hierarchy-skill](https://github.com/zscole/model-hierarchy-skill)** - Cost-optimized model routing based on task complexity
 - **[CloudAI-X/threejs-skills](https://github.com/CloudAI-X/threejs-skills)** - Three.js skills for creating 3D elements and interactive experiences
 - **[Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill)** - High-agency frontend skill that gives AI good taste with tunable design variance, motion intensity, and visual density to stop generic UI slop
+- **[PHY041/design-qa](https://github.com/PHY041/design-qa)** - Full frontend design QA pipeline: audit, critique, normalize, fix, and polish in one command with scored reports (X/40)
 - **[testdino-hq/playwright-skill](https://github.com/testdino-hq/playwright-skill)** - 70+ production-tested Playwright automation testing patterns: E2E, POM, CI/CD, migrations, CLI
 - **[NeoLabHQ/code-review](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/code-review)** - Comprehensive PR code review using specialized agents: bug-hunter, security-auditor, code-quality-reviewer, contracts-reviewer, historical-context-reviewer, test-coverage-reviewer
 - **[NeoLabHQ/reflexion](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/reflexion)** - Self-refinement loop that forces the LLM to reflect on previous output and correct itself.


### PR DESCRIPTION
## Add skill: PHY041/design-qa

**Link:** https://github.com/PHY041/design-qa

**Category:** Development and Testing (next to other UI/UX skills like taste-skill, ui-skills, platform-design-skills)

**Description:** Full frontend design QA pipeline that chains audit, critique, normalize, design-review, and polish into a single `/design-qa` command with scored reports (X/40).

### What it does

```
/design-qa [target]

Phase 1: Diagnose (read-only)
  ├── Technical Audit → a11y, perf, responsive, anti-patterns
  └── UX Critique    → hierarchy, cognitive load, AI slop, emotion

Phase 2: Fix (auto-edit)
  ├── Normalize      → Align to design system tokens
  └── Design Review  → Fix visual issues

Phase 3: Polish (final pass)
  └── Polish         → Pixel-perfect alignment, states, edge cases
```

Supports `--report-only`, `--bold`, `--animate`, `--quick` flags.

Built on top of [Impeccable](https://github.com/pbakaus/impeccable) by Paul Bakaus.

### Checklist
- [x] Skill has documentation (README + SKILL.md)
- [x] Skill is in a public GitHub repository
- [x] Added to correct category (Development and Testing)
- [x] Description is under 10 words in the list entry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new design QA resource featuring an automated frontend pipeline that performs audit, critique, normalize, fix, and polish operations with scored reporting capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->