### PR TITLE
Add skill: drpcorg/drpc-agent-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1144,6 +1144,7 @@ Official Resend skills to send and receive emails, build email templates and pow
 - **[helius-labs/helius-skills](https://github.com/helius-labs/core-ai/tree/main/helius-skills)** - Ship Solana apps end-to-end; transaction sending, asset queries, real-time streaming, token swaps, prediction markets, browser wallets, and deep research into protocol internals all powered by Helius APIs, DFlow trading, and Phantom wallet integrations
 - **[meodai/skill.color-expert](https://github.com/meodai/skill.color-expert)** - Color science expert skill with 286K words of reference material covering OKLCH/OKLAB, palette generation, accessibility/contrast, color naming, pigment mixing, and historical color theory
 - **[bitwize-music-studio/claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills)** - Full-lifecycle AI music album production
+- **[drpcorg/drpc-agent-skills](https://github.com/drpcorg/drpc-agent-skills)** - On-chain data tools: balances, contracts, gas, blocks via DRPC
 
 </details>
 


### PR DESCRIPTION
Adds drpc-agent-skills to the Specialized Domains section under Community Skills. The skill provides on-chain data tools (wallet balances, contract reads, gas prices, block/transaction lookups) for AI agents across EVM chains, Solana, and other networks via DRPC.

Repository: https://github.com/drpcorg/drpc-agent-skills

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented on-chain data tools for accessing blockchain information including balances, contracts, gas, and blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->