### PR TITLE
Add skill: wyddy7/codex-pet-generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1428,6 +1428,7 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[meodai/skill.color-expert](https://github.com/meodai/skill.color-expert)** - Color science expert skill with 286K words of reference material covering OKLCH/OKLAB, palette generation, accessibility/contrast, color naming, pigment mixing, and historical color theory
 - **[aklofas/kicad-happy](https://github.com/aklofas/kicad-happy)** - AI-powered KiCad electronics design review and analysis
 - **[bitwize-music-studio/claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills)** - Full-lifecycle AI music album production
+- **[wyddy7/codex-pet-generator](https://github.com/wyddy7/codex-pet-generator)** - Generate readable Codex desktop pets with deterministic packing
 
 </details>
 


### PR DESCRIPTION
Adds `wyddy7/codex-pet-generator` to **Community Skills → Specialized Domains**.
                                                                                  
  A skill for generating readable Codex desktop pets. Row-semantics-first design, manual slicing with explicit guidance,
   deterministic packing of per-frame inputs into the 1536×1872 / 8×9 grid, validator that catches the typical 72-frame 
  failure mode plus the `pet.json` install contract.                                                                    
                                                                                                                        
  - Source: https://github.com/wyddy7/codex-pet-generator   
  - License: MIT                                         
  - Cross-host: written against the open Agent Skills spec — works in Codex, Claude Code, Cursor, Gemini CLI
                                                                                                                        
  Description follows the ≤10-word rule. Placed at the end of the Specialized Domains category alongside other          
  creative/asset-focused community skills (color-expert, kicad-happy, music-skills). 