### PR TITLE
Add skill: ckorhonen/claude-skills and ckorhonen/swe-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1320,6 +1320,8 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[Lum1104/understand-anything](https://github.com/Lum1104/Understand-Anything)** - Interactive codebase knowledge graphs via multi-agent LLM analysis
 - **[hqhq1025/skill-optimizer](https://github.com/hqhq1025/skill-optimizer)** - Diagnose and optimize Agent Skills (SKILL.md) with real session data and research-backed static analysis. Works with Claude Code, Codex, and any Agent Skills-compatible agent
 - **[LambdaTest/agent-skills](https://github.com/LambdaTest/agent-skills)** - TestMu AI (Formerly LambdaTest) Skills is a curated collection of Agent Skills that teach AI coding assistants how to write production-grade test automation.
+- **[ckorhonen/claude-skills](https://github.com/ckorhonen/claude-skills)** - 45+ Claude Code skills across engineering, design, workflows
+- **[ckorhonen/swe-skills](https://github.com/ckorhonen/swe-skills)** - 15 engineering analysis skills: PR review, audits, refactor hunts
 
 </details>
 


### PR DESCRIPTION
Two community skill packs under Development and Testing.

### ckorhonen/claude-skills
A broader collection of 45+ Claude Code skills spanning engineering, design, marketing, AI, security, and infrastructure. ~4 months old, MIT licensed. Real install usage via skills.sh (~625 installs at time of submission). Hub: https://cdd.dev/skills/.

### ckorhonen/swe-skills
15 skills under the `swe:` namespace for engineering analysis and judgment — PR risk review, repo introspection, performance/security audits, incident follow-up, ownership maps, refactor opportunities, test gap hunts. MIT licensed. Hub: https://cdd.dev/skills/swe/.

Both packs follow the Agent Skills standard and work with Claude Code, Cursor, Codex, Gemini CLI, Copilot. Each has a valid `SKILL.md` per skill and a `.claude-plugin/plugin.json` manifest at the repo root.

Install:

```sh
npx skills add ckorhonen/claude-skills
npx skills add ckorhonen/swe-skills
```

Descriptions are ≤10 words as the contributing guide requires.

A companion pack, `ckorhonen/hone-skills` (scheduled code-hygiene skills), was just renamed/published this week and will be worth revisiting once it has more time in the wild per the "brand new skills not accepted" guidance.