### PR TITLE
Add skill: yohayetsion/product-org-os

### DIFF
--- a/README.md
+++ b/README.md
@@ -1001,6 +1001,7 @@ Official skills from Notion's repositories — workspace-aware skills for captur
 - **[Charlie85270/Dorothy](https://github.com/Charlie85270/Dorothy)** - Orchestrate multiple AI CLI agents with automations and MCP servers
 - **[Digidai/product-manager-skills](https://github.com/Digidai/product-manager-skills)** - Senior PM agent with 30+ frameworks and SaaS metrics
 - **[deusyu/translate-book](https://github.com/deusyu/translate-book)** - Translate books (PDF/DOCX/EPUB) via parallel sub-agents with resume
+- **[yohayetsion/product-org-os](https://github.com/yohayetsion/product-org-os)** - 13 product org agents, 133 skills, and 2 gateways
 
 </details>
 


### PR DESCRIPTION
## Product Org OS

An entire product organization as AI agents — 13 role-based agents, 133 skills, and 2 gateways for product management, strategy, GTM, and competitive intelligence.

- **Repository**: https://github.com/yohayetsion/product-org-os
- **Homepage**: https://yohayetsion.github.io/product-org-os/
- **License**: MIT
- **Agent Guide**: https://github.com/yohayetsion/product-org-os/blob/main/product-org-plugin/agent-guide.md

Agents cover CPO, VP Product, Directors, PMs, PMMs, BizOps, Competitive Intelligence, Product Operations, Value Realization, UX Lead, and more. Each has a distinct role, voice, and domain expertise.

Built on the Agent Skills open standard — works with Claude Code, Cursor, Copilot, Gemini CLI, and other compatible tools.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new community skill entry `yohayetsion/product-org-os` featuring 13 product org agents, 133 skills, and 2 gateways to the Community Skills catalog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->