### PR TITLE
Add skill: luoyuctl/agenttrace-session-audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1378,6 +1378,7 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[LambdaTest/agent-skills](https://github.com/LambdaTest/agent-skills)** - TestMu AI (Formerly LambdaTest) Skills is a curated collection of Agent Skills that teach AI coding assistants how to write production-grade test automation.
 - **[foryourhealth111-pixel/Vibe-Skills](https://github.com/foryourhealth111-pixel/Vibe-Skills)** - A skills governed plug-and-play harness for staged, test-driven skill orchestration
 - **[metalbear-co/skills](https://github.com/metalbear-co/skills)** - Skills that let agents code and test against your Kubernetes cluster using mirrord
+- **[luoyuctl/agenttrace-session-audit](https://github.com/luoyuctl/agenttrace/blob/master/skills/agenttrace-session-audit/SKILL.md)** - Audit local AI coding-agent sessions
 
 </details>
 


### PR DESCRIPTION
## Summary
- adds agenttrace-session-audit under Community Skills / Development and Testing
- links to the public SKILL.md in luoyuctl/agenttrace
- keeps the description short per CONTRIBUTING.md

## Validation
- git diff --check