### PR TITLE
Expand Paperzilla source coverage in README note

### DIFF
--- a/README.md
+++ b/README.md
@@ -1012,6 +1012,13 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 ### Community Skills
 
 <details>
+<summary><h3 style="display:inline">Science & Research</h3></summary>
+
+- **[paperzilla-ai/paperzilla-skills](https://github.com/paperzilla-ai/paperzilla-skills)** - Conversational literature monitoring and paper chat for biology and medical research. Supports project-based bioRxiv and medRxiv feeds today, fetches paper markdown for summarization and relevance checks, and has PubMed support planned. OpenClaw distribution is also available on [ClawHub](https://clawhub.ai/pors/paperzilla).
+
+</details>
+
+<details>
 <summary><h3 style="display:inline">Vector Databases</h3></summary>
 
 - **[qdrant/skills](https://github.com/qdrant/skills)** - Agent skills for Qdrant vector search, covering scaling, performance optimization, search quality, monitoring, deployment, model migration, version upgrades, and SDK usage across Python, TypeScript, Rust, Go, .NET, and Java

--- a/README.md
+++ b/README.md
@@ -1014,7 +1014,7 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 <details>
 <summary><h3 style="display:inline">Science & Research</h3></summary>
 
-- **[paperzilla-ai/paperzilla-skills](https://github.com/paperzilla-ai/paperzilla-skills)** - Conversational literature monitoring and paper chat for biology and medical research. Supports project-based bioRxiv and medRxiv feeds today, fetches paper markdown for summarization and relevance checks, and has PubMed support planned. OpenClaw distribution is also available on [ClawHub](https://clawhub.ai/pors/paperzilla).
+- **[paperzilla-ai/paperzilla-skills](https://github.com/paperzilla-ai/paperzilla-skills)** - Conversational literature monitoring and paper chat for scientific research. Supports project-based feeds from arXiv, bioRxiv, medRxiv, and ChemRxiv, plus scholar alerts; fetches paper markdown for summarization and relevance checks; and has PubMed support planned. OpenClaw distribution is also available on [ClawHub](https://clawhub.ai/pors/paperzilla).
 
 </details>
 


### PR DESCRIPTION
Conversational literature monitoring and paper chat for scientific research. Paperzilla currently supports project-based feeds from arXiv, bioRxiv, medRxiv, and ChemRxiv, plus scholar alerts; can fetch paper markdown for summarization and relevance assessment; and will soon add PubMed support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Added a new "Science & Research" subsection to Community Skills in README. Introduces tools for conversational literature monitoring and paper analysis including: interactive paper chat, preprint feed integration, scholar alerts, paper-to-markdown conversion capabilities for research summarization and quality assessment, planned biomedical research features, and access through community distribution platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->