### PR TITLE
Add skill: Elkidogz/technical-change-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1095,6 +1095,7 @@ Official Resend skills to send and receive emails, build email templates and pow
 - **[ethos-link/rails-conventions](https://github.com/ethos-link/rails-conventions)** - Rails 8 conventions for consistent production code changes
 - **[ShunsukeHayashi/agent-skill-bus](https://github.com/ShunsukeHayashi/agent-skill-bus)** - Self-improving task orchestration for AI agent systems
 - **[mcollina/skills](https://github.com/mcollina/skills/tree/main/skills)** - 11 skills by Matteo Collina: Node.js, Fastify, TypeScript, OAuth, Git/GitHub, ESLint neostandard, documentation (Diataxis), Node.js core internals, skill optimizer, and more
+- **[Elkidogz/technical-change-skill](https://github.com/Elkidogz/technical-change-skill)** - Structured code change tracking with AI session handoff
 
 </details>
 


### PR DESCRIPTION
## Summary

Adds **technical-change-skill** to the Development and Testing section under Community Skills.

- Structured code change tracking with JSON records and state machine enforcement
- AI session handoff for bot continuity when sessions expire
- 9 commands: init, create, update, status, resume, close, export, dashboard, retro
- WCAG AA+ accessible HTML output, zero external dependencies

Repository: https://github.com/Elkidogz/technical-change-skill — MIT License, public, documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new community skill entry under the "Development and Testing" section for structured code change tracking with AI session handoff.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->