### PR TITLE
Add unslop to Community Skills (Marketing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1246,6 +1246,7 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[Xquik-dev/tweetclaw](https://github.com/Xquik-dev/tweetclaw)** - 40+ X/Twitter actions: post, extract, monitor, compose
 - **[SHADOWPR0/beautiful_prose](https://github.com/SHADOWPR0/beautiful_prose)** - Hard-edged writing style contract for timeless, forceful English prose without AI tics
 - **[blader/humanizer](https://github.com/blader/humanizer)** - Remove signs of AI-generated writing from text, making it sound more natural and human
+- **[MohamedAbdallah-14/unslop](https://github.com/MohamedAbdallah-14/unslop)** - Removes named AI writing tells (tricolons, em-dash pileups, hedging stacks, sycophancy openers, stock vocab like "delve"/"crucial"). Split lint/rewrite modes for auditing your own text without auto-rewriting. Five intensity levels, MIT
 - **[Eronred/aso-skills](https://github.com/Eronred/aso-skills)** - 30+ App Store Optimization skills for keyword research, metadata optimization, competitor analysis, creative optimization, and mobile growth strategies via Appeeky API
 - **[degausai/wonda](https://github.com/degausai/wonda)** - AI content creation: images, video, music, audio, editing, publishing
 - **[gitroomhq/postiz-agent](https://github.com/gitroomhq/postiz-agent)** - Schedule social media posts across 28+ platforms programmatically


### PR DESCRIPTION
Adding [unslop](https://github.com/MohamedAbdallah-14/unslop) to the Marketing community skills section alongside `beautiful_prose` and `humanizer`.

**unslop** is a Claude Code plugin that removes named AI writing tells:
- tricolons ("fast, flexible, and scalable")
- em-dash pileups
- hedging stacks ("it's worth noting that...")
- sycophancy openers ("Great question!")
- stock vocab (delve, crucial, moreover, furthermore)

**Key differentiator:** split lint/rewrite architecture — run detection-only passes to audit text without rewriting (use it on your own writing as a style linter). Five intensity levels from subtle to aggressive. MIT licensed, no SaaS.