### PR TITLE
Add skill: mitiay7/senior-by-default

### DIFF
--- a/README.md
+++ b/README.md
@@ -1377,6 +1377,7 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[LambdaTest/agent-skills](https://github.com/LambdaTest/agent-skills)** - TestMu AI (Formerly LambdaTest) Skills is a curated collection of Agent Skills that teach AI coding assistants how to write production-grade test automation.
 - **[foryourhealth111-pixel/Vibe-Skills](https://github.com/foryourhealth111-pixel/Vibe-Skills)** - A skills governed plug-and-play harness for staged, test-driven skill orchestration
 - **[metalbear-co/skills](https://github.com/metalbear-co/skills)** - Skills that let agents code and test against your Kubernetes cluster using mirrord
+- **[mitiay7/senior-by-default](https://github.com/mitiay7/senior-by-default)** - Plain-language tasks become senior-grade implementations via multi-actor pipeline
 
 </details>
 


### PR DESCRIPTION
Adding `mitiay7/senior-by-default` to **Community Skills → Development and Testing**.

**What it is.** Multi-actor `/do` pipeline for Claude Code: Opus plans and reviews, Sonnet implements, Haiku handles trivial mechanical changes. Strict role boundaries — Opus never writes code unless explicitly flagged with `--implementer=opus`. Pass/fail gates against acceptance criteria instead of subjective 1-10 reviews.

**Why it's different from other agent-pipeline skills:**
- **Self-review calibration metric.** Sonnet declares `claimed_status: ready` before Phase 3 review; Phase 3 outcome is compared and `false_positive` rate is logged per task. Designed to be the highest-signal data point for iterating the skill itself over time.
- **Zero-downtime migration audit.** `DROP COLUMN` / `RENAME` / `NOT NULL`-without-default get blocked with the expand-contract pattern suggested.
- **Stack-aware.** Detects Go / TS / Rust / Python / Ruby / PHP / JVM / Dart / .NET / Deno / Elixir, scans monorepo subdirs (`apps/`, `services/`) for marker files, caches detection per repo.
- **Tracker-agnostic.** GitHub (`gh`) by default, GitLab (`glab`), or custom command templates for Linear/Jira/etc.

**Honest disclosure on maturity.** This is v0.1.0, recently released. I'm aware of the "no skills you created 3 hours ago" rule and respect that bar. Submitting now because the skill is structurally complete and deliberately built — plugin manifest, JSON Schema for config validation, ~14 reference files driving progressive disclosure (≤500 lines in SKILL.md), MIT licensed, dogfooded as my own daily-driver pipeline. If you'd rather see external usage signal first, I'll re-submit later — fair call either way.

**Repo:** https://github.com/mitiay7/senior-by-default · MIT

CONTRIBUTING checklist:
- [x] Public repo, working skill
- [x] README + SKILL.md present
- [x] Author prefix in name (`mitiay7/`)
- [x] Description ≤10 words
- [x] Added to end of "Development and Testing" subcategory under Community Skills
- [x] Verified link works