### PR TITLE
Add tianluo to Context Engineering: methodology for long-running autonomous runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1382,6 +1382,7 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[k-kolomeitsev/data-structure-protocol](https://github.com/k-kolomeitsev/data-structure-protocol)** - Graph-based long-term memory skill for AI (LLM) coding agents — faster context, fewer tokens, safer refactors
 - **[awrshift/claude-memory-kit](https://github.com/awrshift/claude-memory-kit)** - Persistent memory with hooks, wiki, and daily synthesis for multi-project workflows
 - **[NeoLabHQ/prompt-engineering](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/customaize-agent/skills/prompt-engineering)** - Widely used prompt engineering techniques and patterns, including Anthropic best practices and agent persuasion principles.
+- **[yeewangcn/tianluo](https://github.com/yeewangcn/tianluo)** - Methodology for multi-hour to multi-day autonomous runs. Persistent state survives context compaction, plan-time fork enumeration (zero mid-run interruptions), 5-layer failure diagnosis, budget-bounded retry, file-role separation. Generic for any cron-driven multi-stage task. Bilingual EN/CN.
 
 </details>
 


### PR DESCRIPTION
Adds **tianluo (田螺姑娘)** — a methodology skill for keeping Claude Code (and any agent) on a multi-hour task without it pinging the operator at 3am for routine confirmations.

Five concrete capabilities, each inverting one specific multi-hour-agent failure mode:

1. **Persistent state survives context compaction** — state.json + self-contained cron prompts that rebuild context from scratch every wake-up
2. **Plan-time fork enumeration** — every future user-decision listed as Q1..Qn before the run starts, answered once, then zero further interruptions
3. **5-layer structured diagnosis** — scheduler / container / log / progress / output
4. **Budget-bounded retry with escalation ladder** — transient → patch → replan → human
5. **File-role strict separation** — state.json / plan.md / failures/*.md / memory/*.md never merged

Adding under **Context Engineering** since the central insight — cron prompts that rebuild context from scratch every wake-up + agent never re-reading its own plan — is fundamentally a context-engineering claim. Adjacent to context-compression and context-optimization.

Repo: https://github.com/yeewangcn/tianluo
License: MIT
Bilingual EN/CN README and case study.
Compatible with Claude Code (native plugin install) and any agent that can read Markdown rules / system prompts (Codex, Cursor, Aider, Continue, Gemini CLI, Copilot, OpenCode, Windsurf — clone-and-reference).