### PR TITLE
Add skill: talkvalue/event-agency-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1144,6 +1144,7 @@ Official Resend skills to send and receive emails, build email templates and pow
 - **[helius-labs/helius-skills](https://github.com/helius-labs/core-ai/tree/main/helius-skills)** - Ship Solana apps end-to-end; transaction sending, asset queries, real-time streaming, token swaps, prediction markets, browser wallets, and deep research into protocol internals all powered by Helius APIs, DFlow trading, and Phantom wallet integrations
 - **[meodai/skill.color-expert](https://github.com/meodai/skill.color-expert)** - Color science expert skill with 286K words of reference material covering OKLCH/OKLAB, palette generation, accessibility/contrast, color naming, pigment mixing, and historical color theory
 - **[bitwize-music-studio/claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills)** - Full-lifecycle AI music album production
+- **[talkvalue/event-agency-skills](https://github.com/talkvalue/event-agency-skills)** - 7 AI skills for event production — inbox triage, outreach, vendor, speaker, budget, analytics
 
 </details>
 


### PR DESCRIPTION
## Summary
- add `talkvalue/event-agency-skills` to the community skills list
- link the public repository with a short event-production-focused description

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new community resource entry for event production AI skills, covering inbox triage, outreach, vendor coordination, speaker management, budgeting, and analytics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->