### PR TITLE
Add Bring Your AI migration auditor skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1317,6 +1317,7 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[mcollina/skills](https://github.com/mcollina/skills/tree/main/skills)** - 11 skills by Matteo Collina: Node.js, Fastify, TypeScript, OAuth, Git/GitHub, ESLint neostandard, documentation (Diataxis), Node.js core internals, skill optimizer, and more
 - **[Lum1104/understand-anything](https://github.com/Lum1104/Understand-Anything)** - Interactive codebase knowledge graphs via multi-agent LLM analysis
 - **[hqhq1025/skill-optimizer](https://github.com/hqhq1025/skill-optimizer)** - Diagnose and optimize Agent Skills (SKILL.md) with real session data and research-backed static analysis. Works with Claude Code, Codex, and any Agent Skills-compatible agent
+- **[unitedideas/bringyour-migration-auditor](https://github.com/unitedideas/bringyour-mcp/tree/main/skills/bringyour-migration-auditor)** - Audit Claude Code to Codex migrations before code edits: AGENTS.md and CLAUDE.md scope, hooks, MCP config, skills, secret exposure, and validation-note drift
 
 </details>
 


### PR DESCRIPTION
Adds `bringyour-migration-auditor` to the Development and Testing community skills list.

The skill audits Claude Code to Codex migrations before code edits. It checks AGENTS.md and CLAUDE.md scope, hooks, MCP config, skills, secret exposure, and validation notes for behavior drift.

Public skill path:
https://github.com/unitedideas/bringyour-mcp/tree/main/skills/bringyour-migration-auditor