### PR TITLE
Add skill: Aryan1718/aws-s3-agent-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1144,6 +1144,7 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[mcollina/skills](https://github.com/mcollina/skills/tree/main/skills)** - 11 skills by Matteo Collina: Node.js, Fastify, TypeScript, OAuth, Git/GitHub, ESLint neostandard, documentation (Diataxis), Node.js core internals, skill optimizer, and more
 - **[Lum1104/understand-anything](https://github.com/Lum1104/Understand-Anything)** - Interactive codebase knowledge graphs via multi-agent LLM analysis
 - **[hqhq1025/skill-optimizer](https://github.com/hqhq1025/skill-optimizer)** - Diagnose and optimize Agent Skills (SKILL.md) with real session data and research-backed static analysis. Works with Claude Code, Codex, and any Agent Skills-compatible agent
+- **[Aryan1718/aws-s3-agent-skill](https://github.com/Aryan1718/aws-s3-agent-skill)** - Enforce correct S3 workflows with Terraform and CLI separation
 
 </details>
 


### PR DESCRIPTION
## Add AWS S3 agent skill

Adds an AWS S3 agent skill focused on correct workflow execution.

### Covers
- bucket creation vs adoption
- Terraform for infrastructure setup
- CLI or SDK for runtime object operations
- identity and region verification
- safeguards for destructive actions

Repo: https://github.com/Aryan1718/aws-s3-agent-skill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new community skill documentation for AWS S3 workflow enforcement using Terraform and CLI separation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->