### PR TITLE
Add skill: Slashworks-biz/idea-os

### DIFF
--- a/README.md
+++ b/README.md
@@ -1242,6 +1242,7 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[Digidai/product-manager-skills](https://github.com/Digidai/product-manager-skills)** - Senior PM agent with 30+ frameworks and SaaS metrics
 - **[deusyu/translate-book](https://github.com/deusyu/translate-book)** - Translate books (PDF/DOCX/EPUB) via parallel sub-agents with resume
 - **[mvanhorn/last30days-skill](https://github.com/mvanhorn/last30days-skill)** - Research any topic across Reddit, X, YouTube, HN, Polymarket, and the web, ranked by upvotes, likes, and real money instead of editors
+- **[Slashworks-biz/idea-os](https://github.com/Slashworks-biz/idea-os)** - Idea to PRD, research, and phased plan pipeline
 
 </details>
 


### PR DESCRIPTION
Added under **Productivity and Collaboration** → Community Skills.

Entry follows the CONTRIBUTING format: `author/skill-name` prefix, ≤10-word description, appended to end of subcategory.

- Description: "Idea to PRD, research, and phased plan pipeline"
- Repo: https://github.com/Slashworks-biz/idea-os
- License: MIT

Neighbour skills in the same category (obra/brainstorming, obra/writing-plans, ognjengt/founder-skills, Digidai/product-manager-skills) don't overlap — idea-os sits downstream of brainstorming, upstream of writing-plans.