### PR TITLE
Add BlogBurst to Community Skills > Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1234,6 +1234,7 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[Eronred/aso-skills](https://github.com/Eronred/aso-skills)** - 30+ App Store Optimization skills for keyword research, metadata optimization, competitor analysis, creative optimization, and mobile growth strategies via Appeeky API
 - **[degausai/wonda](https://github.com/degausai/wonda)** - AI content creation: images, video, music, audio, editing, publishing
 - **[gitroomhq/postiz-agent](https://github.com/gitroomhq/postiz-agent)** - Schedule social media posts across 28+ platforms programmatically
+- **[shensi8312/blogburst-claude-skill](https://github.com/shensi8312/blogburst-claude-skill)** - Autonomous social media manager: writes, posts, replies, and learns on Twitter, Bluesky, Telegram, Discord. Replaces a $500-1,500/mo freelance SMM for $29-99/mo. Public API endpoints demo content before signup
 
 </details>
 


### PR DESCRIPTION
## Skill

**BlogBurst** — Autonomous social media manager Claude skill. Writes posts, replies, and learns what works across Twitter, Bluesky, Telegram, and Discord.

- Repo: https://github.com/shensi8312/blogburst-claude-skill
- Positioned as a replacement for a \$500-1500/mo freelance social media manager (\$29-99/mo)
- Public API endpoints (`/blog/platforms`, `/public/free-tools/brand-audit`) let Claude demo real sample posts **without** an API key — no friction for discovery
- Complements existing entries like `gitroomhq/postiz-agent` and `wshuyi/x-article-publisher-skill`, but focuses on autonomous operation rather than manual posting

Added to **Community Skills → Marketing**.