### PR TITLE
Add skill: connerlambden/helium-mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -1193,6 +1193,7 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[helius-labs/helius-skills](https://github.com/helius-labs/core-ai/tree/main/helius-skills)** - Ship Solana apps end-to-end; transaction sending, asset queries, real-time streaming, token swaps, prediction markets, browser wallets, and deep research into protocol internals all powered by Helius APIs, DFlow trading, and Phantom wallet integrations
 - **[meodai/skill.color-expert](https://github.com/meodai/skill.color-expert)** - Color science expert skill with 286K words of reference material covering OKLCH/OKLAB, palette generation, accessibility/contrast, color naming, pigment mixing, and historical color theory
 - **[bitwize-music-studio/claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills)** - Full-lifecycle AI music album production
+- **[connerlambden/helium-mcp](https://github.com/connerlambden/helium-mcp/blob/main/SKILL.md)** - News bias scoring, live markets, ML options pricing
 
 </details>
 


### PR DESCRIPTION
Adds Helium MCP to the Specialized Domains section.

**Skill**: [connerlambden/helium-mcp](https://github.com/connerlambden/helium-mcp/blob/main/SKILL.md)

**What it does**: Remote MCP server with 9 tools for news intelligence (bias scoring across 15+ dimensions, 5,000+ sources), live stock/ETF/crypto data with AI-generated analysis, ML options pricing, and balanced news synthesis.

- Public repo with SKILL.md documentation
- Listed on npm, Glama, Smithery, Official MCP Registry
- Free tier: 50 queries, no signup
- Compatible with Claude Code, Codex, Gemini CLI, Cursor, Windsurf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new community resource entry in the "Specialized Domains" section highlighting a toolset for news bias scoring, live market tracking, and machine-learning options pricing. Included a link to the skill documentation to help users discover capabilities, examples, and usage guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->