### PR TITLE
Add skill: Future3lab/iran-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1367,6 +1367,7 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[meodai/skill.color-expert](https://github.com/meodai/skill.color-expert)** - Color science expert skill with 286K words of reference material covering OKLCH/OKLAB, palette generation, accessibility/contrast, color naming, pigment mixing, and historical color theory
 - **[aklofas/kicad-happy](https://github.com/aklofas/kicad-happy)** - AI-powered KiCad electronics design review and analysis
 - **[bitwize-music-studio/claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills)** - Full-lifecycle AI music album production
+- **[Future3lab/iran-skill](https://github.com/Future3lab/iran-skill)** - AI geopolitical analysis OS for Iran crisis
 
 </details>
 


### PR DESCRIPTION
## What is this skill?

[Future3lab/iran-skill](https://github.com/Future3lab/iran-skill) is a 119-file AI geopolitical analysis OS for the 2026 Iran crisis, added under the **Specialized Domains** category.

**Key features:**
- 21 distilled analyst frameworks (Carnegie/CFR/ICG/SAIS)
- - 12 decision-maker behavioral models
- - 7 Persian empire mental models (2,500 years of history)
- - Multi-agent adversarial debate protocol
- - Probability audit trails
- - Built with the Nuwa Skill methodology
**Repo:** https://github.com/Future3lab/iran-skill