### PR TITLE
Add skill: gitroomhq/postiz-agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1204,6 +1204,7 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[blader/humanizer](https://github.com/blader/humanizer)** - Remove signs of AI-generated writing from text, making it sound more natural and human
 - **[Eronred/aso-skills](https://github.com/Eronred/aso-skills)** - 30+ App Store Optimization skills for keyword research, metadata optimization, competitor analysis, creative optimization, and mobile growth strategies via Appeeky API
 - **[degausai/wonda](https://github.com/degausai/wonda)** - AI content creation: images, video, music, audio, editing, publishing
+- **[gitroomhq/postiz-agent](https://github.com/gitroomhq/postiz-agent)** - Schedule social media posts across 28+ platforms programmatically
 
 </details>
 


### PR DESCRIPTION
Adding one community skill to the Marketing category

1. gitroomhq/postiz-agent

Social media automation CLI for AI agents. Schedule posts, manage drafts, upload media, and fetch analytics across 28+ platforms (Twitter/X, LinkedIn, Reddit, YouTube, TikTok, Instagram, Facebook, and more) from the command line. Authentication via OAuth2 device flow or API key, with a self-hostable auth server.

Skill repo: https://github.com/gitroomhq/postiz-agent
Main app repo: https://github.com/gitroomhq/postiz-app
Install: npx skills add gitroomhq/postiz-agent

The skill has a documented README with setup instructions, command reference, and example workflows. Postiz is an open-source social media scheduling platform with an active user base, and the agent CLI is already used in production to drive posting from AI coding assistants.