### PR TITLE
Add skill: phnx-labs/linear-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -1247,6 +1247,7 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[EveryInc/charlie-cfo-skill](https://github.com/EveryInc/charlie-cfo-skill)** - Bootstrapped CFO financial management inspired by Charlie Munger
 - **[openaccountants/openaccountants](https://github.com/openaccountants/openaccountants)** - 371 tax classification skills across 134 countries
 - **[wrsmith108/linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill)** - Manage Linear issues, projects, and teams
+- **[phnx-labs/linear-cli](https://github.com/phnx-labs/linear-cli)** - Zero-dependency Python CLI for Linear issue management
 - **[Shpigford/readme](https://github.com/Shpigford/skills/tree/main/readme)** - Generate comprehensive project documentation
 - **[hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill)** - Minimal, low-friction hierarchical memory system with background agents and filesystem-based persistence
 - **[kreuzberg-dev/kreuzberg](https://github.com/kreuzberg-dev/kreuzberg/tree/main/skills/kreuzberg)** - Extract text, tables, and metadata from 62+ document formats


### PR DESCRIPTION
Adds phnx-labs/linear-cli to the Productivity and Collaboration section, alongside the existing Linear skill entry.

linear-cli is a single-file Python CLI for Linear (the issue tracker) with zero third-party dependencies. It includes a SKILL.md, making it installable as a Claude Code skill in one step. MIT licensed.