### PR TITLE
Add skill: chengjialu8888/LLM-Wiki-KB

### DIFF
--- a/README.md
+++ b/README.md
@@ -1020,6 +1020,7 @@ Official Resend skills to send and receive emails, build email templates and pow
 - **[Charlie85270/Dorothy](https://github.com/Charlie85270/Dorothy)** - Orchestrate multiple AI CLI agents with automations and MCP servers
 - **[Digidai/product-manager-skills](https://github.com/Digidai/product-manager-skills)** - Senior PM agent with 30+ frameworks and SaaS metrics
 - **[deusyu/translate-book](https://github.com/deusyu/translate-book)** - Translate books (PDF/DOCX/EPUB) via parallel sub-agents with resume
+- **[chengjialu8888/LLM-Wiki-KB](https://github.com/chengjialu8888/LLM-Wiki-KB)** - Compile articles into structured interlinked Markdown Wiki knowledge base (Kaparthy workflow inspired)
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -1020,7 +1020,7 @@ Official Resend skills to send and receive emails, build email templates and pow
 - **[Charlie85270/Dorothy](https://github.com/Charlie85270/Dorothy)** - Orchestrate multiple AI CLI agents with automations and MCP servers
 - **[Digidai/product-manager-skills](https://github.com/Digidai/product-manager-skills)** - Senior PM agent with 30+ frameworks and SaaS metrics
 - **[deusyu/translate-book](https://github.com/deusyu/translate-book)** - Translate books (PDF/DOCX/EPUB) via parallel sub-agents with resume
-- **[chengjialu8888/LLM-Wiki-KB](https://github.com/chengjialu8888/LLM-Wiki-KB)** - Compile articles into structured interlinked Markdown Wiki knowledge base (Kaparthy workflow inspired)
+- **[chengjialu8888/LLM-Wiki-KB](https://github.com/chengjialu8888/LLM-Wiki-KB)** - Compile articles into structured interlinked Markdown Wiki knowledge base (Andrej Kaparthy workflow inspired)
 
 </details>
 


### PR DESCRIPTION
## Skill Submission

**Skill:** chengjialu8888/LLM-Wiki-KB

**Description:** Compile articles into structured interlinked Markdown Wiki knowledge base

**Category:** Productivity and Collaboration

**Overview:**
LLM Wiki KB is a knowledge compiling engine based on Andrej Karpathy's LLM Wiki pattern. It helps LLMs compile scattered articles, papers, and notes into a structured, interlinked Markdown Wiki knowledge base.

**Features:**
- 5 CLI tools: init, add, search, lint, export
- Multi-platform support (Claude Code, OpenCode, Mira, generic assistants)
- Obsidian-compatible with graph visualization
- 35/35 tests passing

**Repository:** https://github.com/chengjialu8888/LLM-Wiki-KB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new community skill entry documenting a tool for compiling articles into structured, interlinked Markdown wikis, broadening the community resources available to project users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->