### PR TITLE
Add skill: aklofas/kicad-happy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1365,6 +1365,7 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[talkstream/ru-text](https://github.com/talkstream/ru-text)** - Russian text quality: ~1,040 rules for typography, info-style, editorial, UX writing, business correspondence. Cross-platform: Claude Code, Codex CLI, Gemini CLI, Cursor.
 - **[helius-labs/helius-skills](https://github.com/helius-labs/core-ai/tree/main/helius-skills)** - Ship Solana apps end-to-end; transaction sending, asset queries, real-time streaming, token swaps, prediction markets, browser wallets, and deep research into protocol internals all powered by Helius APIs, DFlow trading, and Phantom wallet integrations
 - **[meodai/skill.color-expert](https://github.com/meodai/skill.color-expert)** - Color science expert skill with 286K words of reference material covering OKLCH/OKLAB, palette generation, accessibility/contrast, color naming, pigment mixing, and historical color theory
+- **[aklofas/kicad-happy](https://github.com/aklofas/kicad-happy)** - AI-powered KiCad electronics design review and analysis
 - **[bitwize-music-studio/claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills)** - Full-lifecycle AI music album production
 
 </details>


### PR DESCRIPTION
Adds [aklofas/kicad-happy](https://github.com/aklofas/kicad-happy) to the Specialized Domains section.

AI-powered KiCad electronics design review with 11 skills: schematic analysis, PCB layout checks, EMC pre-compliance, SPICE simulation, component sourcing, BOM management, and manufacturing prep. Cross-platform (Claude Code + Codex). MIT license, 166 stars, 245 installs.