### PR TITLE
Add imessage-sms-agent skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1020,6 +1020,7 @@ Official Resend skills to send and receive emails, build email templates and pow
 - **[Charlie85270/Dorothy](https://github.com/Charlie85270/Dorothy)** - Orchestrate multiple AI CLI agents with automations and MCP servers
 - **[Digidai/product-manager-skills](https://github.com/Digidai/product-manager-skills)** - Senior PM agent with 30+ frameworks and SaaS metrics
 - **[deusyu/translate-book](https://github.com/deusyu/translate-book)** - Translate books (PDF/DOCX/EPUB) via parallel sub-agents with resume
+- **[emotion-machine-org/imessage-sms-agent](https://github.com/emotion-machine-org/imessage-sms-agent)** - Give any AI agent iMessage, RCS & SMS capabilities. No Mac required. Works with Claude Code, Codex, Cursor, Gemini CLI. Powered by Claw Messenger ($5/mo)
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -1020,7 +1020,7 @@ Official Resend skills to send and receive emails, build email templates and pow
 - **[Charlie85270/Dorothy](https://github.com/Charlie85270/Dorothy)** - Orchestrate multiple AI CLI agents with automations and MCP servers
 - **[Digidai/product-manager-skills](https://github.com/Digidai/product-manager-skills)** - Senior PM agent with 30+ frameworks and SaaS metrics
 - **[deusyu/translate-book](https://github.com/deusyu/translate-book)** - Translate books (PDF/DOCX/EPUB) via parallel sub-agents with resume
-- **[emotion-machine-org/imessage-sms-agent](https://github.com/emotion-machine-org/imessage-sms-agent)** - Give any AI agent iMessage, RCS & SMS capabilities. No Mac required. Works with Claude Code, Codex, Cursor, Gemini CLI. Powered by Claw Messenger ($5/mo)
+- **[emotion-machine-org/imessage-no-mac-sms](https://github.com/emotion-machine-org/imessage-no-mac-sms)** - Give any AI agent iMessage, RCS & SMS capabilities. No Mac required. Works with Claude Code, Codex, Cursor, Gemini CLI. Powered by Claw Messenger ($5/mo)
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -1020,7 +1020,7 @@ Official Resend skills to send and receive emails, build email templates and pow
 - **[Charlie85270/Dorothy](https://github.com/Charlie85270/Dorothy)** - Orchestrate multiple AI CLI agents with automations and MCP servers
 - **[Digidai/product-manager-skills](https://github.com/Digidai/product-manager-skills)** - Senior PM agent with 30+ frameworks and SaaS metrics
 - **[deusyu/translate-book](https://github.com/deusyu/translate-book)** - Translate books (PDF/DOCX/EPUB) via parallel sub-agents with resume
-- **[emotion-machine-org/imessage-with-no-mac](https://github.com/emotion-machine-org/imessage-with-no-mac)** - Give any AI agent iMessage, RCS & SMS capabilities. No Mac required. Works with Claude Code, Codex, Cursor, Gemini CLI. Powered by Claw Messenger ($5/mo)
+- **[emotion-machine-org/imessage-with-no-mac](https://github.com/emotion-machine-org/imessage-with-no-mac)** - Give any AI agent iMessage, RCS & SMS capabilities. No Mac required. Works with Claude Code, Codex, Cursor, Gemini CLI. Powered by Claw Messenger
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -1020,7 +1020,7 @@ Official Resend skills to send and receive emails, build email templates and pow
 - **[Charlie85270/Dorothy](https://github.com/Charlie85270/Dorothy)** - Orchestrate multiple AI CLI agents with automations and MCP servers
 - **[Digidai/product-manager-skills](https://github.com/Digidai/product-manager-skills)** - Senior PM agent with 30+ frameworks and SaaS metrics
 - **[deusyu/translate-book](https://github.com/deusyu/translate-book)** - Translate books (PDF/DOCX/EPUB) via parallel sub-agents with resume
-- **[emotion-machine-org/imessage-no-mac-sms](https://github.com/emotion-machine-org/imessage-no-mac-sms)** - Give any AI agent iMessage, RCS & SMS capabilities. No Mac required. Works with Claude Code, Codex, Cursor, Gemini CLI. Powered by Claw Messenger ($5/mo)
+- **[emotion-machine-org/imessage-with-no-mac](https://github.com/emotion-machine-org/imessage-with-no-mac)** - Give any AI agent iMessage, RCS & SMS capabilities. No Mac required. Works with Claude Code, Codex, Cursor, Gemini CLI. Powered by Claw Messenger ($5/mo)
 
 </details>
 


### PR DESCRIPTION
Adds [imessage-sms-agent](https://github.com/emotion-machine-org/imessage-sms-agent) to the Agents & Automation section.

**What it does:** Gives any AI agent iMessage, RCS & SMS capabilities via Claw Messenger. No Mac or phone required. Works with Claude Code, Codex, Cursor, Gemini CLI, and 22+ other agents.

**Install:** `npx skills add emotion-machine-org/imessage-sms-agent`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new community skill: `emotion-machine-org/imessage-sms-agent` for iMessage/RCS/SMS integration with cross-editor compatibility (Claude Code, Codex, Cursor, Gemini CLI).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->