### PR TITLE
Add skill: unitedideas/nothumansearch, unitedideas/aidevboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1370,6 +1370,8 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[meodai/skill.color-expert](https://github.com/meodai/skill.color-expert)** - Color science expert skill with 286K words of reference material covering OKLCH/OKLAB, palette generation, accessibility/contrast, color naming, pigment mixing, and historical color theory
 - **[aklofas/kicad-happy](https://github.com/aklofas/kicad-happy)** - AI-powered KiCad electronics design review and analysis
 - **[bitwize-music-studio/claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills)** - Full-lifecycle AI music album production
+- **[unitedideas/nothumansearch](https://github.com/unitedideas/nothumansearch/tree/main/skills/nothumansearch)** - Search and score AI-ready websites via MCP
+- **[unitedideas/aidevboard](https://github.com/unitedideas/ai-dev-jobs/tree/main/skills/aidevboard)** - Search AI/ML job listings across 340+ companies via MCP
 
 </details>
 


### PR DESCRIPTION
## Adding two community skills to the Specialized Domains category

### 1. unitedideas/nothumansearch
Search and score AI-ready websites via MCP. Indexes 1,750+ sites with tools for search, AI-readiness scoring, and live MCP endpoint verification. Listed in the official MCP registry as `ai.nothumansearch/search`.

- **Repo**: https://github.com/unitedideas/nothumansearch
- **SKILL.md**: https://github.com/unitedideas/nothumansearch/tree/main/skills/nothumansearch/SKILL.md
- **Live MCP endpoint**: https://nothumansearch.ai/mcp
- **Registry listing**: https://github.com/modelcontextprotocol/servers

### 2. unitedideas/aidevboard
Search AI/ML job listings across 340+ companies via MCP. Provides search_jobs, get_job, list_companies, and get_stats tools over 6,300+ job listings. Listed in the official MCP registry as `com.aidevboard/jobs`.

- **Repo**: https://github.com/unitedideas/ai-dev-jobs
- **SKILL.md**: https://github.com/unitedideas/ai-dev-jobs/tree/main/skills/aidevboard/SKILL.md
- **Live MCP endpoint**: https://aidevboard.com/mcp
- **Registry listing**: https://github.com/modelcontextprotocol/servers

Both skills have documented SKILL.md files with setup instructions, tool descriptions, and example workflows. Both MCP servers are live in production with active users and listed in the official MCP server registry.