### PR TITLE
Add skill: MiniMax-AI/cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -866,8 +866,9 @@ Official Web3 and trading skills from the Binance team. Includes crypto market d
 <details>
 <summary><h3 style="display:inline">Skills by MiniMax Team</h3></summary>
 
-10 development and document generation skills from the MiniMax AI team. Covers frontend, fullstack, mobile, shader development, and document creation (PDF, DOCX, XLSX, PPTX) with MiniMax API integration.
+11 development and document generation skills from the MiniMax AI team. Covers frontend, fullstack, mobile, shader development, document creation (PDF, DOCX, XLSX, PPTX), and the MiniMax AI CLI with MiniMax API integration.
 
+- **[MiniMax-AI/cli](https://officialskills.sh/MiniMax-AI/skills/cli)** - Generate text, image, video, speech, and music via MiniMax AI
 - **[MiniMax-AI/frontend-dev](https://officialskills.sh/MiniMax-AI/skills/frontend-dev)** - Full-stack frontend with cinematic animations, AI-generated media via MiniMax API, and generative art
 - **[MiniMax-AI/fullstack-dev](https://officialskills.sh/MiniMax-AI/skills/fullstack-dev)** - Backend architecture with REST API design, auth flows, real-time features, and database integration
 - **[MiniMax-AI/android-native-dev](https://officialskills.sh/MiniMax-AI/skills/android-native-dev)** - Android native development with Kotlin/Jetpack Compose, Material Design 3, and accessibility


### PR DESCRIPTION
## Summary

- Add `MiniMax-AI/cli` to the Skills by MiniMax Team section so the mmx-cli skill is discoverable in this collection
- The skill is available at [MiniMax-AI/cli](https://github.com/MiniMax-AI/cli/blob/main/skill/SKILL.md) following the agentskills.io standard
- Skill updates are fully decoupled: MiniMax maintains the upstream SKILL.md, no changes needed in this project

**2 lines changed, 0 new files.**

## What is mmx-cli?

[mmx-cli](https://github.com/MiniMax-AI/cli) is a CLI tool for the MiniMax AI platform, providing:
- **Text generation** (MiniMax-M2.7 model)
- **Image generation** (image-01)
- **Video generation** (Hailuo-2.3)
- **Speech synthesis** (speech-2.8-hd, 300+ voices)
- **Music generation** (music-2.6, with lyrics, cover, and instrumental)
- **Web search**

The [SKILL.md](https://github.com/MiniMax-AI/cli/blob/main/skill/SKILL.md) follows the [agentskills.io](https://agentskills.io) standard and includes agent-specific flags (`--non-interactive`, `--quiet`, `--output json`).

## Test plan

- The mmx-cli skill entry is visible in the MiniMax Team section
- Link resolves to the correct officialskills.sh page for MiniMax-AI/cli