### PR TITLE
Add SoulTavern under Specialized Domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -1430,6 +1430,7 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[meodai/skill.color-expert](https://github.com/meodai/skill.color-expert)** - Color science expert skill with 286K words of reference material covering OKLCH/OKLAB, palette generation, accessibility/contrast, color naming, pigment mixing, and historical color theory
 - **[aklofas/kicad-happy](https://github.com/aklofas/kicad-happy)** - AI-powered KiCad electronics design review and analysis
 - **[bitwize-music-studio/claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills)** - Full-lifecycle AI music album production
+- **[imphillip/SoulTavern](https://github.com/imphillip/SoulTavern)** - Import SillyTavern V2 character cards as SOUL.md personas for SOUL-aware agent runtimes (Hermes-Agent, OpenClaw, …)
 
 </details>
 


### PR DESCRIPTION
## Summary
- Adds [SoulTavern](https://github.com/imphillip/SoulTavern) to the Specialized Domains section.
- SoulTavern imports SillyTavern V2 character cards as SOUL.md personas for SOUL-aware agent runtimes (Hermes-Agent, OpenClaw, …).