### PR TITLE
Add skill: Xquik-dev/x-twitter-scraper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1251,6 +1251,7 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[wshuyi/x-article-publisher-skill](https://github.com/wshuyi/x-article-publisher-skill)** - Publish articles to X/Twitter
 - **[CosmoBlk/email-marketing-bible](https://github.com/CosmoBlk/email-marketing-bible)** - 55K-word email marketing guide as an AI skill
 - **[smixs/creative-director-skill](https://github.com/smixs/creative-director-skill)** - AI creative director with recursive self-assessment: 20+ methodologies (SIT, TRIZ, Bisociation, SCAMPER, Synectics), 3-axis evaluation calibrated against Cannes/D&AD/HumanKind, 5-phase process from brief to presentation
+- **[Xquik-dev/x-twitter-scraper](https://github.com/Xquik-dev/x-twitter-scraper)** - X API skill for search, extraction, webhooks, MCP
 - **[Xquik-dev/tweetclaw](https://github.com/Xquik-dev/tweetclaw)** - 40+ X/Twitter actions: post, extract, monitor, compose
 - **[SHADOWPR0/beautiful_prose](https://github.com/SHADOWPR0/beautiful_prose)** - Hard-edged writing style contract for timeless, forceful English prose without AI tics
 - **[blader/humanizer](https://github.com/blader/humanizer)** - Remove signs of AI-generated writing from text, making it sound more natural and human


### PR DESCRIPTION
## Summary
- Add Xquik-dev/x-twitter-scraper to the Community Skills marketing section.
- Keep the entry short and adjacent to the existing TweetClaw listing.

## Checks
- Verified the skill repo link returns HTTP 200.
- Checked open PRs and issues for x-twitter-scraper duplicates.
- Ran git diff --check.
