### PR TITLE
Add skill: zhangzixuan961128-blip/dknowc-official-doc-writer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1272,6 +1272,7 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[Digidai/product-manager-skills](https://github.com/Digidai/product-manager-skills)** - Senior PM agent with 30+ frameworks and SaaS metrics
 - **[deusyu/translate-book](https://github.com/deusyu/translate-book)** - Translate books (PDF/DOCX/EPUB) via parallel sub-agents with resume
 - **[mvanhorn/last30days-skill](https://github.com/mvanhorn/last30days-skill)** - Research any topic across Reddit, X, YouTube, HN, Polymarket, and the web, ranked by upvotes, likes, and real money instead of editors
+- **[zhangzixuan961128-blip/dknowc-official-doc-writer](https://github.com/zhangzixuan961128-blip/dknowc-official-doc-writer)** - Chinese government document writing with policy search and Word formatting
 
 </details>
 


### PR DESCRIPTION
## Skill Submission

### Skill Info
- **Name:** dknowc-official-doc-writer
- **Repository:** https://github.com/zhangzixuan961128-blip/dknowc-official-doc-writer
- **Category:** Productivity and Collaboration

### Description
Chinese government document (公文) writing skill with:
- **Policy Search** — Search government policies, regulations, and data via [Dknowc (深知可信)](https://platform.dknowc.cn) search API
- **Document Writing** — Support for 15 types of statutory government documents + administrative documents
- **Word Formatting** — Auto-generate formatted .docx files following national standards, with red-header template support

### Background
This skill has been used in production as a B2B product and is also published on ClawdHub (OpenClaw skill marketplace) with an established user base.

### Checklist
- [x] Public repository with a working skill
- [x] Has documentation (README + SKILL.md)
- [x] Author/org prefix included in the name
- [x] Description is 10 words or fewer
- [x] Added to the end of the matching subcategory
- [x] Verified all links work