### PR TITLE
Add skill: TheColonyCC/colony-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1020,6 +1020,7 @@ Official Resend skills to send and receive emails, build email templates and pow
 - **[Charlie85270/Dorothy](https://github.com/Charlie85270/Dorothy)** - Orchestrate multiple AI CLI agents with automations and MCP servers
 - **[Digidai/product-manager-skills](https://github.com/Digidai/product-manager-skills)** - Senior PM agent with 30+ frameworks and SaaS metrics
 - **[deusyu/translate-book](https://github.com/deusyu/translate-book)** - Translate books (PDF/DOCX/EPUB) via parallel sub-agents with resume
+- **[TheColonyCC/colony-skill](https://github.com/TheColonyCC/colony-skill)** - Integrate AI agents with The Colony (thecolony.cc) — create posts, comment, vote, send DMs, and browse the marketplace on the AI agent community platform. Includes [colony-agent-template](https://pypi.org/project/colony-agent-template/) for three-command agent setup.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -1020,7 +1020,7 @@ Official Resend skills to send and receive emails, build email templates and pow
 - **[Charlie85270/Dorothy](https://github.com/Charlie85270/Dorothy)** - Orchestrate multiple AI CLI agents with automations and MCP servers
 - **[Digidai/product-manager-skills](https://github.com/Digidai/product-manager-skills)** - Senior PM agent with 30+ frameworks and SaaS metrics
 - **[deusyu/translate-book](https://github.com/deusyu/translate-book)** - Translate books (PDF/DOCX/EPUB) via parallel sub-agents with resume
-- **[TheColonyCC/colony-skill](https://github.com/TheColonyCC/colony-skill)** - Integrate AI agents with The Colony (thecolony.cc) — create posts, comment, vote, send DMs, and browse the marketplace on the AI agent community platform. Includes [colony-agent-template](https://pypi.org/project/colony-agent-template/) for three-command agent setup.
+- **[TheColonyCC/colony-skill](https://github.com/TheColonyCC/colony-skill)** - AI agent forum integration for The Colony platform
 
 </details>
 


### PR DESCRIPTION
## Summary

- Adds [TheColonyCC/colony-skill](https://github.com/TheColonyCC/colony-skill) to the **Productivity and Collaboration** community skills section
- This is an OpenClaw agent skill for integrating AI agents with [The Colony](https://thecolony.cc), a community platform for AI agents
- The skill enables agents to create posts, comment, vote, send DMs, and browse the marketplace
- Has a public SKILL.md and is actively used by agents on the platform

## Checklist

- [x] Public repository with working skill
- [x] Has SKILL.md documentation
- [x] Author/org prefix included
- [x] Description is under 10 words
- [x] Added to end of matching subcategory

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Added new community skill entry: AI agent forum integration for The Colony platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->