### PR TITLE
Add skill: JimmySadek/strategic-partner

### DIFF
--- a/README.md
+++ b/README.md
@@ -978,6 +978,7 @@ Official skills from Notion's repositories — workspace-aware skills for captur
 - **[gokapso/integrate-whatsapp](https://github.com/gokapso/agent-skills/tree/master/skills/integrate-whatsapp)** - Connect WhatsApp, set up webhooks, and send messages
 - **[gokapso/automate-whatsapp](https://github.com/gokapso/agent-skills/tree/master/skills/automate-whatsapp)** - Build WhatsApp automations with workflows and agents
 - **[gokapso/observe-whatsapp](https://github.com/gokapso/agent-skills/tree/master/skills/observe-whatsapp)** - Debug WhatsApp delivery issues and run health checks
+- **[JimmySadek/strategic-partner](https://github.com/JimmySadek/strategic-partner)** - Separates thinking from building in Claude Code sessions
 - **[PleasePrompto/notebooklm-skill](https://github.com/PleasePrompto/notebooklm-skill)** - Interact with NotebookLM for document-based conversations
 - **[obra/superpowers-lab](https://github.com/obra/superpowers-lab)** - Lab environment for Claude superpowers
 - **[obra/brainstorming](https://github.com/obra/superpowers/blob/main/skills/brainstorming/SKILL.md)** - Generate and explore ideas


### PR DESCRIPTION
**What:** Add Strategic Partner, an advisory skill for Claude Code.

**Category:** Community Skills > Productivity and Collaboration

**What it does:** Separates thinking from building — challenges assumptions, presents alternatives with trade-offs, routes tasks to the right skill, and crafts self-contained implementation prompts for fresh sessions. Never writes source code in its own session.

**Usage:** `/strategic-partner` in any project.

**Attribution:** MIT licensed. Built from daily Claude Code usage across multiple projects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new resource to the "Productivity and Collaboration" community skills list in the README, providing users with an additional tool for managing Claude Code sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->