### PR TITLE
Add claude-code-dual-build (Development and Testing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1377,6 +1377,7 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[LambdaTest/agent-skills](https://github.com/LambdaTest/agent-skills)** - TestMu AI (Formerly LambdaTest) Skills is a curated collection of Agent Skills that teach AI coding assistants how to write production-grade test automation.
 - **[foryourhealth111-pixel/Vibe-Skills](https://github.com/foryourhealth111-pixel/Vibe-Skills)** - A skills governed plug-and-play harness for staged, test-driven skill orchestration
 - **[metalbear-co/skills](https://github.com/metalbear-co/skills)** - Skills that let agents code and test against your Kubernetes cluster using mirrord
+- **[cjcsecurity/claude-code-dual-build](https://github.com/cjcsecurity/claude-code-dual-build)** - Symmetric multi-agent build with mandatory bidirectional cross-review for Claude Code + Codex. Splits coding tasks ~50/50, runs both in parallel in isolated git worktrees, then has the opposite model review each diff before consolidation. Lightweight skill + four agents.
 
 </details>
 


### PR DESCRIPTION
Adding `claude-code-dual-build` to the **Development and Testing** community section.

It's a Claude Code skill that orchestrates symmetric Claude+Codex builds with mandatory bidirectional cross-review:

- Splits a coding task ~50/50 between the two models
- Runs both in parallel in isolated git worktrees
- Has the *opposite* model review each diff before consolidation

The cross-review is the load-bearing piece — different model families catch different bug classes (worked example in the repo's [EXAMPLES.md](https://github.com/cjcsecurity/claude-code-dual-build/blob/main/EXAMPLES.md): Claude reviewing Codex's stop-button code caught a SIGKILL→ESRCH race + an `ss` permission-model UX bug the implementing model missed).

Repo includes a Claude Code plugin manifest (`.claude-plugin/plugin.json`), four agents (claude-builder, codex-builder, claude-reviewer, codex-reviewer), an automated A/B test harness, and a worked-examples gallery. ~700 lines of markdown total — no framework, no MCP server, no daemon.

Repo: https://github.com/cjcsecurity/claude-code-dual-build