### PR TITLE
Add vaultweaver — Knowledge Management skill (Karpathy LLM Wiki)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1161,6 +1161,13 @@ Official Resend skills to send and receive emails, build email templates and pow
 </details>
 
 
+<details>
+<summary><h3 style="display:inline">Knowledge Management</h3></summary>
+
+- **[Apexlify/vaultweaver](https://github.com/Apexlify/vaultweaver)** - LLM Knowledge Base compiler implementing Karpathy's wiki pattern. Raw sources compiled into interconnected Obsidian-compatible markdown wikis with auto-ingest, concept extraction, BM25 search, and drift detection
+
+</details>
+
 ## 🔒 Security Notice
 
 Skills in this list are curated, not audited. They may be updated, modified, or replaced by their original maintainers at any time after being added here.


### PR DESCRIPTION
Adds [vaultweaver](https://github.com/Apexlify/vaultweaver) to a new **Knowledge Management** category under Community Skills.

Claude Code skill implementing Karpathy's LLM Knowledge Bases pattern — raw sources compiled into interconnected Obsidian-compatible markdown wikis.

**Features:** 8 commands, auto-ingest hooks, BM25 search, drift detection, 7 health checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Added a new "Knowledge Management" community section to the README with curated resource listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->