### PR TITLE
Add Naxuye/Claude-code-skill-agent-Factory - Skill-to-Agent Compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -1001,7 +1001,7 @@ Official skills from Notion's repositories — workspace-aware skills for captur
 <details>
 <summary><h3 style="display:inline">Development and Testing</h3></summary>
 
-- **- [Naxuye/Claude-code-skill-agent-Factory](https://github.com/Naxuye/Claude-code-skill-agent-Factory) - Skill-to-Agent Compiler: scans installed skills, combines matching ones, self-generates missing components, delivers production-ready runnable agents
+- **[Naxuye/Claude-code-skill-agent-Factory](https://github.com/Naxuye/Claude-code-skill-agent-Factory)** - Skill-to-Agent Compiler: scans installed skills, combines matching ones, self-generates missing components, delivers production-ready runnable agents
 - **[robzolkos/skill-rails-upgrade](https://github.com/robzolkos/skill-rails-upgrade)** - Analyze Rails apps and provide upgrade assessments
 - **[Shpigford/screenshots](https://github.com/Shpigford/skills/tree/main/screenshots)** - Generate marketing screenshots with Playwright
 - **[antonbabenko/terraform-skill](https://github.com/antonbabenko/terraform-skill)** - Terraform infrastructure as code best practices

--- a/README.md
+++ b/README.md
@@ -1001,6 +1001,7 @@ Official skills from Notion's repositories — workspace-aware skills for captur
 <details>
 <summary><h3 style="display:inline">Development and Testing</h3></summary>
 
+- **- [Naxuye/Claude-code-skill-agent-Factory](https://github.com/Naxuye/Claude-code-skill-agent-Factory) - Skill-to-Agent Compiler: scans installed skills, combines matching ones, self-generates missing components, delivers production-ready runnable agents
 - **[robzolkos/skill-rails-upgrade](https://github.com/robzolkos/skill-rails-upgrade)** - Analyze Rails apps and provide upgrade assessments
 - **[Shpigford/screenshots](https://github.com/Shpigford/skills/tree/main/screenshots)** - Generate marketing screenshots with Playwright
 - **[antonbabenko/terraform-skill](https://github.com/antonbabenko/terraform-skill)** - Terraform infrastructure as code best practices


### PR DESCRIPTION
Adds a community skill that acts as a Skill-to-Agent Compiler.

- Scans installed skills, reuses matching ones
- Self-generates missing components
- Language-agnostic (Python, JS, and more)
- Delivers production-ready agents with unified run()/health() interface

Tested Application Scenarios:
- GitHub API → AI analysis → report
- Web scraping → AI summary → file
- PPT Agent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added reference to a Skill-to-Agent Compiler tool that scans and combines installed skills to generate production-ready agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->