### PR TITLE
Add squirrel-skill to Development and Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1365,6 +1365,7 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[Lum1104/understand-anything](https://github.com/Lum1104/Understand-Anything)** - Interactive codebase knowledge graphs via multi-agent LLM analysis
 - **[hqhq1025/skill-optimizer](https://github.com/hqhq1025/skill-optimizer)** - Diagnose and optimize Agent Skills (SKILL.md) with real session data and research-backed static analysis. Works with Claude Code, Codex, and any Agent Skills-compatible agent
 - **[LambdaTest/agent-skills](https://github.com/LambdaTest/agent-skills)** - TestMu AI (Formerly LambdaTest) Skills is a curated collection of Agent Skills that teach AI coding assistants how to write production-grade test automation.
+- **[flyingsquirrel0419/squirrel-skill](https://github.com/flyingsquirrel0419/squirrel-skill)** - Full-cycle AI coding skill: plans, builds, tests, lints, fixes bugs, and writes production-grade docs. Works across 8 AI coding agents
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -1365,7 +1365,7 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[Lum1104/understand-anything](https://github.com/Lum1104/Understand-Anything)** - Interactive codebase knowledge graphs via multi-agent LLM analysis
 - **[hqhq1025/skill-optimizer](https://github.com/hqhq1025/skill-optimizer)** - Diagnose and optimize Agent Skills (SKILL.md) with real session data and research-backed static analysis. Works with Claude Code, Codex, and any Agent Skills-compatible agent
 - **[LambdaTest/agent-skills](https://github.com/LambdaTest/agent-skills)** - TestMu AI (Formerly LambdaTest) Skills is a curated collection of Agent Skills that teach AI coding assistants how to write production-grade test automation.
-- **[flyingsquirrel0419/squirrel-skill](https://github.com/flyingsquirrel0419/squirrel-skill)** - Full-cycle AI coding skill: plans, builds, tests, lints, fixes bugs, and writes production-grade docs. Works across 8 AI coding agents
+- **[flyingsquirrel0419/squirrel-skill](https://github.com/flyingsquirrel0419/squirrel-skill)** - Full-cycle AI coding skill: plans, builds, tests, lints, fixes bugs, and writes production-grade docs. Works across 9 AI coding agents
 
 </details>
 


### PR DESCRIPTION
## Summary

Adds [squirrel-skill](https://github.com/flyingsquirrel0419/squirrel-skill) to the Community Skills → Development and Testing section.

**What it does:** Full-cycle AI coding skill — plans, builds, tests, lints, fixes bugs, and writes production-grade docs. Auto-detects project state (greenfield vs. existing) and adapts its 8-phase pipeline accordingly.

**Platforms supported:** Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, Windsurf, OpenCode, Aider, Antigravity (9 total)

**Spec compliance:** agentskills.io compliant with proper frontmatter, `npx skills add` installable, Apache-2.0 licensed.

## Checklist
- [x] Entry added in alphabetical/chronological order within the section
- [x] Follows existing format: `- **[owner/repo](url)** - description`
- [x] Description is concise and descriptive