### PR TITLE
Add skill: takechanman1228/claude-persona

### DIFF
--- a/README.md
+++ b/README.md
@@ -1234,6 +1234,7 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[Eronred/aso-skills](https://github.com/Eronred/aso-skills)** - 30+ App Store Optimization skills for keyword research, metadata optimization, competitor analysis, creative optimization, and mobile growth strategies via Appeeky API
 - **[degausai/wonda](https://github.com/degausai/wonda)** - AI content creation: images, video, music, audio, editing, publishing
 - **[gitroomhq/postiz-agent](https://github.com/gitroomhq/postiz-agent)** - Schedule social media posts across 28+ platforms programmatically
+- **[takechanman1228/claude-persona](https://github.com/takechanman1228/claude-persona)** - Build AI persona panels for virtual customer research: generate diverse personas, run agent-separated interviews and concept tests, and deliver executive reports with themes, cross-tabs, and charts
 
 </details>
 


### PR DESCRIPTION
Adds [takechanman1228/claude-persona](https://github.com/takechanman1228/claude-persona) to the Marketing community section.

**What it does:** A Claude Code skill (inspired by Microsoft's TinyTroupe) that builds AI persona panels for virtual customer research. It generates diverse personas, runs agent-separated interviews and concept tests (each persona as an independent `claude -p` subprocess to avoid groupthink), and delivers executive reports with themes, cross-tabs, and charts — useful for marketers and PMs who want qualitative signal before paying for fieldwork.

**Why Marketing:** The primary users are marketers, PMs, and strategy teams running concept/message/packaging tests; neighbors like `smixs/creative-director-skill` and `CosmoBlk/email-marketing-bible` target the same audience.

**Requirements per CONTRIBUTING.md:**
- Public repo with working skill — yes
- Documentation (README + SKILL.md) — yes
- Author/org prefix — yes (`takechanman1228/`)
- Link verified — `https://github.com/takechanman1228/claude-persona` returns 200