### PR TITLE
Add skill: aaajiao/aaajiao.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1141,6 +1141,7 @@ Official Resend skills to send and receive emails, build email templates and pow
 - **[helius-labs/helius-skills](https://github.com/helius-labs/core-ai/tree/main/helius-skills)** - Ship Solana apps end-to-end; transaction sending, asset queries, real-time streaming, token swaps, prediction markets, browser wallets, and deep research into protocol internals all powered by Helius APIs, DFlow trading, and Phantom wallet integrations
 - **[meodai/skill.color-expert](https://github.com/meodai/skill.color-expert)** - Color science expert skill with 286K words of reference material covering OKLCH/OKLAB, palette generation, accessibility/contrast, color naming, pigment mixing, and historical color theory
 - **[bitwize-music-studio/claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills)** - Full-lifecycle AI music album production
+- **[aaajiao/aaajiao.md](https://github.com/aaajiao/aaajiao.md)** - Think like media artist aaajiao: critical lens for algorithmic governance and trade infrastructure
 
 </details>
 


### PR DESCRIPTION
## Summary

Adds [aaajiao/aaajiao.md](https://github.com/aaajiao/aaajiao.md) to the Specialized Domains section.

**aaajiao** (Xu Wenkai) is a media artist working between Berlin and Shanghai since 2007. This skill distills his conceptual framework — algorithmic governance critique, platform politics, trade infrastructure analysis — into a format agents can load and use.

- **SKILL.md**: 2100 words — identity, double helix framework, concept-as-filter methodology, 18 key works, critical lens checklist
- **Knowledge base**: 112 reference documents (interview transcripts, 58 media articles from Frieze/Artforum/NYT/Ocula/etc., 40 print PDFs, project documents)
- **Works database**: 163 artworks with metadata
- **Install**: `npx skills add aaajiao/aaajiao.md --all`

Category: **Specialized Domains** (alongside color-expert, music-skills, genealogy-research)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new community skill entry in the specialized domains section documenting expertise in algorithmic governance and trade infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->