### PR TITLE
Add 3 audit-first skills (hormozi-offer-audit, cialdini-influence-audit, claude-blog-assistant)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1260,6 +1260,9 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[Eronred/aso-skills](https://github.com/Eronred/aso-skills)** - 30+ App Store Optimization skills for keyword research, metadata optimization, competitor analysis, creative optimization, and mobile growth strategies via Appeeky API
 - **[degausai/wonda](https://github.com/degausai/wonda)** - AI content creation: images, video, music, audio, editing, publishing
 - **[gitroomhq/postiz-agent](https://github.com/gitroomhq/postiz-agent)** - Schedule social media posts across 28+ platforms programmatically
+- **[johnericforte/claude-skill-hormozi-offer-audit](https://github.com/johnericforte/claude-skill-hormozi-offer-audit)** - Audit sales offers (landing pages, pricing tiers, lead magnets) using Alex Hormozi's frameworks from $100M Offers and $100M Leads. Scores Value Equation (4 levers, 0-25 each) + Grand Slam checklist. Returns Top 3 Fixes with before/after
+- **[johnericforte/claude-skill-cialdini-influence-audit](https://github.com/johnericforte/claude-skill-cialdini-influence-audit)** - Audit persuasive copy (landing pages, emails, sales sequences) for missing influence principles using Robert Cialdini's seven principles + Pre-Suasion. Scores each principle PRESENT/WEAK/MISSING with anti-overstacking check
+- **[johnericforte/claude-skill-blog-assistant](https://github.com/johnericforte/claude-skill-blog-assistant)** - Dual-mode blog publishing assistant. Ship new posts via 8-step lifecycle (brief → write → humanize → SEO → schema → analyze → repurpose) OR retroactively audit existing posts and return prioritized retrofit list. Wraps AgriciDaniel/claude-blog
 
 </details>
 


### PR DESCRIPTION
Adds 3 audit-first Claude Code plugins to the **Marketing** Community Skills section:

- **johnericforte/claude-skill-hormozi-offer-audit** — scored audit of sales offers (landing pages, pricing tiers, lead magnets) using Alex Hormozi's frameworks from \$100M Offers and \$100M Leads. Returns Top 3 Fixes with before/after examples.
- **johnericforte/claude-skill-cialdini-influence-audit** — per-principle audit of persuasive copy using Robert Cialdini's seven principles + Pre-Suasion. Anti-overstacking check.
- **johnericforte/claude-skill-blog-assistant** — dual-mode blog publishing assistant wrapping AgriciDaniel/claude-blog. Ship via 8-step lifecycle OR audit existing posts for retrofit.

All three:
- MIT licensed
- Audit-first (not generators)
- Plugin format (.claude-plugin manifest + skills/<name>/SKILL.md)
- Frameworks cited descriptively under nominative fair use
- Include DISCLAIMER.md for IP transparency

Repos:
- https://github.com/johnericforte/claude-skill-hormozi-offer-audit
- https://github.com/johnericforte/claude-skill-cialdini-influence-audit
- https://github.com/johnericforte/claude-skill-blog-assistant

Author: Eric Forte (https://www.ericforte.com)