### PR TITLE
Add skill: monte-carlo-data/mc-agent-toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The most contributed Agent Skills repository, built and maintained together with
 | [Product Manager Skills by Dean Peters](#product-manager-skills-by-dean-peters) | [Product Management Skills by Paweł Huryn](#product-management-skills-by-pawel-huryn) | [Skills by MiniMax](#skills-by-minimax-team) |
 | [Skills by DuckDB](#skills-by-duckdb) | [Skills by GSAP](#skills-by-gsap-greensock) | [Skills by Garry Tan (gstack)](#skills-by-garry-tan-gstack) |
 | [Skills by Monte Carlo Data](#skills-by-monte-carlo-data) | [Skills by Notion](#skills-by-notion) | [Skills by Resend](#skills-by-resend) |
-| [Community Skills](#community-skills) |
+| [Community Skills](#community-skills) | | |
 | [Skill Quality Standards](#skill-quality-standards) | | |
 
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ The most contributed Agent Skills repository, built and maintained together with
 | [Skills by Figma](#skills-by-figma) | [Marketing Skills by Corey Haines](#marketing-skills-by-corey-haines) | [Skills by Binance](#skills-by-binance) |
 | [Product Manager Skills by Dean Peters](#product-manager-skills-by-dean-peters) | [Product Management Skills by Paweł Huryn](#product-management-skills-by-pawel-huryn) | [Skills by MiniMax](#skills-by-minimax-team) |
 | [Skills by DuckDB](#skills-by-duckdb) | [Skills by GSAP](#skills-by-gsap-greensock) | [Skills by Garry Tan (gstack)](#skills-by-garry-tan-gstack) |
-| [Skills by Notion](#skills-by-notion) | [Skills by Resend](#skills-by-resend) | [Community Skills](#community-skills) |
+| [Skills by Monte Carlo Data](#skills-by-monte-carlo-data) | [Skills by Notion](#skills-by-notion) | [Skills by Resend](#skills-by-resend) |
+| [Community Skills](#community-skills) |
 | [Skill Quality Standards](#skill-quality-standards) | | |
 
 
@@ -139,6 +140,12 @@ Official skills by VoltAgent for building AI agents with the VoltAgent TypeScrip
 
 ### Skills by Courier
 - **[trycourier/courier-skills](https://github.com/trycourier/courier-skills)** - Multi-channel notifications via email, SMS, push, and chat
+
+### Skills by Monte Carlo Data
+- **[monte-carlo-data/mc-agent-toolkit](https://github.com/monte-carlo-data/mc-agent-toolkit/tree/main/skills/prevent)** - Change impact assessment with lineage and blast radius
+- **[monte-carlo-data/mc-agent-toolkit](https://github.com/monte-carlo-data/mc-agent-toolkit/tree/main/skills/monitor-creation)** - Create monitors-as-code YAML via MCP tools
+- **[monte-carlo-data/mc-agent-toolkit](https://github.com/monte-carlo-data/mc-agent-toolkit/tree/main/skills/push-ingestion)** - Push metadata and lineage to Monte Carlo
+- **[monte-carlo-data/mc-agent-toolkit](https://github.com/monte-carlo-data/mc-agent-toolkit/tree/main/skills/generate-validation-notebook)** - Generate SQL validation notebooks for dbt PRs
 
 ### Skills by CallStack
 - **[callstackincubator/react-native-best-practices](https://officialskills.sh/callstackincubator/skills/react-native-best-practices)** - Performance optimization for React Native apps from Callstack

--- a/README.md
+++ b/README.md
@@ -142,10 +142,10 @@ Official skills by VoltAgent for building AI agents with the VoltAgent TypeScrip
 - **[trycourier/courier-skills](https://github.com/trycourier/courier-skills)** - Multi-channel notifications via email, SMS, push, and chat
 
 ### Skills by Monte Carlo Data
-- **[monte-carlo-data/mc-agent-toolkit](https://github.com/monte-carlo-data/mc-agent-toolkit/tree/main/skills/prevent)** - Change impact assessment with lineage and blast radius
-- **[monte-carlo-data/mc-agent-toolkit](https://github.com/monte-carlo-data/mc-agent-toolkit/tree/main/skills/monitor-creation)** - Create monitors-as-code YAML via MCP tools
-- **[monte-carlo-data/mc-agent-toolkit](https://github.com/monte-carlo-data/mc-agent-toolkit/tree/main/skills/push-ingestion)** - Push metadata and lineage to Monte Carlo
-- **[monte-carlo-data/mc-agent-toolkit](https://github.com/monte-carlo-data/mc-agent-toolkit/tree/main/skills/generate-validation-notebook)** - Generate SQL validation notebooks for dbt PRs
+- **[monte-carlo-data/prevent](https://github.com/monte-carlo-data/mc-agent-toolkit/tree/main/skills/prevent)** - Change impact assessment with lineage and blast radius
+- **[monte-carlo-data/monitor-creation](https://github.com/monte-carlo-data/mc-agent-toolkit/tree/main/skills/monitor-creation)** - Create monitors-as-code YAML via MCP tools
+- **[monte-carlo-data/push-ingestion](https://github.com/monte-carlo-data/mc-agent-toolkit/tree/main/skills/push-ingestion)** - Push metadata and lineage to Monte Carlo
+- **[monte-carlo-data/generate-validation-notebook](https://github.com/monte-carlo-data/mc-agent-toolkit/tree/main/skills/generate-validation-notebook)** - Generate SQL validation notebooks for dbt PRs
 
 ### Skills by CallStack
 - **[callstackincubator/react-native-best-practices](https://officialskills.sh/callstackincubator/skills/react-native-best-practices)** - Performance optimization for React Native apps from Callstack

--- a/README.md
+++ b/README.md
@@ -936,6 +936,7 @@ Official GSAP animation skills covering the full GreenSock ecosystem — core AP
 
 </details>
 
+<a id="skills-by-notion"></a>
 <details>
 <summary><h3 style="display:inline">Skills by Notion</h3></summary>
 
@@ -957,6 +958,7 @@ Official skills from Notion's repositories — workspace-aware skills for captur
 
 </details>
 
+<a id="skills-by-resend"></a>
 <details>
 <summary><h3 style="display:inline">Skills by Resend</h3></summary>
 


### PR DESCRIPTION
Adds a new **Skills by Monte Carlo Data** section with 4 data observability skills from [monte-carlo-data/mc-agent-toolkit](https://github.com/monte-carlo-data/mc-agent-toolkit).

**Entries added:**
- `prevent` — Change impact assessment with lineage and blast radius
- `monitor-creation` — Create monitors-as-code YAML via MCP tools
- `push-ingestion` — Push metadata and lineage to Monte Carlo
- `generate-validation-notebook` — Generate SQL validation notebooks for dbt PRs

**About the repo:**
- 68 GitHub stars, Apache-2.0 license
- Used by Monte Carlo Data's engineering team and customers
- Has README and SKILL.md documentation for all skills
- Table of contents updated with the new section

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reworked the Table of Contents into two rows: added "Skills by Monte Carlo Data" alongside Notion and Resend, and separated "Community Skills" for clearer navigation.
  * Added a "Skills by Monte Carlo Data" section listing four linked Monte Carlo skills (prevent, monitor-creation, push-ingestion, generate-validation-notebook).
  * Inserted explicit anchors to improve fragment navigation to the Notion and Resend sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->