### PR TITLE
Add prompt-to-asset to Community Marketing Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1248,6 +1248,7 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[blader/humanizer](https://github.com/blader/humanizer)** - Remove signs of AI-generated writing from text, making it sound more natural and human
 - **[Eronred/aso-skills](https://github.com/Eronred/aso-skills)** - 30+ App Store Optimization skills for keyword research, metadata optimization, competitor analysis, creative optimization, and mobile growth strategies via Appeeky API
 - **[degausai/wonda](https://github.com/degausai/wonda)** - AI content creation: images, video, music, audio, editing, publishing
+- **[MohamedAbdallah-14/prompt-to-asset](https://github.com/MohamedAbdallah-14/prompt-to-asset)** - Route image-generation prompts to 30+ models — DALL-E, Stable Diffusion, Flux, Midjourney, and more — through a single MCP server and CLI. Install: `npm install -g prompt-to-asset`
 - **[gitroomhq/postiz-agent](https://github.com/gitroomhq/postiz-agent)** - Schedule social media posts across 28+ platforms programmatically
 
 </details>


### PR DESCRIPTION
## Add prompt-to-asset to Community Marketing Skills

**[prompt-to-asset](https://github.com/MohamedAbdallah-14/prompt-to-asset)** is an MCP server and CLI that routes image-generation prompts to 30+ models — DALL-E, Stable Diffusion, Flux, Midjourney, and more — through a single interface.

**Why it belongs in Marketing skills:**
- Generates visual assets for campaigns, social posts, and product pages
- Removes friction when choosing and configuring individual image providers
- Available as an MCP server. Agents can call it directly without any setup beyond `npm install -g prompt-to-asset`

**Category:** Community → Marketing (alongside wonda and postiz-agent)

**Checklist:**
- [x] Existing repo with real usage (npm package, MCP server)
- [x] Relevant to AI agent workflows
- [x] Correct section and format