### PR TITLE
Add skill: unitedideas/nothumansearch and unitedideas/aidevboard-mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -1367,6 +1367,8 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[meodai/skill.color-expert](https://github.com/meodai/skill.color-expert)** - Color science expert skill with 286K words of reference material covering OKLCH/OKLAB, palette generation, accessibility/contrast, color naming, pigment mixing, and historical color theory
 - **[aklofas/kicad-happy](https://github.com/aklofas/kicad-happy)** - AI-powered KiCad electronics design review and analysis
 - **[bitwize-music-studio/claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills)** - Full-lifecycle AI music album production
+- **[unitedideas/nothumansearch](https://github.com/unitedideas/nothumansearch)** - MCP server for AI agent tool discovery: search 1,400+ agent-first tools and APIs via JSON-RPC
+- **[unitedideas/aidevboard-mcp](https://github.com/unitedideas/aidevboard-mcp)** - MCP server for AI/ML job search: query 5,300+ jobs by role, location, salary, and company
 
 </details>
 


### PR DESCRIPTION
## Summary

Adds two MCP server skills to the **Specialized Domains** community section:

- **[unitedideas/nothumansearch](https://github.com/unitedideas/nothumansearch)** — MCP server for AI agent tool discovery: search 1,400+ agent-first tools and APIs via JSON-RPC. 6 tools: `search`, `check_score`, `get_stats`, `get_site`, `verify_mcp`, `submit`. Listed in the [official MCP registry](https://github.com/modelcontextprotocol/servers).

- **[unitedideas/aidevboard-mcp](https://github.com/unitedideas/aidevboard-mcp)** — MCP server for AI/ML job search: query 5,300+ jobs by role, location, salary, and company. 4 tools: `search_jobs`, `get_job`, `list_companies`, `get_stats`. Also listed in the [official MCP registry](https://github.com/modelcontextprotocol/servers).

Both have public repos with documentation (README + SKILL.md equivalent via llms.txt), are registered in the official MCP registry, and are actively used by AI agents in production.

## Checklist

- [x] Public repository with working skill
- [x] Has documentation
- [x] Author/org prefix included
- [x] Description under 10 words
- [x] Real community usage (listed in official MCP registry)