### PR TITLE
Add skill: chainstacklabs/pumpclaw

### DIFF
--- a/README.md
+++ b/README.md
@@ -1124,6 +1124,7 @@ Official skills from Notion's repositories — workspace-aware skills for captur
 - **[helius-labs/helius-skills](https://github.com/helius-labs/core-ai/tree/main/helius-skills)** - Ship Solana apps end-to-end; transaction sending, asset queries, real-time streaming, token swaps, prediction markets, browser wallets, and deep research into protocol internals all powered by Helius APIs, DFlow trading, and Phantom wallet integrations
 - **[meodai/skill.color-expert](https://github.com/meodai/skill.color-expert)** - Color science expert skill with 286K words of reference material covering OKLCH/OKLAB, palette generation, accessibility/contrast, color naming, pigment mixing, and historical color theory
 - **[bitwize-music-studio/claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills)** - Full-lifecycle AI music album production
+- **[chainstacklabs/pumpclaw](https://github.com/chainstacklabs/pumpclaw)** - Trade on pump.fun via AI agents on Solana
 
 </details>
 


### PR DESCRIPTION
Adds [chainstacklabs/pumpclaw](https://github.com/chainstacklabs/pumpclaw) to the **Community Skills > Specialized Domains** section.

## What is pumpclaw

An open-source agent skill for pump.fun token trading on Solana via [pumpfun-cli](https://github.com/chainstacklabs/pumpfun-cli). Gives AI agents the ability to buy, sell, launch tokens, manage wallets, and handle PumpSwap AMM migrations — with dry-run simulation and slippage safety checks.

Works with Claude Code, Codex, Cursor, OpenClaw, and other agents that support the Agent Skills standard. Apache 2.0 licensed. Built by [Chainstack](https://chainstack.com).

Built on top of [pumpfun-cli](https://github.com/chainstacklabs/pumpfun-cli), which itself descends from [pumpfun-bot](https://github.com/chainstacklabs/pumpfun-bonkfun-bot) (800+ stars).

## Checklist

- [x] Public repository with working skill
- [x] Has documentation (SKILL.md + references)
- [x] Author/org prefix included in the name
- [x] Description is 10 words or fewer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new community skill entry for AI-agent-based Solana trading functionality to the Skills section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->