### PR TITLE
Add skill: insumer/insumer-agent-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -840,6 +840,19 @@ Official wallet, payments, and trading skills from the Coinbase team. Covers USD
 </details>
 
 <details>
+<summary><h3 style="display:inline">Skills by InsumerAPI</h3></summary>
+
+Wallet auth (condition-based access) skills for verifying wallet state across 33 chains. ES256-signed, JWKS-verifiable boolean responses; never raw balances.
+
+- **[insumer/insumer-auth](https://github.com/douglasborthwick-crypto/insumer-agent-skills/tree/main/skills/insumer/insumer-auth)** - Free key creation, env vars, crypto top-up
+- **[insumer/insumer-attest](https://github.com/douglasborthwick-crypto/insumer-agent-skills/tree/main/skills/insumer/insumer-attest)** - Wallet condition attestation across 33 chains
+- **[insumer/insumer-trust](https://github.com/douglasborthwick-crypto/insumer-agent-skills/tree/main/skills/insumer/insumer-trust)** - Multi-dimensional wallet trust profile, 36 base checks
+- **[insumer/insumer-trust-batch](https://github.com/douglasborthwick-crypto/insumer-agent-skills/tree/main/skills/insumer/insumer-trust-batch)** - Trust profiles for up to 10 wallets in one call
+- **[insumer/insumer-jwks-verify](https://github.com/douglasborthwick-crypto/insumer-agent-skills/tree/main/skills/insumer/insumer-jwks-verify)** - Offline ES256 verification against public JWKS
+
+</details>
+
+<details>
 <summary><h3 style="display:inline">Skills by Datadog Labs</h3></summary>
 
 Observability skills from Datadog Labs for APM, logs, monitors, and LLM observability workflows powered by the pup CLI.


### PR DESCRIPTION
Adding the InsumerAPI agent skills as a new "Skills by InsumerAPI" subsection in the Web3 area (after Skills by Coinbase).

**What it is:** Five agent skills for wallet auth (condition-based access) — verifying wallet state across 33 chains and returning ES256-signed, JWKS-verifiable boolean responses. Boolean, not balance. The same primitive ships as `insumer-skill` for Claude Code direct install (since March), `mcp-server-insumer` for runtime MCP access, plus npm/pypi SDKs (`langchain-insumer`, `llama-index-tools-insumer`, `eliza-plugin-insumer`, `insumer-verify`); this repo packages it for the agentskills.io standard so Cursor/Codex/Gemini CLI/Junie/Goose/Amp/Letta and others can install via `npx skills add`.

**Production usage:** InsumerAPI is in live use by AsterPay (KYA-style integration since March), is named in the [ERC-8210 v2 changelog](https://ethereum-magicians.org/t/erc-8210-agent-assurance/28097/28) as the reference implementation for pre-commitment wallet-state attestation (ES256 + JWKS, 33 chains), and powers SkyeProfile (multi-issuer trust orchestration). Public OpenAPI at https://insumermodel.com/openapi.yaml.

Repo: https://github.com/douglasborthwick-crypto/insumer-agent-skills

All five skills smoke-tested end-to-end against the live API on 2026-04-22.

---

AI assistance disclosure: this PR was drafted with Claude Code per the CONTRIBUTING.md disclosure policy.