### PR TITLE
Add mohitagw15856/pm-claude-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1067,6 +1067,7 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[Digidai/product-manager-skills](https://github.com/Digidai/product-manager-skills)** - Senior PM agent with 30+ frameworks and SaaS metrics
 - **[deusyu/translate-book](https://github.com/deusyu/translate-book)** - Translate books (PDF/DOCX/EPUB) via parallel sub-agents with resume
 - **[mvanhorn/last30days-skill](https://github.com/mvanhorn/last30days-skill)** - Research any topic across Reddit, X, YouTube, HN, Polymarket, and the web, ranked by upvotes, likes, and real money instead of editors
+- **[mohitagw15856/pm-claude-skills](https://github.com/mohitagw15856/pm-claude-skills)** - 90 professional skills across 14 professions.
 
 </details>
 


### PR DESCRIPTION
Adding pm-claude-skills to the Productivity and Collaboration section.

- Repository: https://github.com/mohitagw15856/pm-claude-skills
- 90 Claude Skills across 14 professions (PM, legal, finance, HR, sales, engineering, design, Figma, operations, research, and more)
- 210+ GitHub stars, 4 forks, MIT licence
- Active maintenance — 11-part article series, 22 plugin bundles
- Community usage: 240k+ views, organic sharing across Facebook, Reddit, and LinkedIn
- Install: /plugin marketplace add mohitagw15856/pm-claude-skills

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new Community Skills entry to README showcasing 90 professional skills across 14 professions, expanding available community expertise resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->