### PR TITLE
Add Design and UX community section (uxuiprinciples/agent-skills)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1238,6 +1238,13 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 </details>
 
 <details>
+<summary><h3 style="display:inline">Design and UX</h3></summary>
+
+- **[uxuiprinciples/agent-skills](https://github.com/uxuiprinciples/agent-skills)** - 5 skills for evaluating interfaces against 168 research-backed UX/UI principles, detecting antipatterns, and injecting UX context into AI coding sessions
+
+</details>
+
+<details>
 <summary><h3 style="display:inline">Productivity and Collaboration</h3></summary>
 
 - **[PSPDFKit-labs/nutrient-agent-skill](https://github.com/PSPDFKit-labs/nutrient-agent-skill)** - Document processing with Nutrient DWS API: convert (PDF/DOCX/XLSX/PPTX/HTML/images), extract text/tables, OCR (20+ languages), redact PII (pattern + AI), watermark, digital signatures, form filling. [MCP server](https://www.npmjs.com/package/@nutrient-sdk/dws-mcp-server) also available.


### PR DESCRIPTION
## What this adds

A new **Design and UX** subsection under Community Skills, linking to [uxuiprinciples/agent-skills](https://github.com/uxuiprinciples/agent-skills) — 5 skills for evaluating interfaces against 168 research-backed UX/UI principles, detecting antipatterns, and injecting UX context into AI coding sessions.

| Skill | Description |
|-------|-------------|
| uxui-evaluator | Evaluate interfaces against 168 research-backed UX/UI principles |
| interface-auditor | Detect UX antipatterns using the smell taxonomy |
| ai-interface-reviewer | Audit AI/LLM interfaces against the Part V taxonomy (44 principles) |
| flow-checker | Run preflight/postflight checklists against UX flows |
| vibe-coding-advisor | Inject UX context into AI coding sessions before generating components |

Skills work with Claude Code, Cursor, Windsurf, and any agent that reads SKILL.md.

## Diff

7-line addition to `README.md` only. New `<details>` block placed between **Marketing** and **Productivity and Collaboration** under Community Skills (alphabetical/thematic fit). No TOC change — consistent with how other community subsections (Marketing, Vector Databases, n8n Automation, etc.) are listed.

## Context

This replaces closed PR #359, which was closed as "already in the list" — but the README has no existing Design and UX section and no `uxuiprinciples` entry (verified with a fresh search). This fresh PR is rebased onto current `main` and drops the TOC entry that triggered the earlier anchor-fragment CodeRabbit nit, keeping the change minimal.