### PR TITLE
Add skill: deployhq/deployhq-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -1070,6 +1070,7 @@ Official skills from Notion's repositories — workspace-aware skills for captur
 - **[ethos-link/rails-conventions](https://github.com/ethos-link/rails-conventions)** - Rails 8 conventions for consistent production code changes
 - **[ShunsukeHayashi/agent-skill-bus](https://github.com/ShunsukeHayashi/agent-skill-bus)** - Self-improving task orchestration for AI agent systems
 - **[mcollina/skills](https://github.com/mcollina/skills/tree/main/skills)** - 11 skills by Matteo Collina: Node.js, Fastify, TypeScript, OAuth, Git/GitHub, ESLint neostandard, documentation (Diataxis), Node.js core internals, skill optimizer, and more
+- **[deployhq/deployhq-cli](https://github.com/deployhq/deployhq-cli/blob/main/skills/deployhq/SKILL.md)** - Deploy, manage servers, and automate releases on DeployHQ
 
 </details>
 


### PR DESCRIPTION
Adds DeployHQ CLI skill to the Development and Testing category.

**Skill**: [deployhq/deployhq-cli SKILL.md](https://github.com/deployhq/deployhq-cli/blob/main/skills/deployhq/SKILL.md)

Agent skill for the DeployHQ deployment platform — deployment workflows, decision trees, rollback patterns, and an escape hatch for any API endpoint. Features `--json` field selection, piped output auto-detection, and agent detection via `DEPLOYHQ_AGENT` and `CLAUDE_CODE` env vars.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added DeployHQ CLI skill to the official skills directory, enabling users to deploy, manage servers, and automate releases on DeployHQ.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->