### PR TITLE
Add skill: metalbear-co/mirrord-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1376,6 +1376,7 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[hqhq1025/skill-optimizer](https://github.com/hqhq1025/skill-optimizer)** - Diagnose and optimize Agent Skills (SKILL.md) with real session data and research-backed static analysis. Works with Claude Code, Codex, and any Agent Skills-compatible agent
 - **[LambdaTest/agent-skills](https://github.com/LambdaTest/agent-skills)** - TestMu AI (Formerly LambdaTest) Skills is a curated collection of Agent Skills that teach AI coding assistants how to write production-grade test automation.
 - **[foryourhealth111-pixel/Vibe-Skills](https://github.com/foryourhealth111-pixel/Vibe-Skills)** - A skills governed plug-and-play harness for staged, test-driven skill orchestration
+- **[metalbear-co/skills](https://github.com/metalbear-co/skills)** - Skills that let agents code and test against your Kubernetes cluster using mirrord
 
 </details>
 


### PR DESCRIPTION
Adds a "Skills by MetalBear Team for mirrord" section with 6 official mirrord skills.

[mirrord](https://github.com/metalbear-co/mirrord) is an open-source Kubernetes development tool (5K+ stars, ~4 years in production). It runs a local process as if it were inside a target pod, so engineers and AI coding agents can test code against real cluster services without deploying. Used in production by monday.com (350+ engineers on one shared staging cluster) and Daylight Security (Cursor + mirrord, cut their dev cycle from 5–8 min to 5 sec).

| Skill | Description |
|-------|-------------|
| mirrord-quickstart | Zero-to-first-session mirrord setup for new users |
| mirrord-config | Generate and validate mirrord.json configurations |
| mirrord-operator | Set up the mirrord Operator for teams |
| mirrord-ci | Run mirrord in CI for integration tests |
| mirrord-db-branching | Configure isolated database branches for development |
| mirrord-kafka | Configure Kafka queue splitting with the operator |

Distributed as a Claude Code plugin (`/plugin marketplace add metalbear-co/skills`) and via `npx skills add metalbear-co/skills`. All skills follow the [Agent Skills](https://agentskills.io) open standard.