### PR TITLE
Add BOUCH skills and 4 UK MCP servers (Specialized Domains)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1124,6 +1124,11 @@ Official skills from Notion's repositories — workspace-aware skills for captur
 - **[helius-labs/helius-skills](https://github.com/helius-labs/core-ai/tree/main/helius-skills)** - Ship Solana apps end-to-end; transaction sending, asset queries, real-time streaming, token swaps, prediction markets, browser wallets, and deep research into protocol internals all powered by Helius APIs, DFlow trading, and Phantom wallet integrations
 - **[meodai/skill.color-expert](https://github.com/meodai/skill.color-expert)** - Color science expert skill with 286K words of reference material covering OKLCH/OKLAB, palette generation, accessibility/contrast, color naming, pigment mixing, and historical color theory
 - **[bitwize-music-studio/claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills)** - Full-lifecycle AI music album production
+- **[paulieb89/bouch-skills](https://github.com/paulieb89/bouch-skills)** - 9 free skills for UK professionals: property comps, P6 schedule summary, legislation lookup, Pine Script v6 lookup (4 with free MCP servers), plus content humaniser, meeting actions, client prep, workflow auditor, AI policy generator
+- **[paulieb89/property-shared](https://github.com/paulieb89/property-shared)** - UK property data MCP server with skills: Land Registry comps, EPC, Rightmove, rental yields, stamp duty, Companies House, planning
+- **[paulieb89/pyp6xer-mcp](https://github.com/paulieb89/pyp6xer-mcp)** - Primavera P6 XER schedule analysis MCP server with skills: critical path, earned value, float, quality checks, CSV export
+- **[paulieb89/uk-legal-mcp](https://github.com/paulieb89/uk-legal-mcp)** - UK legal research MCP server with skills: case law, legislation, Hansard debates, HMRC guidance, OSCOLA citations
+- **[paulieb89/pinescript-mcp](https://github.com/paulieb89/pinescript-mcp)** - Pine Script v6 MCP server with skills: documentation lookup, function validation, linting
 
 </details>
 


### PR DESCRIPTION
Adds to the Specialized Domains section:

- **bouch-skills** — 9 free skills for UK professionals (4 MCP-powered, 5 standalone)
- **property-shared** — UK property data MCP server (Land Registry, EPC, Rightmove, yields, stamp duty)
- **pyp6xer-mcp** — Primavera P6 XER schedule analysis MCP server
- **uk-legal-mcp** — UK legal research MCP server (case law, legislation, Hansard, HMRC, OSCOLA)
- **pinescript-mcp** — Pine Script v6 documentation and validation MCP server

All public, Apache 2.0, actively maintained. MCP servers live on Fly.io with free access.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the specialized domains section with five new skill entries: bouch-skills, property-shared, pyp6xer-mcp, uk-legal-mcp, and pinescript-mcp. Each entry includes detailed descriptions and references to support expanded functionality and use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->