### PR TITLE
Add skill: tonone-ai/tonone

### DIFF
--- a/README.md
+++ b/README.md
@@ -1144,6 +1144,7 @@ Official Resend skills to send and receive emails, build email templates and pow
 - **[helius-labs/helius-skills](https://github.com/helius-labs/core-ai/tree/main/helius-skills)** - Ship Solana apps end-to-end; transaction sending, asset queries, real-time streaming, token swaps, prediction markets, browser wallets, and deep research into protocol internals all powered by Helius APIs, DFlow trading, and Phantom wallet integrations
 - **[meodai/skill.color-expert](https://github.com/meodai/skill.color-expert)** - Color science expert skill with 286K words of reference material covering OKLCH/OKLAB, palette generation, accessibility/contrast, color naming, pigment mixing, and historical color theory
 - **[bitwize-music-studio/claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills)** - Full-lifecycle AI music album production
+- **[tonone-ai/tonone](https://github.com/tonone-ai/tonone)** - 23-agent engineering + product team with 125 skills
 
 </details>
 


### PR DESCRIPTION
## Summary

Adds [tonone-ai/tonone](https://github.com/tonone-ai/tonone) to the **Specialized Domains** section under Community Skills.

- 23-agent engineering + product team (15 engineering, 8 product) with 125 skills
- MIT licensed, installable via Claude Code plugin marketplace
- Public repo with documentation and CI

## Entry added

```
- **[tonone-ai/tonone](https://github.com/tonone-ai/tonone)** - 23-agent engineering + product team with 125 skills
```