### PR TITLE
Add skill: openweb-org/openweb

### DIFF
--- a/README.md
+++ b/README.md
@@ -1272,6 +1272,7 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[Digidai/product-manager-skills](https://github.com/Digidai/product-manager-skills)** - Senior PM agent with 30+ frameworks and SaaS metrics
 - **[deusyu/translate-book](https://github.com/deusyu/translate-book)** - Translate books (PDF/DOCX/EPUB) via parallel sub-agents with resume
 - **[mvanhorn/last30days-skill](https://github.com/mvanhorn/last30days-skill)** - Research any topic across Reddit, X, YouTube, HN, Polymarket, and the web, ranked by upvotes, likes, and real money instead of editors
+- **[openweb-org/openweb](https://github.com/openweb-org/openweb)** - Typed API access to 90+ websites (Reddit, YouTube, Amazon, GitHub); any site can be added through the agent
 
 </details>
 


### PR DESCRIPTION
## Add skill: openweb-org/openweb

**Repo:** https://github.com/openweb-org/openweb
**License:** MIT
**Section:** Community Skills → Productivity and Collaboration
**npm:** `@openweb-org/openweb` (current: v0.1.5; v0.1.6 prepared)

### What it does

From the README:

> Browser automation clicks buttons, reads pixels, and burns tokens. OpenWeb calls the same APIs the website calls.

- **Fast, cheap, and token-efficient** — No screenshots, no vision API, no LLM-powered parsing. JSON in, JSON out.
- **Predictable, typed API** — Typed params, response schemas, and examples for every operation.
- **Auth that just works** — Cookies, JWT, CSRF, request signing, exchange chains — auto-resolved per request.
- **Safe by default** — Read, write, delete, and transact operations gated by permission tiers. SSRF protection on every request.
- **Any site, any time** — 90+ sites out of the box across social, commerce, content, travel, finance, and more (Reddit, YouTube, Amazon, GitHub, Bloomberg, Zillow, Booking, …).

### Why Productivity and Collaboration

Direct cousin in the section: `mvanhorn/last30days-skill` — a "research across Reddit, X, YouTube, HN" skill. OpenWeb is the same shape generalized to 90+ sites, with typed schemas and write/transact ops on top of read. Other peers using the same "agent calls real web service" pattern: `gokapso/integrate-whatsapp`, `notiondevs/Notion Skills`, `wrsmith108/linear-claude-skill`, `PleasePrompto/notebooklm-skill`, `op7418/Youtube-clipper-skill`.

### Traction

- Published on npm: https://www.npmjs.com/package/@openweb-org/openweb, 660 downloads in 3 days.
- Listed on ClawHub: https://clawhub.ai/imoonkey/openweb, 75 installs in 2 days.
