### PR TITLE
fix: remove stray quote in img attribute and fix ToC table column count

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
 <a href="https://github.com/VoltAgent/voltagent">
-     <img width="1500" " alt="claude-skills" src="https://github.com/user-attachments/assets/0db54cfc-f3dd-4683-abbb-e4c01d9dfb5d" />
+     <img width="1500" alt="claude-skills" src="https://github.com/user-attachments/assets/0db54cfc-f3dd-4683-abbb-e4c01d9dfb5d" />
 </a>
 
 
@@ -51,7 +51,7 @@ The most contributed Agent Skills repository, built and maintained together with
 
 ### Official Skills by
 
-| | | | |
+| | | | | |
 |---|---|---|---|
 | [Claude](#official-claude-skills) | [VoltAgent](#skills-by-voltagent) | [Angular](#skills-by-angular) | [Composio](#skills-by-composio-team) | [Supabase](#skills-by-supabase-team) |
 | [Google Gemini](#skills-by-google-gemini) | [Stripe](#skills-by-stripe-team) | [Courier](#skills-by-courier) | [CallStack](#skills-by-callstack) |


### PR DESCRIPTION
## Summary

Fixes two issues in `README.md`.

### Fix 1 — Invalid HTML attribute in `<img>` tag

The header image tag had an orphaned double-quote character between the `width` and `alt` attributes, producing invalid HTML:

```diff
-     <img width="1500" " alt="claude-skills" src="..." />
+     <img width="1500" alt="claude-skills" src="..." />
```

### Fix 2 — Table of Contents column count mismatch

The Markdown table header declared 4 columns but the first data row contained 5 cells, breaking rendering in strict parsers:

```diff
-| | | | |
+| | | | | |
 |---|---|---|---|
```

Closes #490

Signed-off-by: Cocoon-Break <86288566+lingxiu58@users.noreply.github.com>