### PR TITLE
Add Kavach skill (new Security and Authorization community subsection)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1229,6 +1229,13 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 ### Community Skills
 
 <details>
+<summary><h3 style="display:inline">Security and Authorization</h3></summary>
+
+- **[SarthiAI/kavach-skill](https://github.com/SarthiAI/kavach-skill)** - Default-deny execution gate for AI agents and APIs (post-quantum signed permits, drift detection, audit chain), Python SDK on PyPI
+
+</details>
+
+<details>
 <summary><h3 style="display:inline">Vector Databases</h3></summary>
 
 - **[qdrant/skills](https://github.com/qdrant/skills)** - Agent skills for Qdrant vector search, covering scaling, performance optimization, search quality, monitoring, deployment, model migration, version upgrades, and SDK usage across Python, TypeScript, Rust, Go, .NET, and Java


### PR DESCRIPTION
Adds Kavach under a new `Security and Authorization` subsection at the top of `Community Skills`. The existing Community subsections cover Vector Databases, Marketing, Productivity, Development and Testing, Context Engineering, Specialized Domains, and n8n Automation; none of these capture authorization or access-control specifically, and the category is broad enough to host other contributions in the same space.

Kavach is a default-deny execution gate for AI agents, APIs, and distributed systems. It runs identity, policy, drift, and invariant checks on every action and produces a post-quantum signed permit any downstream service can verify. The skill teaches AI coding agents how to integrate the published `kavach-sdk` library (Python, on PyPI) into a real service: policy authoring, drift wiring, signed permits, audit chain, secure channel, observe-mode rollout.

Skill repo: https://github.com/SarthiAI/kavach-skill (Apache-2.0)
Library repo: https://github.com/SarthiAI/Kavach (Elastic License 2.0)
Install: `npx skills add SarthiAI/kavach-skill`
Validates with `skills-ref validate`. Compatible with Claude Code, Cursor, Codex, Gemini CLI, and any client that reads `SKILL.md`.