### PR TITLE
Add skill: xyzm6/chatgpt-plus-guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1192,6 +1192,7 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[helius-labs/helius-skills](https://github.com/helius-labs/core-ai/tree/main/helius-skills)** - Ship Solana apps end-to-end; transaction sending, asset queries, real-time streaming, token swaps, prediction markets, browser wallets, and deep research into protocol internals all powered by Helius APIs, DFlow trading, and Phantom wallet integrations
 - **[meodai/skill.color-expert](https://github.com/meodai/skill.color-expert)** - Color science expert skill with 286K words of reference material covering OKLCH/OKLAB, palette generation, accessibility/contrast, color naming, pigment mixing, and historical color theory
 - **[bitwize-music-studio/claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills)** - Full-lifecycle AI music album production
+- **[xyzm6/chatgpt-plus-guide](https://github.com/xyzm6/chatgpt-plus-guide)** - ChatGPT Plus/Pro subscription guide: regional pricing, payments, account safety
 
 </details>
 


### PR DESCRIPTION
Adds [chatgpt-plus-guide](https://github.com/xyzm6/chatgpt-plus-guide) — a practical guide for ChatGPT Plus/Pro subscribers covering regional pricing, payment methods for blocked regions, and account safety checklist.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new community skill guide covering ChatGPT Plus/Pro subscription information, including regional pricing, payments, and account safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->