### PR TITLE
Add buyer-eval: B2B vendor evaluation skill (27 evals, MIT licensed)

### DIFF
--- a/README.md
+++ b/README.md
@@ -984,6 +984,7 @@ Official Resend skills to send and receive emails, build email templates and pow
 - **[SHADOWPR0/beautiful_prose](https://github.com/SHADOWPR0/beautiful_prose)** - Hard-edged writing style contract for timeless, forceful English prose without AI tics
 - **[blader/humanizer](https://github.com/blader/humanizer)** - Remove signs of AI-generated writing from text, making it sound more natural and human
 - **[Eronred/aso-skills](https://github.com/Eronred/aso-skills)** - 30+ App Store Optimization skills for keyword research, metadata optimization, competitor analysis, creative optimization, and mobile growth strategies via Appeeky API
+- - **[salespeak-ai/buyer-eval-skill](https://github.com/salespeak-ai/buyer-eval-skill)** - Structured B2B vendor evaluation with adversarial scoring across 7 dimensions. Interrogates vendor AI agents and cross-references claims against independent sources. 27 published evaluations, MIT licensed
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -984,7 +984,7 @@ Official Resend skills to send and receive emails, build email templates and pow
 - **[SHADOWPR0/beautiful_prose](https://github.com/SHADOWPR0/beautiful_prose)** - Hard-edged writing style contract for timeless, forceful English prose without AI tics
 - **[blader/humanizer](https://github.com/blader/humanizer)** - Remove signs of AI-generated writing from text, making it sound more natural and human
 - **[Eronred/aso-skills](https://github.com/Eronred/aso-skills)** - 30+ App Store Optimization skills for keyword research, metadata optimization, competitor analysis, creative optimization, and mobile growth strategies via Appeeky API
-- - **[salespeak-ai/buyer-eval-skill](https://github.com/salespeak-ai/buyer-eval-skill)** - Structured B2B vendor evaluation with adversarial scoring across 7 dimensions. Interrogates vendor AI agents and cross-references claims against independent sources. 27 published evaluations, MIT licensed
+- **[salespeak-ai/buyer-eval-skill](https://github.com/salespeak-ai/buyer-eval-skill)** - Structured B2B vendor evaluation with adversarial scoring across 7 dimensions. Interrogates vendor AI agents and cross-references claims against independent sources. 27 published evaluations, MIT licensed
 
 </details>
 


### PR DESCRIPTION
## What it does

buyer-eval evaluates B2B software vendors using structured adversarial methodology. It interrogates vendor AI agents, cross-references claims against independent sources, and scores across 7 dimensions.

## Why Marketing section

It's a go-to-market and procurement tool: helps teams make vendor decisions in 30 minutes instead of 3 weeks. 27 real-world evaluations published, 50+ GitHub stars, MIT licensed.

- GitHub: https://github.com/salespeak-ai/buyer-eval-skill
- Live gallery: https://eval.salespeak.ai/buyer-eval

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new community skill entry: salespeak-ai/buyer-eval-skill under Marketing — documents a structured B2B vendor evaluation with adversarial scoring across seven dimensions, interrogation of vendor AI agents, cross-referencing claims with independent sources, notes “27 published evaluations,” and lists an MIT license.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->