### PR TITLE
Add skill: openaccountants/openaccountants

### DIFF
--- a/README.md
+++ b/README.md
@@ -1227,6 +1227,7 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[op7418/Youtube-clipper-skill](https://github.com/op7418/Youtube-clipper-skill)** - YouTube clip generation and editing with automated workflows
 - **[ognjengt/founder-skills](https://github.com/ognjengt/founder-skills)** - Claude skills for founders with packaged startup workflows
 - **[EveryInc/charlie-cfo-skill](https://github.com/EveryInc/charlie-cfo-skill)** - Bootstrapped CFO financial management inspired by Charlie Munger
+- **[openaccountants/openaccountants](https://github.com/openaccountants/openaccountants)** - 371 tax classification skills across 134 countries
 - **[wrsmith108/linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill)** - Manage Linear issues, projects, and teams
 - **[Shpigford/readme](https://github.com/Shpigford/skills/tree/main/readme)** - Generate comprehensive project documentation
 - **[hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill)** - Minimal, low-friction hierarchical memory system with background agents and filesystem-based persistence


### PR DESCRIPTION
Adds OpenAccountants to the Productivity and Collaboration section.

**What it does:** 371 tax classification skills across 134 countries — classifies bank statement transactions into VAT/GST, income tax, and social contribution categories with conservative defaults and accountant-ready working papers.

**Who uses it:** Freelancers, sole traders, and small businesses preparing tax figures before meeting their accountant. 8 countries have full guided experiences (US, UK, Malta, Germany, Australia, Canada, India, Spain), 27 have multi-skill coverage, and 99 have VAT/GST classification.

**Repository:** https://github.com/openaccountants/openaccountants