### PR TITLE
Add skill: deployhq/deployhq-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -1086,6 +1086,7 @@ Official skills from Notion's repositories — workspace-aware skills for captur
 - **[muratcankoylan/evaluation](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/evaluation)** - Build evaluation frameworks for agent systems
 - **[k-kolomeitsev/data-structure-protocol](https://github.com/k-kolomeitsev/data-structure-protocol)** - Graph-based long-term memory skill for AI (LLM) coding agents — faster context, fewer tokens, safer refactors
 - **[NeoLabHQ/prompt-engineering](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/customaize-agent/skills/prompt-engineering)** - Widely used prompt engineering techniques and patterns, including Anthropic best practices and agent persuasion principles.
+- **[deployhq/deployhq-cli](https://github.com/deployhq/deployhq-cli/tree/main/skills/deployhq)** - Deploy, rollback, and manage servers via DeployHQ CLI
 
 </details>
 


### PR DESCRIPTION
Adds deployhq-cli to the Development and Testing community skills section.

**Skill:** [deployhq/deployhq-cli](https://github.com/deployhq/deployhq-cli/tree/main/skills/deployhq)

**What it does:** Agent skill for the DeployHQ CLI (`dhq`) — deploy code, rollback, manage servers and projects via the DeployHQ REST API. Features `--json` output with breadcrumbs, `dhq commands --json` for self-discovery, and a SKILL.md agent guide with decision trees.

**Install:** `brew install deployhq/tap/dhq` or `go install github.com/deployhq/deployhq-cli/cmd/deployhq@latest`

**License:** MIT