### PR TITLE
Add skill: yummy-chat/masterchef

### DIFF
--- a/README.md
+++ b/README.md
@@ -1428,6 +1428,7 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[meodai/skill.color-expert](https://github.com/meodai/skill.color-expert)** - Color science expert skill with 286K words of reference material covering OKLCH/OKLAB, palette generation, accessibility/contrast, color naming, pigment mixing, and historical color theory
 - **[aklofas/kicad-happy](https://github.com/aklofas/kicad-happy)** - AI-powered KiCad electronics design review and analysis
 - **[bitwize-music-studio/claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills)** - Full-lifecycle AI music album production
+- **[yummy-chat/masterchef](https://github.com/yummy-chat/masterchef-skill)** - 2,988 real Chinese recipes for AI agents
 
 </details>
 


### PR DESCRIPTION
## Summary

- Add **yummy-chat/masterchef** to the "Specialized Domains" section under Community Skills

**Skill:** 2,988 real, human-verified Chinese recipes for AI agents — not AI-generated. Organized by 22 cuisine categories with full ingredients, step-by-step instructions, and cooking tips.

**Repo:** https://github.com/yummy-chat/masterchef-skill

## Checklist

- [x] Public repository with a working skill
- [x] Has documentation (README + SKILL.md)
- [x] Author/org prefix included in the name
- [x] Description is 10 words or fewer
- [x] Added at the end of the relevant subcategory