### PR TITLE
Add vscode-extension-guide-en skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1093,6 +1093,7 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[scarletkc/vexor](https://github.com/scarletkc/vexor)** - Vector-powered CLI for semantic file search with a Claude/Codex skill
 - **[obra/test-driven-development](https://github.com/obra/superpowers/blob/main/skills/test-driven-development/SKILL.md)** - Write tests before implementing code
 - **[obra/subagent-driven-development](https://github.com/obra/superpowers/blob/main/skills/subagent-driven-development/SKILL.md)** - Development using multiple sub-agents
+- **[lewiswigmore/vscode-extension-guide-en](https://github.com/lewiswigmore/agent-skills/tree/main/skills/vscode-extension-guide-en)** - VS Code extension development guide for 1.74+
 - **[obra/systematic-debugging](https://github.com/obra/superpowers/blob/main/skills/systematic-debugging/SKILL.md)** - Methodical problem-solving in code
 - **[obra/root-cause-tracing](https://github.com/obra/superpowers/blob/main/skills/root-cause-tracing/SKILL.md)** - Investigate and identify fundamental problems
 - **[obra/testing-skills-with-subagents](https://github.com/obra/superpowers/blob/main/skills/testing-skills-with-subagents/SKILL.md)** - Collaborative testing approaches

--- a/README.md
+++ b/README.md
@@ -1093,7 +1093,6 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[scarletkc/vexor](https://github.com/scarletkc/vexor)** - Vector-powered CLI for semantic file search with a Claude/Codex skill
 - **[obra/test-driven-development](https://github.com/obra/superpowers/blob/main/skills/test-driven-development/SKILL.md)** - Write tests before implementing code
 - **[obra/subagent-driven-development](https://github.com/obra/superpowers/blob/main/skills/subagent-driven-development/SKILL.md)** - Development using multiple sub-agents
-- **[lewiswigmore/vscode-extension-guide-en](https://github.com/lewiswigmore/agent-skills/tree/main/skills/vscode-extension-guide-en)** - VS Code extension development guide for 1.74+
 - **[obra/systematic-debugging](https://github.com/obra/superpowers/blob/main/skills/systematic-debugging/SKILL.md)** - Methodical problem-solving in code
 - **[obra/root-cause-tracing](https://github.com/obra/superpowers/blob/main/skills/root-cause-tracing/SKILL.md)** - Investigate and identify fundamental problems
 - **[obra/testing-skills-with-subagents](https://github.com/obra/superpowers/blob/main/skills/testing-skills-with-subagents/SKILL.md)** - Collaborative testing approaches
@@ -1144,6 +1143,7 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[ShunsukeHayashi/agent-skill-bus](https://github.com/ShunsukeHayashi/agent-skill-bus)** - Self-improving task orchestration for AI agent systems
 - **[mcollina/skills](https://github.com/mcollina/skills/tree/main/skills)** - 11 skills by Matteo Collina: Node.js, Fastify, TypeScript, OAuth, Git/GitHub, ESLint neostandard, documentation (Diataxis), Node.js core internals, skill optimizer, and more
 - **[Lum1104/understand-anything](https://github.com/Lum1104/Understand-Anything)** - Interactive codebase knowledge graphs via multi-agent LLM analysis
+- **[lewiswigmore/vscode-extension-guide-en](https://github.com/lewiswigmore/agent-skills/tree/main/skills/vscode-extension-guide-en)** - VS Code extension development guide for 1.74+
 
 </details>
 


### PR DESCRIPTION
Adds vscode-extension-guide-en to the Development and Testing section.

This is an English guide for building VS Code extensions, covering scaffolding, webview patterns, CSP security, TreeView, testing and publishing. Updated for VS Code 1.74+ APIs.

Adapted from aktsmm/agent-skills (CC BY-NC-SA 4.0) with corrections where the extension docs have changed.

Install: `npx skills add lewiswigmore/agent-skills --skill vscode-extension-guide-en`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new entry to the "Development and Testing" community skills list: a VS Code extension development guide (targets VS Code 1.74+). This was a single-line README update; no other content or code changes were made.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->