### PR TITLE
Add skill: talkvalue/event-agency-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1119,6 +1119,7 @@ Official skills from Notion's repositories — workspace-aware skills for captur
 - **[helius-labs/helius-skills](https://github.com/helius-labs/core-ai/tree/main/helius-skills)** - Ship Solana apps end-to-end; transaction sending, asset queries, real-time streaming, token swaps, prediction markets, browser wallets, and deep research into protocol internals all powered by Helius APIs, DFlow trading, and Phantom wallet integrations
 - **[meodai/skill.color-expert](https://github.com/meodai/skill.color-expert)** - Color science expert skill with 286K words of reference material covering OKLCH/OKLAB, palette generation, accessibility/contrast, color naming, pigment mixing, and historical color theory
 - **[bitwize-music-studio/claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills)** - Full-lifecycle AI music album production
+- **[talkvalue/event-agency-skills](https://github.com/talkvalue/event-agency-skills)** - 7 AI skills for event production — inbox triage, outreach, vendor, speaker, budget, analytics
 
 </details>
 


### PR DESCRIPTION
## Summary

- Adds [talkvalue/event-agency-skills](https://github.com/talkvalue/event-agency-skills) to the **Specialized Domains** section under Community Skills
- 7 self-contained skills: inbox-digest, cold-outreach, vendor-tracker, speaker-management, budget-tracker, post-event-report, registration-analytics
- Domain-knowledge-first approach — encodes event industry workflows, not just tool commands
- Apache-2.0, Claude Code plugin format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new Specialized Domain entry for event production AI skills, covering inbox triage, outreach, vendor coordination, speaker management, budget management, and analytics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->