### PR TITLE
Add bouch-mcp-skills to Specialized Domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -1401,6 +1401,7 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[meodai/skill.color-expert](https://github.com/meodai/skill.color-expert)** - Color science expert skill with 286K words of reference material covering OKLCH/OKLAB, palette generation, accessibility/contrast, color naming, pigment mixing, and historical color theory
 - **[aklofas/kicad-happy](https://github.com/aklofas/kicad-happy)** - AI-powered KiCad electronics design review and analysis
 - **[bitwize-music-studio/claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills)** - Full-lifecycle AI music album production
+- **[paulieb89/bouch-mcp-skills](https://github.com/paulieb89/bouch-mcp-skills)** - UK-specialised agent skills for property investment, legal research, due diligence, HMRC/VAT, and parliamentary intelligence. Backed by UK public registers (Companies House, Land Registry, legislation.gov.uk, TNA Find Case Law). British English throughout.
 
 </details>
 


### PR DESCRIPTION
Adds a single entry for [paulieb89/bouch-mcp-skills](https://github.com/paulieb89/bouch-mcp-skills) to the **Specialized Domains** section.

## What it is

UK-specialised agent skills (30+) for property investment, legal research, due diligence, HMRC/VAT, and parliamentary intelligence. Every skill is backed by official UK public registers (Companies House, HM Land Registry, legislation.gov.uk, TNA Find Case Law, Hansard, HMRC). British English throughout.

## Example skills

- `property-report` — Land Registry comps, EPC, rental yields, stamp duty for any UK address
- `legal-research` — legislation.gov.uk section text + case law + OSCOLA citations
- `company-check` — Companies House profile + officers + PSC + disqualification + VAT + Gazette insolvency
- `mp-dig` — declared interests, voting record, Hansard contributions, donor crossref
- `policy-briefing` — parliamentary landscape + Hansard + related bills for any policy topic

## Quality

- Every skill has a `SKILL.md` with allowed-tools frontmatter
- Gold-standard pattern with `references/`, `assets/`, and deterministic `scripts/` for post-processing
- Voice validator (`check_voice.py`) catches banned phrases, superlative claims, em dashes, American spellings
- All skills pass a pre-publish grep for client names, personal identifiers, internal repo paths

One line added after `bitwize-music-studio/claude-ai-music-skills`, matching the existing format exactly.