### PR TITLE
Add skill: bitjaru/styleseed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1401,6 +1401,7 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[meodai/skill.color-expert](https://github.com/meodai/skill.color-expert)** - Color science expert skill with 286K words of reference material covering OKLCH/OKLAB, palette generation, accessibility/contrast, color naming, pigment mixing, and historical color theory
 - **[aklofas/kicad-happy](https://github.com/aklofas/kicad-happy)** - AI-powered KiCad electronics design review and analysis
 - **[bitwize-music-studio/claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills)** - Full-lifecycle AI music album production
+- **[bitjaru/styleseed](https://github.com/bitjaru/styleseed)** - Design judgment engine with 69 rules, 11 skills, and swappable brand skins
 
 </details>
 


### PR DESCRIPTION
Adding StyleSeed to Community Skills (Other).

- **[bitjaru/styleseed](https://github.com/bitjaru/styleseed)** - Design judgment engine with 69 rules, 11 skills, and swappable brand skins

**Evidence of community usage:**
- 300+ GitHub stars, 37 forks in 2 weeks
- oosmetrics Frontend Top 6 (acceleration ranking)
- Merged into bradtraversy/design-resources-for-developers
- Live demo: https://styleseed-demo.vercel.app
- MIT licensed, no telemetry, no network calls