### PR TITLE
Add skill: Hybirdss/smartest-tv

### DIFF
--- a/README.md
+++ b/README.md
@@ -995,6 +995,7 @@ Official skills from Notion's repositories — workspace-aware skills for captur
 - **[Charlie85270/Dorothy](https://github.com/Charlie85270/Dorothy)** - Orchestrate multiple AI CLI agents with automations and MCP servers
 - **[Digidai/product-manager-skills](https://github.com/Digidai/product-manager-skills)** - Senior PM agent with 30+ frameworks and SaaS metrics
 - **[deusyu/translate-book](https://github.com/deusyu/translate-book)** - Translate books (PDF/DOCX/EPUB) via parallel sub-agents with resume
+- **[Hybirdss/smartest-tv](https://github.com/Hybirdss/smartest-tv)** - Play Netflix, YouTube, Spotify on your smart TV by name
 
 </details>
 


### PR DESCRIPTION
Adds smartest-tv to Community Skills > Productivity and Collaboration.

- **Repo**: https://github.com/Hybirdss/smartest-tv
- **PyPI**: https://pypi.org/project/stv/
- **Skill file**: https://github.com/Hybirdss/smartest-tv/blob/main/skills/tv/SKILL.md

CLI + MCP server + Claude Code skill for playing Netflix episodes, YouTube videos, and Spotify music on smart TVs (LG, Samsung, Android TV, Roku) by name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Added a community skill entry enabling Netflix, YouTube, and Spotify playback on smart TVs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->