### PR TITLE
Add skill: kodifydev/voizbot-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1262,6 +1262,7 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[gokapso/integrate-whatsapp](https://github.com/gokapso/agent-skills/tree/master/skills/integrate-whatsapp)** - Connect WhatsApp, set up webhooks, and send messages
 - **[gokapso/automate-whatsapp](https://github.com/gokapso/agent-skills/tree/master/skills/automate-whatsapp)** - Build WhatsApp automations with workflows and agents
 - **[gokapso/observe-whatsapp](https://github.com/gokapso/agent-skills/tree/master/skills/observe-whatsapp)** - Debug WhatsApp delivery issues and run health checks
+- **[kodifydev/voizbot-skill](https://github.com/kodifydev/voizbot-skill)** - Outbound phone calls for AI agents
 - **[PleasePrompto/notebooklm-skill](https://github.com/PleasePrompto/notebooklm-skill)** - Interact with NotebookLM for document-based conversations
 - **[obra/superpowers-lab](https://github.com/obra/superpowers-lab)** - Lab environment for Claude superpowers
 - **[obra/brainstorming](https://github.com/obra/superpowers/blob/main/skills/brainstorming/SKILL.md)** - Generate and explore ideas


### PR DESCRIPTION
Adds the public Voizbot phone-call agent skill to the Productivity and Collaboration community list.

Repo: https://github.com/kodifydev/voizbot-skill
Install: `npx skills add kodifydev/voizbot-skill`
