### PR TITLE
Add skill: lonelymoon87/need-a-hug

### DIFF
--- a/README.md
+++ b/README.md
@@ -1280,6 +1280,7 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[kreuzberg-dev/kreuzberg](https://github.com/kreuzberg-dev/kreuzberg/tree/main/skills/kreuzberg)** - Extract text, tables, and metadata from 62+ document formats
 - **[Paramchoudhary/ResumeSkills](https://github.com/Paramchoudhary/ResumeSkills)** - 20 specialized skills for resume optimization, ATS analysis, interview prep, and career transitions
 - **[RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills)** - Transform docs or codebases into Obsidian StudyVaults with interactive quizzes
+- **[lonelymoon87/need-a-hug](https://github.com/lonelymoon87/need-a-hug)** - Comfort-first support for overwhelmed AI users
 - **[NeoLabHQ/write-concisely](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/docs/skills/write-concisely)** - Applies the famous *The Elements of Style* book principles to make documentation and writing clearer and more professional by eliminating wordiness and improving structure.
 - **[ReScienceLab/opc-skills](https://github.com/ReScienceLab/opc-skills)** - Agent skills for solopreneurs with SEO, geo, and LLM tools
 - **[SeanZoR/claude-speed-reader](https://github.com/SeanZoR/claude-speed-reader)** - Speed read Claude's responses at 600+ WPM using RSVP with Spritz-style ORP highlighting


### PR DESCRIPTION
## Summary

Adds `lonelymoon87/need-a-hug` to Community Skills under Productivity and Collaboration.

## Why

Need a Hug is a lightweight emotional first-aid Agent Skill that helps agents respond more gently when users are overwhelmed, anxious, burned out, ashamed, or explicitly ask for comfort. It is compatible with the standard `SKILL.md` folder format.

## Safety

The skill does not claim to provide therapy, diagnosis, or medical care. It includes boundaries for crisis and self-harm scenarios and keeps the agent focused on emotional support plus gentle task recovery.