### PR TITLE
Add OpenRegistry skillpack — 10 Claude skills for live company-registry data (27 countries)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1209,6 +1209,8 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 
 ### Community Skills
 
+
+- [sophymarine/openregistry](https://github.com/sophymarine/openregistry) — **OpenRegistry skillpack: 10 Claude Agent Skills for live company-registry data across 27 national government registries.** Unmodified, source-linked responses. Cross-border UBO chain walking in a single prompt. Flagship: Cross-Border UBO Chain Walker (walk UK Ltd → LU SARL → KY LP → individual). Free anonymous tier on hosted MCP at openregistry.sophymarine.com/mcp.
 <details>
 <summary><h3 style="display:inline">Vector Databases</h3></summary>
 


### PR DESCRIPTION
## What

Adds the [**sophymarine/openregistry**](https://github.com/sophymarine/openregistry) skillpack — 10 Claude Agent Skills for live, direct-to-government company-registry data.

## Why it fits

OpenRegistry is a remote MCP server that connects Claude agents directly to 27 national company registries (UK Companies House, France RNE, Germany Handelsregister, Korea OpenDART, Canada CBCA, 10 US states, Italy, Cayman CIMA, and more). Every response is unmodified — the registry's own field names + raw filing bytes returned verbatim, with source identifiers preserved.

The 10 skills cover: KYC & Cross-Border Due Diligence, **Cross-Border UBO Chain Walker** (flagship), Director Search & PEP Screening, Live Company Accounts & XBRL, Corporate Filing Monitor, Global Company Name Availability, Industry & Competitor Search, Shell Company Detector, Phoenix Company Radar, Sector Gatekeeper List.

## Live demo

Ran the UBO Chain Walker on TikTok's UK operating entity (Companies House 10165711) — in ~900 ms Claude ran three live queries to UK Companies House and returned:
- Entity name-history: Cheetah Technology UK → ByteDance UK → TikTok Information Technologies UK Limited
- Active PSC: Mr Yiming Zhang, Chinese nationality, Singapore-resident, 25-50% shares + 50-75% voting rights, notified 2017-12-05

Every fact verifiable at the government URL (https://find-and-update.company-information.service.gov.uk/company/10165711/persons-with-significant-control).

## Install

```bash
git clone https://github.com/sophymarine/openregistry
cp -r openregistry/skills/* ~/.claude/skills/

claude mcp add --transport http OpenRegistry https://openregistry.sophymarine.com/mcp
```

## Also published

- Official MCP Registry: `io.github.sophymarine/openregistry`
- MCP.so: https://mcp.so/server/openregistry
- punkpeye/awesome-mcp-servers: PR #5117

Licence: CC-BY-4.0 for the docs + skills (no source code in the repo — the hosted service is closed-source).