### PR TITLE
Add skill: SunflowersLwtech/polanyi-design

### DIFF
--- a/README.md
+++ b/README.md
@@ -1143,6 +1143,7 @@ Official Resend skills to send and receive emails, build email templates and pow
 - **[talkstream/ru-text](https://github.com/talkstream/ru-text)** - Russian text quality: ~1,040 rules for typography, info-style, editorial, UX writing, business correspondence. Cross-platform: Claude Code, Codex CLI, Gemini CLI, Cursor.
 - **[helius-labs/helius-skills](https://github.com/helius-labs/core-ai/tree/main/helius-skills)** - Ship Solana apps end-to-end; transaction sending, asset queries, real-time streaming, token swaps, prediction markets, browser wallets, and deep research into protocol internals all powered by Helius APIs, DFlow trading, and Phantom wallet integrations
 - **[meodai/skill.color-expert](https://github.com/meodai/skill.color-expert)** - Color science expert skill with 286K words of reference material covering OKLCH/OKLAB, palette generation, accessibility/contrast, color naming, pigment mixing, and historical color theory
+- **[SunflowersLwtech/polanyi-design](https://github.com/SunflowersLwtech/polanyi-design)** - Frontend design cognitive engine grounded in tacit knowledge theory
 - **[bitwize-music-studio/claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills)** - Full-lifecycle AI music album production
 
 </details>


### PR DESCRIPTION
## Summary

- Adds [SunflowersLwtech/polanyi-design](https://github.com/SunflowersLwtech/polanyi-design) to the **Specialized Domains** section under Community Skills
- Frontend design cognitive engine grounded in Michael Polanyi's tacit knowledge theory — surfaces expert-level visual judgment for UI design, layout, and aesthetic decisions
- Cross-platform compatible: Claude Code, any agent with SKILL.md support

## What it does

Three systems: Knowledge Filter (skip explicit / extract implicit / approximate tacit), Five Design Lenses (gestalt diagnostics, subsidiary-focal awareness, tacit translation), and Aesthetic Judgment Encoding (six anti-convergence patterns). Includes live A/B comparison demos.

## Links

- [Repository](https://github.com/SunflowersLwtech/polanyi-design)
- [SKILL.md](https://github.com/SunflowersLwtech/polanyi-design/blob/main/SKILL.md)
- [Live A/B demo](https://sunflowerslwtech.github.io/polanyi-design/showcase/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new community skill entry to the "Specialized Domains" section in documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->