### PR TITLE
Add chrome-relay to Community Skills > Development and Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1306,6 +1306,7 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[sanjay3290/deep-research](https://github.com/sanjay3290/ai-skills/tree/main/skills/deep-research)** - Autonomous multi-step research using Gemini Deep Research Agent
 - **[jthack/ffuf-claude-skill](https://github.com/jthack/ffuf_claude_skill)** - Web fuzzing with ffuf
 - **[lackeyjb/playwright-skill](https://github.com/lackeyjb/playwright-skill)** - Browser automation with Playwright
+- **[chrome-relay](https://chrome-relay.kushalsm.com/)** - Drive your already-open Chrome session — cookies, SSO, extensions, localhost — from a local CLI bridge. Real-Chrome counterpart to Playwright; install via `npx skills add chrome-relay` + a [Chrome Web Store extension](https://chromewebstore.google.com/detail/chrome-relay/cpdiapbifblhlcpnmlmfpgfjlacebokb). No remote relay, no Playwright fixtures, no MCP server needed.
 - **[ibelick/ui-skills](https://github.com/ibelick/ui-skills)** - Opinionated, evolving constraints to guide agents when building interfaces
 - **[muthuishere/hand-drawn-diagrams](https://github.com/muthuishere/hand-drawn-diagrams)** - Generate hand-drawn Excalidraw diagrams from a prompt — animated SVG, hosted edit link, and PNG export. Works with Claude Code, Codex, Gemini CLI, and any agent supporting standard skill paths
 - **[nextlevelbuilder/ui-ux-pro-max-skill](https://github.com/nextlevelbuilder/ui-ux-pro-max-skill)** - UI/UX design patterns and best practices


### PR DESCRIPTION
Adds **chrome-relay** to Community Skills → Development and Testing, immediately after \`lackeyjb/playwright-skill\` (line 1308).

It's the real-Chrome / authenticated-session counterpart to Playwright: same shape (Claude Code skill installable via \`npx skills add ...\`), different tradeoff on the auth/state axis. Playwright = fresh Chromium per run. chrome-relay = your real Chrome with cookies, SSO, extensions, localhost intact.

**Install:** \`npx skills add chrome-relay\` + the [Chrome Web Store extension](https://chromewebstore.google.com/detail/chrome-relay/cpdiapbifblhlcpnmlmfpgfjlacebokb).

**Architecture:** Chrome extension ↔ local CLI bridge (Fastify on localhost) over Web Store native messaging. No Playwright fixtures, no MCP server, no headless browser, no remote relay.

**Links:**
- Landing: https://chrome-relay.kushalsm.com/
- npm: https://www.npmjs.com/package/chrome-relay (\`chrome-relay@0.2.3\`, MIT)
- Chrome Web Store: https://chromewebstore.google.com/detail/chrome-relay/cpdiapbifblhlcpnmlmfpgfjlacebokb

Single-line addition. Happy to adjust framing or relocate the row if you'd prefer.