### PR TITLE
Add paperjsx/agent-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1241,6 +1241,7 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 <summary><h3 style="display:inline">Productivity and Collaboration</h3></summary>
 
 - **[PSPDFKit-labs/nutrient-agent-skill](https://github.com/PSPDFKit-labs/nutrient-agent-skill)** - Document processing with Nutrient DWS API: convert (PDF/DOCX/XLSX/PPTX/HTML/images), extract text/tables, OCR (20+ languages), redact PII (pattern + AI), watermark, digital signatures, form filling. [MCP server](https://www.npmjs.com/package/@nutrient-sdk/dws-mcp-server) also available.
+- **[paperjsx/agent-skill](https://github.com/paperjsx/agent-skill)** - Generate PPTX presentations, DOCX documents, XLSX spreadsheets, and PDF invoices/reports/charts from structured JSON. Runs locally via [`@paperjsx/mcp-server`](https://www.npmjs.com/package/@paperjsx/mcp-server) — no API key, no network calls. Apache-2.0.
 - **[notiondevs/Notion Skills for Claude](https://www.notion.so/notiondevs/Notion-Skills-for-Claude-28da4445d27180c7af1df7d8615723d0)** - Skills for working with Notion
 - **[op7418/NanoBanana-PPT-Skills](https://github.com/op7418/NanoBanana-PPT-Skills)** - AI-powered PPT generation with document analysis and styled images
 - **[zarazhangrui/frontend-slides](https://github.com/zarazhangrui/frontend-slides)** - Generate animation-rich HTML presentations with visual style previews


### PR DESCRIPTION
Adds **PaperJSX** under Community Skills → Productivity and Collaboration (next to PSPDFKit-labs/nutrient-agent-skill, similar space).

- Generates PPTX, DOCX, XLSX, and PDF documents from structured JSON
- Runs locally via `@paperjsx/mcp-server` — no API key, no network calls
- License: Apache-2.0
- Compatible with Claude Code, Claude.ai, Codex CLI, Gemini CLI (via [paperjsx/gemini-extension](https://github.com/paperjsx/gemini-extension)), Cursor, VS Code Copilot, Windsurf
- Skill source: https://github.com/paperjsx/agent-skill
- npm: https://www.npmjs.com/package/@paperjsx/mcp-server