### PR TITLE
Add skill: awrshift/claude-memory-kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1335,6 +1335,7 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[muratcankoylan/tool-design](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/tool-design)** - Build tools that agents can use effectively, including architectural reduction patterns
 - **[muratcankoylan/evaluation](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/evaluation)** - Build evaluation frameworks for agent systems
 - **[k-kolomeitsev/data-structure-protocol](https://github.com/k-kolomeitsev/data-structure-protocol)** - Graph-based long-term memory skill for AI (LLM) coding agents — faster context, fewer tokens, safer refactors
+- **[awrshift/claude-memory-kit](https://github.com/awrshift/claude-memory-kit)** - Persistent memory with hooks, wiki, and daily synthesis for multi-project workflows
 - **[NeoLabHQ/prompt-engineering](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/customaize-agent/skills/prompt-engineering)** - Widely used prompt engineering techniques and patterns, including Anthropic best practices and agent persuasion principles.
 
 </details>


### PR DESCRIPTION
Adds claude-memory-kit to Context Engineering > Community Skills.

Persistent memory system for Claude Code with hooks, knowledge wiki, and `/close-day` daily synthesis. 700+ production sessions, 7 projects, zero external dependencies.

https://github.com/awrshift/claude-memory-kit