### PR TITLE
Add skill: Nagarjuna2997/ios-agent-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1376,6 +1376,7 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[hqhq1025/skill-optimizer](https://github.com/hqhq1025/skill-optimizer)** - Diagnose and optimize Agent Skills (SKILL.md) with real session data and research-backed static analysis. Works with Claude Code, Codex, and any Agent Skills-compatible agent
 - **[LambdaTest/agent-skills](https://github.com/LambdaTest/agent-skills)** - TestMu AI (Formerly LambdaTest) Skills is a curated collection of Agent Skills that teach AI coding assistants how to write production-grade test automation.
 - **[foryourhealth111-pixel/Vibe-Skills](https://github.com/foryourhealth111-pixel/Vibe-Skills)** - A skills governed plug-and-play harness for staged, test-driven skill orchestration
+- **[Nagarjuna2997/ios-agent-skill](https://github.com/Nagarjuna2997/ios-agent-skill)** - Senior iOS and Swift guidance for coding agents
 
 </details>
 


### PR DESCRIPTION
## Summary

Adds `Nagarjuna2997/ios-agent-skill` to the Community Skills list under Development and Testing.

## Skill

This skill provides iOS, Swift, SwiftUI, Xcode workflow, architecture, and testing guidance for AI coding assistants.

## Notes

The linked repository now includes clearer documentation, an `ADOPTION.md` evidence tracker, and a `v1.0.0` release to establish a stable baseline for community usage.

Thank you for reviewing.