### PR TITLE
Add powerpoint.md — curated directory of 33 AI PPT & Excel skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1186,6 +1186,12 @@ As the ecosystem grows, consistent quality helps agents discover and use skills 
 | **No absolute paths** | Never hard-code machine-specific paths like `/Users/alice/`. Use relative paths or well-known variables (`$HOME`, `$PROJECT_ROOT`). |
 | **Scoped tools** | Request only the tools the skill actually needs. Avoid blanket `"tools": ["*"]`. Declare tool dependencies explicitly. |
 
+## 📚 Skill Directories & Discovery
+
+| Directory | Description |
+|-----------|-------------|
+| [powerpoint.md](https://powerpoint.md) | Curated directory of 33 AI PowerPoint & Excel skills for Claude Code — tested install commands, quality ratings, and agent-friendly `/llms.txt` |
+
 ## 🤝 Contributing
 
 We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ The most contributed Agent Skills repository, built and maintained together with
 | [Product Manager Skills by Dean Peters](#product-manager-skills-by-dean-peters) | [Product Management Skills by Paweł Huryn](#product-management-skills-by-pawel-huryn) | [Skills by MiniMax](#skills-by-minimax-team) |
 | [Skills by DuckDB](#skills-by-duckdb) | [Skills by GSAP](#skills-by-gsap-greensock) | [Skills by Garry Tan (gstack)](#skills-by-garry-tan-gstack) |
 | [Skills by Notion](#skills-by-notion) | [Community Skills](#community-skills) | [Skill Quality Standards](#skill-quality-standards) |
+| [Skill Directories & Discovery](#-skill-directories--discovery) | | |
 
 
 


### PR DESCRIPTION
Hi VoltAgent team! I'd like to add [powerpoint.md](https://powerpoint.md) as a skill discovery resource.

**What it is**: A curated directory of 33 AI PowerPoint & Excel skills (Claude Code skills, MCP servers, CLI tools). Each entry includes:
- Verified, tested install commands
- Quality & ease-of-use ratings (skills are actually run and evaluated)
- Dedicated detail pages
- Agent-friendly `/llms.txt` for programmatic discovery

It's a natural complement to this awesome list — a searchable, rated catalog specifically for the PPT/Excel skill category.

Thanks for maintaining this resource!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "Skill Directories & Discovery" section under Skill Quality Standards and added it to the Table of Contents.
  * Introduces a curated directory of 33 AI PowerPoint & Excel skills, with tested installation commands, quality ratings, and an agent-friendly discovery file to streamline finding and installing recommended skills.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->