### PR TITLE
Add skill: jiawei248/daily-gift

### DIFF
--- a/README.md
+++ b/README.md
@@ -1240,6 +1240,7 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[Digidai/product-manager-skills](https://github.com/Digidai/product-manager-skills)** - Senior PM agent with 30+ frameworks and SaaS metrics
 - **[deusyu/translate-book](https://github.com/deusyu/translate-book)** - Translate books (PDF/DOCX/EPUB) via parallel sub-agents with resume
 - **[mvanhorn/last30days-skill](https://github.com/mvanhorn/last30days-skill)** - Research any topic across Reddit, X, YouTube, HN, Polymarket, and the web, ranked by upvotes, likes, and real money instead of editors
+- **[jiawei248/daily-gift](https://github.com/openclaw/skills/tree/main/skills/jiawei248/daily-gift)** - Five-stage creative engine for personalized daily gifts in H5, image, or video
 
 </details>
 


### PR DESCRIPTION
## Skill

**[jiawei248/daily-gift](https://github.com/openclaw/skills/tree/main/skills/jiawei248/daily-gift)** — Five-stage creative engine for personalized daily gifts in H5, image, or video

## Links

- ClawHub: https://clawhub.ai/jiawei248/daily-gift
- GitHub: https://github.com/openclaw/skills/tree/main/skills/jiawei248/daily-gift

## What it does

A relationship-aware gift engine that decides *whether* a gift should exist before deciding *what* it should be. Uses a five-stage creative pipeline:

1. **Editorial Judgment** — should a gift be sent today? (skip / nudge / light / standard / heavy)
2. **Synthesis** — extract 6 content slots from conversation context, form a gift thesis (anchor + return)
3. **Creative Concept** — generate 5+ concept candidates, cross-pollinate with 73 creative seeds, run quality/diversity/collision checks across 8 concept families
4. **Visual Strategy** — choose visual approach, plan assets, run pre-visualization checks
5. **Rendering** — produce the final artifact in H5, image, or video format

Key design features:
- "Idea before medium" — creative concept is locked before format is chosen
- Multi-layer anti-repetition system (concept family, visual elements, theme, style, content direction)
- Three-layer user taste profile (identity / context / signals) that evolves over time
- Three runtime modes: onboarding setup, daily cron, and manual trigger

## Category

Added to **Productivity and Collaboration** under Community Skills.

## Documentation

Full SKILL.md with 30+ reference files covering editorial judgment, creative concept generation, visual strategy, delivery rules, and taste profile management.