### PR TITLE
Add Software Engineering section with swell-agents/coding-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1236,6 +1236,13 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 </details>
 
 <details>
+<summary><h3 style="display:inline">Software Engineering</h3></summary>
+
+- **[swell-agents/coding-skills](https://github.com/swell-agents/coding-skills)** - Ten harness-agnostic Agent Skills for software engineering, portable across Claude Code, SkillNet, Cursor 2.0 (via MDC frontmatter), OpenAI Codex Skills, and Microsoft Agent Framework. Covers running-tdd-cycles, reviewing-changes, designing-architecture, managing-github-issues, committing-changes, plus per-language conventions for Python, Go, Solidity, shell, and engineering-philosophy
+
+</details>
+
+<details>
 <summary><h3 style="display:inline">Marketing</h3></summary>
 
 - **[BrianRWagner/ai-marketing-skills](https://github.com/BrianRWagner/ai-marketing-skills)** - 17 marketing frameworks for cold outreach, homepage audit, social cards, and more


### PR DESCRIPTION
Adds a new **Software Engineering** subsection under Community Skills with [swell-agents/coding-skills](https://github.com/swell-agents/coding-skills) — ten harness-agnostic Agent Skills for software engineering, portable across Claude Code, SkillNet, Cursor 2.0 (via MDC frontmatter), OpenAI Codex Skills, and Microsoft Agent Framework.

- **Workflow skills:** running-tdd-cycles, reviewing-changes, designing-architecture, managing-github-issues, committing-changes
- **Rule skills:** python-conventions, go-conventions, solidity-conventions, shell-discipline, engineering-philosophy

Each skill ships canonical SKILL.md plus optional scripts/ and reference/ docs. Hybrid frontmatter (Anthropic Skills + Cursor MDC) means a single file works in both ecosystems with no transformation. MIT-licensed, v1.0.0 tagged.