### PR TITLE
Add Finance and Trading category with TBD

### DIFF
--- a/README.md
+++ b/README.md
@@ -1024,6 +1024,13 @@ Official Resend skills to send and receive emails, build email templates and pow
 </details>
 
 <details>
+<summary><h3 style="display:inline">Finance and Trading</h3></summary>
+
+- **[ego-protocol/tbd-vote-cli](https://github.com/ego-protocol/tbd-vote-cli)** - Trade on TBD, a Solana-based prediction market for human opinions, via the `@tbd-vote/cli` package; defers to an [AGENTS.md](https://www.tbd.vote/agents/AGENTS.md) spec for autonomous-loop instructions and HTTP fallback.
+
+</details>
+
+<details>
 <summary><h3 style="display:inline">Development and Testing</h3></summary>
 
 - **[robzolkos/skill-rails-upgrade](https://github.com/robzolkos/skill-rails-upgrade)** - Analyze Rails apps and provide upgrade assessments


### PR DESCRIPTION
Adds a new **Finance and Trading** category to Community Skills with one initial entry: TBD.

[TBD](https://www.tbd.vote) is a Solana-based prediction market for human opinions — wagering on what people think and believe rather than purely objective event outcomes. The [`@tbd-vote/cli`](https://www.npmjs.com/package/@tbd-vote/cli) npm package and [SKILL.md](https://github.com/ego-protocol/tbd-vote-cli/blob/main/SKILL.md) let agents authenticate, browse opinion campaigns, and place bets via JSON-friendly commands. The skill defers to a long-form [AGENTS.md spec](https://www.tbd.vote/agents/AGENTS.md) for autonomous-loop patterns and HTTP fallback.

I added a new "Finance and Trading" category since none of the existing community categories (Vector Databases, Marketing, Productivity, Development and Testing, Context Engineering) is a clean fit. Happy to merge this entry into Productivity and Collaboration instead if you'd prefer not to add a new category — peers like `EveryInc/charlie-cfo-skill` and `wrsmith108/linear-claude-skill` set a precedent for finance-adjacent skills there.

- Repo: https://github.com/ego-protocol/tbd-vote-cli
- Website: https://www.tbd.vote
- AGENTS.md: https://www.tbd.vote/agents/AGENTS.md
- npm: https://www.npmjs.com/package/@tbd-vote/cli

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Finance and Trading section documenting TBD trading capabilities and integration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->