### PR TITLE
Add skill: jaimeschwarz/brandvoice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1234,6 +1234,7 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[Eronred/aso-skills](https://github.com/Eronred/aso-skills)** - 30+ App Store Optimization skills for keyword research, metadata optimization, competitor analysis, creative optimization, and mobile growth strategies via Appeeky API
 - **[degausai/wonda](https://github.com/degausai/wonda)** - AI content creation: images, video, music, audio, editing, publishing
 - **[gitroomhq/postiz-agent](https://github.com/gitroomhq/postiz-agent)** - Schedule social media posts across 28+ platforms programmatically
+- **[jaimeschwarz/brandvoice](https://github.com/jaimeschwarz/brandvoice)** - Governed brand voice via Brand Therapy discipline.
 
 </details>
 


### PR DESCRIPTION
Adds `brandvoice` to Community Skills → Marketing.

**What it does:** A Claude skill that walks users through the Brand Therapy discipline to build a governed brand voice — eight stages from Purpose through Personification, a governance framework (hard/soft guardrails, escalation protocol), a birth ritual, and generation of a second brand-specific skill the user installs and stewards.

**Repo:** https://github.com/jaimeschwarz/brandvoice
**Author:** Jaime Schwarz — https://brandtherapy.coach
**License:** CC BY-NC 4.0

**Note on your maturity rule:** The GitHub repo is new, but the underlying methodology has 10+ years of use in the author's Brand Therapy consulting practice. The skill is what ports that discipline into Claude. Happy to defer this PR if you'd prefer to see traction first — feel free to close and I'll resubmit in a few weeks once the repo has usage signals.