### PR TITLE
Add skill: Sassine/wtf-approve

### DIFF
--- a/README.md
+++ b/README.md
@@ -1076,6 +1076,7 @@ Official skills from Notion's repositories — workspace-aware skills for captur
 - **[ethos-link/rails-conventions](https://github.com/ethos-link/rails-conventions)** - Rails 8 conventions for consistent production code changes
 - **[ShunsukeHayashi/agent-skill-bus](https://github.com/ShunsukeHayashi/agent-skill-bus)** - Self-improving task orchestration for AI agent systems
 - **[mcollina/skills](https://github.com/mcollina/skills/tree/main/skills)** - 11 skills by Matteo Collina: Node.js, Fastify, TypeScript, OAuth, Git/GitHub, ESLint neostandard, documentation (Diataxis), Node.js core internals, skill optimizer, and more
+- **[Sassine/wtf-approve](https://github.com/Sassine/wtf-approve)** - Human-readable consent layer for agent command approval
 
 </details>
 


### PR DESCRIPTION
## Add skill: Sassine/wtf-approve

**Repository:** https://github.com/Sassine/wtf-approve
**Category:** Development and Testing

### Description

**wtf-approve** is a human-readable consent layer for agent command approval. It intercepts approval prompts and generates minimal explanations of intent, scope, and risk — so users make informed decisions instead of blind approvals.

### Features

- 3-tier risk classification (low / medium / HIGH)
- Auto-detects conversation language (en, pt-BR, es, ja, etc.)
- `/wtf:explain` for per-command breakdown via Tab to amend
- Agent-agnostic — works with Claude Code, Codex, Gemini CLI

### Checklist

- [x] Public repository
- [x] Working skill with documentation (README + SKILL.md)
- [x] CI test suite (12 scenarios against Anthropic API)
- [x] Author prefix in name (Sassine/wtf-approve)
- [x] Description under 10 words

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new community skill to the development and testing resources list for agent command approval workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->