### PR TITLE
Add Evanyuan-builder/temporal-core (Context Engineering)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1394,6 +1394,7 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[k-kolomeitsev/data-structure-protocol](https://github.com/k-kolomeitsev/data-structure-protocol)** - Graph-based long-term memory skill for AI (LLM) coding agents — faster context, fewer tokens, safer refactors
 - **[awrshift/claude-memory-kit](https://github.com/awrshift/claude-memory-kit)** - Persistent memory with hooks, wiki, and daily synthesis for multi-project workflows
 - **[NeoLabHQ/prompt-engineering](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/customaize-agent/skills/prompt-engineering)** - Widely used prompt engineering techniques and patterns, including Anthropic best practices and agent persuasion principles.
+- **[Evanyuan-builder/temporal-core](https://github.com/Evanyuan-builder/temporal-core)** - Make agents feel time pass — 3 hooks (SessionStart + UserPromptSubmit + PreToolUse) inject `session elapsed` and `since last action` signals into context, plus a `temporal-awareness` skill that teaches pacing, deadline, and recency reasoning. Research-backed (Aher et al. 2026: explicit time surfacing → 6× deadline performance). Apache-2.0.
 
 </details>
 


### PR DESCRIPTION
Adds `Evanyuan-builder/temporal-core` to **Context Engineering** as the closest fit category.

## What it is

A small Apache-2.0 Claude Code plugin that gives agents a sense of time passing within a session. Three hooks inject elapsed-time signals into context:

- `SessionStart` → records session start
- `UserPromptSubmit` → injects `[temporal-core] session elapsed: 12m 34s`
- `PreToolUse` → injects `[temporal-core] since last action: 47s`

A bundled `temporal-awareness` skill (SKILL.md) teaches the agent how to use the signals — pacing decisions, deadline-aware prioritization, recency reasoning, honest "how long did this take?" answers.

## Why Context Engineering

Sits squarely with the existing entries on memory systems, compression, and prompt engineering — making elapsed-time *visible* is a context-engineering primitive that LLMs do not have natively. Aher et al. (2026), *Real-Time Deadlines Reveal Temporal Awareness Failures in LLM Strategic Dialogues*, found that surfacing remaining time boosted negotiation acceptance odds **6×** without changing the underlying model.

## Verified

Plugin loads via `claude --plugin-dir` and `UserPromptSubmit` hook fires correctly — verified in headless `claude -p` session: agent quoted the injected `[temporal-core] session elapsed: 1s` fragment unprompted.

## Repo

- https://github.com/Evanyuan-builder/temporal-core
- v0.1.0 release: https://github.com/Evanyuan-builder/temporal-core/releases/tag/v0.1.0