### PR TITLE
Add Createya MCP — image and video generation via single API

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The most contributed Agent Skills repository, built and maintained together with
 | [Kim Barrett (Advertising)](#advertising-skills-by-kim-barrett) | [Apollo GraphQL](#skills-by-apollo-graphql) | [Auth0](#skills-by-auth0) | [Brave](#skills-by-brave) |
 | [Browserbase](#skills-by-browserbase) | [CodeRabbit](#skills-by-coderabbit) | [Coinbase](#skills-by-coinbase) | [Datadog Labs](#skills-by-datadog-labs) |
 | [Firebase](#skills-by-firebase) | [Flutter](#skills-by-flutter) | [Venice.ai](#skills-by-veniceai) | [Community](#community-skills) |
-| [Quality Standards](#skill-quality-standards) |  |  |  |
+| [Createya](#skills-by-createya) | [Quality Standards](#skill-quality-standards) |  |  |
 
 
 
@@ -590,6 +590,9 @@ Domain-specific knowledge for Azure SDK and Microsoft AI Foundry development. 13
 - **[fal-ai-community/fal-workflow](https://officialskills.sh/fal-ai-community/skills/fal-workflow)** - Generate workflow JSON files for chaining AI models
 
 </details>
+
+### Skills by Createya
+- **[Createya-ai/createya-mcp](https://github.com/Createya-ai/createya-mcp)** — Generate images and videos through MCP/REST API. FLUX, Sora, Veo, Kling, Runway, Suno via single key. No VPN, ruble billing.
 
 <details>
 <summary><h3 style="display:inline">Skills by WordPress Development Team</h3></summary>


### PR DESCRIPTION
## What this adds

**[Createya-ai/createya-mcp](https://github.com/Createya-ai/createya-mcp)** — a Claude Code skill + MCP server for AI image and video generation.

- 100+ models via a single API key: FLUX, Sora, Veo, Kling, Runway, Higgsfield, Seedance, Suno and more
- No VPN required (works in Russia / CIS regions where direct fal.ai / Replicate access is blocked)
- Ruble billing with free 100-credit starter
- One-line install: `curl -fsSL https://raw.githubusercontent.com/Createya-ai/createya-mcp/main/install.sh | bash`

## Changes

- Added `### Skills by Createya` section after the fal.ai Team section (similar AI media generation provider)
- Added navigation table entry `[Createya](#skills-by-createya)`