### PR TITLE
Add chatgpt-plus-guide to Specialized Domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -1192,6 +1192,7 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[helius-labs/helius-skills](https://github.com/helius-labs/core-ai/tree/main/helius-skills)** - Ship Solana apps end-to-end; transaction sending, asset queries, real-time streaming, token swaps, prediction markets, browser wallets, and deep research into protocol internals all powered by Helius APIs, DFlow trading, and Phantom wallet integrations
 - **[meodai/skill.color-expert](https://github.com/meodai/skill.color-expert)** - Color science expert skill with 286K words of reference material covering OKLCH/OKLAB, palette generation, accessibility/contrast, color naming, pigment mixing, and historical color theory
 - **[bitwize-music-studio/claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills)** - Full-lifecycle AI music album production
+- **[xyzm6/chatgpt-plus-guide](https://github.com/xyzm6/chatgpt-plus-guide)** - Practical guide for ChatGPT Plus/Pro subscribers — regional pricing, payment methods for blocked regions, account safety checklist
 
 </details>
 


### PR DESCRIPTION
## Summary

- Adds [xyzm6/chatgpt-plus-guide](https://github.com/xyzm6/chatgpt-plus-guide) to the **Specialized Domains** section
- Practical guide for ChatGPT Plus/Pro subscribers — regional pricing, payment methods for blocked regions, account safety checklist

## Checklist

- [x] Entry follows the existing format (`**[user/repo](url)** - description`)
- [x] Added to an appropriate category (Specialized Domains)
- [x] Link is valid and points to a public repository

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new specialized domain entry providing a comprehensive guide for ChatGPT Plus/Pro subscribers, including regional pricing information, payment methods for restricted regions, and account security best practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->