### PR TITLE
Add Emdash Skills to Community > Development and Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1334,6 +1334,7 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[ethos-link/rails-conventions](https://github.com/ethos-link/rails-conventions)** - Rails 8 conventions for consistent production code changes
 - **[ShunsukeHayashi/agent-skill-bus](https://github.com/ShunsukeHayashi/agent-skill-bus)** - Self-improving task orchestration for AI agent systems
 - **[mcollina/skills](https://github.com/mcollina/skills/tree/main/skills)** - 11 skills by Matteo Collina: Node.js, Fastify, TypeScript, OAuth, Git/GitHub, ESLint neostandard, documentation (Diataxis), Node.js core internals, skill optimizer, and more
+- **[megabytespace/claude-skills](https://github.com/megabytespace/claude-skills)** - 14-category autonomous product-building OS for 30+ AI coding tools. 94 reference docs, 18 agents, 30 platform variants. One-line prompts to deployed products on Cloudflare Workers
 - **[Lum1104/understand-anything](https://github.com/Lum1104/Understand-Anything)** - Interactive codebase knowledge graphs via multi-agent LLM analysis
 - **[hqhq1025/skill-optimizer](https://github.com/hqhq1025/skill-optimizer)** - Diagnose and optimize Agent Skills (SKILL.md) with real session data and research-backed static analysis. Works with Claude Code, Codex, and any Agent Skills-compatible agent
 - **[LambdaTest/agent-skills](https://github.com/LambdaTest/agent-skills)** - TestMu AI (Formerly LambdaTest) Skills is a curated collection of Agent Skills that teach AI coding assistants how to write production-grade test automation.


### PR DESCRIPTION
Adds [megabytespace/claude-skills](https://github.com/megabytespace/claude-skills) to the Community > Development and Testing section.

**What it is:** A 14-category autonomous product-building OS for 30+ AI coding tools. 94 reference docs, 18 agents, 30 platform variants. One-line prompts to deployed products on Cloudflare Workers.

Compatible with Claude Code, Codex, Gemini CLI, Cursor, GitHub Copilot, Windsurf, and 24 more platforms.