### PR TITLE
Add Imprint: portable AI collaboration profile (1 skill → 11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1232,6 +1232,7 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[wrsmith108/linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill)** - Manage Linear issues, projects, and teams
 - **[Shpigford/readme](https://github.com/Shpigford/skills/tree/main/readme)** - Generate comprehensive project documentation
 - **[hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill)** - Minimal, low-friction hierarchical memory system with background agents and filesystem-based persistence
+- **[ilang-ai/Imprint](https://github.com/ilang-ai/Imprint)** - One skill replaces eleven: memory, compression, onboarding, code review, debugging, planning, progress tracking, testing, git workflow, SEO, and copywriting. Portable collaboration profile across 19 agents.
 - **[kreuzberg-dev/kreuzberg](https://github.com/kreuzberg-dev/kreuzberg/tree/main/skills/kreuzberg)** - Extract text, tables, and metadata from 62+ document formats
 - **[Paramchoudhary/ResumeSkills](https://github.com/Paramchoudhary/ResumeSkills)** - 20 specialized skills for resume optimization, ATS analysis, interview prep, and career transitions
 - **[RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills)** - Transform docs or codebases into Obsidian StudyVaults with interactive quizzes


### PR DESCRIPTION
Adds Imprint, a single skill that replaces 11 specialized skills by creating a portable user profile.

- MIT licensed, no external API calls, no SaaS dependency
- Works across Claude Code, Codex, Cursor, Copilot, Gemini, Windsurf, Trae, Cline, Roo + 10 more
- Profile stored as plain text under 500 tokens
- Live on skills.sh, VS Code Marketplace, Open VSX, Gemini CLI Gallery
- GitHub: https://github.com/ilang-ai/Imprint