### PR TITLE
docs: add dograh skills to the Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1124,6 +1124,7 @@ Official skills from Notion's repositories — workspace-aware skills for captur
 - **[helius-labs/helius-skills](https://github.com/helius-labs/core-ai/tree/main/helius-skills)** - Ship Solana apps end-to-end; transaction sending, asset queries, real-time streaming, token swaps, prediction markets, browser wallets, and deep research into protocol internals all powered by Helius APIs, DFlow trading, and Phantom wallet integrations
 - **[meodai/skill.color-expert](https://github.com/meodai/skill.color-expert)** - Color science expert skill with 286K words of reference material covering OKLCH/OKLAB, palette generation, accessibility/contrast, color naming, pigment mixing, and historical color theory
 - **[bitwize-music-studio/claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills)** - Full-lifecycle AI music album production
+- **[dograh-hq/skills](https://github.com/dograh-hq/skills)** - Build and trigger voice AI agents, outbound calls, campaigns, and webhooks with Dograh
 
 </details>
 


### PR DESCRIPTION
  - Added [dograh-hq/skills](https://github.com/dograh-hq/skills) to the Community Skills > Specialized Domains section
  - Dograh enables building and triggering voice AI agents, outbound calls, campaigns, and webhooks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for a new community skill integration enabling users to build and trigger voice AI agents, outbound calls, campaigns, and webhooks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->