### PR TITLE
Add skill: degausai/wonda

### DIFF
--- a/README.md
+++ b/README.md
@@ -1203,6 +1203,7 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[SHADOWPR0/beautiful_prose](https://github.com/SHADOWPR0/beautiful_prose)** - Hard-edged writing style contract for timeless, forceful English prose without AI tics
 - **[blader/humanizer](https://github.com/blader/humanizer)** - Remove signs of AI-generated writing from text, making it sound more natural and human
 - **[Eronred/aso-skills](https://github.com/Eronred/aso-skills)** - 30+ App Store Optimization skills for keyword research, metadata optimization, competitor analysis, creative optimization, and mobile growth strategies via Appeeky API
+- **[degausai/wonda](https://github.com/degausai/wonda)** - AI content creation: images, video, music, audio, editing, publishing
 
 </details>
 


### PR DESCRIPTION
Adding [wonda](https://github.com/degausai/wonda) to the **Marketing** section.

**wonda** is an AI-powered content creation toolkit for the terminal: generate images, videos, music, and audio; edit and compose media; publish to Instagram and TikTok; research across LinkedIn, Reddit, and X/Twitter.

- Works with Claude Code, Codex, Gemini CLI, Cursor, Copilot, Hermes Agent
- Install: `npx skills add degausai/wonda`
- 46+ GitHub stars, MIT licensed
