### PR TITLE
feat: add TrustBoost PII Sanitizer to Security & Privacy community skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1453,6 +1453,13 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 <br/>
 
 
+<details>
+<summary><h3 style="display:inline">Security & Privacy</h3></summary>
+
+- **[teodorofodocrispin-cmyk/TrustBoost-PII-Sanitizer](https://github.com/teodorofodocrispin-cmyk/TrustBoost-PII-Sanitizer)** - Blockchain-verified PII sanitization layer for autonomous AI agent pipelines. Redacts names, emails, phone numbers, national IDs, private keys, and financial data before text reaches LLM providers. Solana-native, no SDK required, single POST request. Supports EN, ES (LATAM), PT (BR/PT), DE, JA. Try instantly: `POST https://api.trustboost.dev/sanitize/preview` — no wallet, no setup.
+
+</details>
+
 ## 🔒 Security Notice
 
 Skills in this list are curated, not audited. They may be updated, modified, or replaced by their original maintainers at any time after being added here.


### PR DESCRIPTION
## What this adds

A new `Security & Privacy` category under Community Skills, with TrustBoost PII Sanitizer as the first entry.

## About TrustBoost

- Blockchain-verified PII sanitization for autonomous AI agent pipelines
- Solana-native, no SDK required, single POST request
- Supports EN, ES (LATAM), PT (BR/PT), DE, JA
- 200+ downloads on ClawHub
- Live API: https://api.trustboost.dev/health
- Zero-friction preview (no wallet): `POST https://api.trustboost.dev/sanitize/preview`
- Open source: https://github.com/teodorofodocrispin-cmyk/TrustBoost-PII-Sanitizer

## Why Security & Privacy deserves its own category

With x402/Pay.sh launching and AI agents autonomously calling APIs, PII sanitization is becoming a hard compliance requirement (GDPR, EU AI Act Aug 2026, HIPAA, LGPD). No existing category in this list covers this gap.