### PR TITLE
Add living-docs — Claude Code plugin for auto-fixing stale docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1210,6 +1210,13 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 ### Community Skills
 
 <details>
+<summary><h3 style="display:inline">Developer Tools</h3></summary>
+
+- **[phlx0/living-docs](https://github.com/phlx0/living-docs)** - Claude Code plugin that auto-detects stale documentation after code changes and applies surgical fixes. Catches renamed functions, env vars, CLI flags, config keys, and API endpoints across Markdown, JSDoc, OpenAPI, Python docstrings, and Go doc comments. Runs as a PostToolUse hook that warns on edits; /living-docs applies fixes surgically.
+
+</details>
+
+<details>
 <summary><h3 style="display:inline">Vector Databases</h3></summary>
 
 - **[qdrant/skills](https://github.com/qdrant/skills)** - Agent skills for Qdrant vector search, covering scaling, performance optimization, search quality, monitoring, deployment, model migration, version upgrades, and SDK usage across Python, TypeScript, Rust, Go, .NET, and Java


### PR DESCRIPTION
## What

Adds [living-docs](https://github.com/phlx0/living-docs) under a new **Developer Tools** section in Community Skills.

## About

**living-docs** detects stale documentation after code changes and applies surgical fixes — without rewriting content that's already correct.

What it catches:
- Function signature changes documented incorrectly in JSDoc/README
- Renamed env vars, CLI flags, config keys referenced in docs
- API endpoints that moved, described in OpenAPI specs
- New public exports not yet documented

Supports: Markdown, JSDoc/TSDoc, Python docstrings, Go doc comments, OpenAPI/Swagger, RST.

Works with Claude Code, has a PostToolUse hook for passive warnings, and a `/living-docs` skill for applying fixes on demand.

## Install

```bash
curl -fsSL https://raw.githubusercontent.com/phlx0/living-docs/main/scripts/install.sh | sh
```