### PR TITLE
feat: add CodeShuX/tokenwise to Community Skills (Dev & Testing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1347,6 +1347,7 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[rudrankriyam/app-store-connect-cli-skills](https://github.com/rudrankriyam/app-store-connect-cli-skills)** - Automate App Store deployments and management using ASC CLI
 - **[rameerez/claude-code-startup-skills](https://github.com/rameerez/claude-code-startup-skills)** - Skills for building and running software startups, apps, and SaaS
 - **[zscole/model-hierarchy-skill](https://github.com/zscole/model-hierarchy-skill)** - Cost-optimized model routing based on task complexity
+- **[CodeShuX/tokenwise](https://github.com/CodeShuX/tokenwise)** - Measurement-driven model router for Claude Code. Auto-routes work across Haiku/Sonnet/Opus, logs every routed task with verified $ saved to local NDJSON, A/B tests cheaper tiers before trusting them. MIT, zero telemetry.
 - **[CloudAI-X/threejs-skills](https://github.com/CloudAI-X/threejs-skills)** - Three.js skills for creating 3D elements and interactive experiences
 - **[Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill)** - High-agency frontend skill that gives AI good taste with tunable design variance, motion intensity, and visual density to stop generic UI slop
 - **[testdino-hq/playwright-skill](https://github.com/testdino-hq/playwright-skill)** - 70+ production-tested Playwright automation testing patterns: E2E, POM, CI/CD, migrations, CLI


### PR DESCRIPTION
## Summary

Adds [TokenWise](https://github.com/CodeShuX/tokenwise) under \`### Community Skills > Development and Testing\` — placed adjacent to \`zscole/model-hierarchy-skill\` since both deal with cost-optimized model routing.

## What it does

A Claude Code skill that auto-routes subtasks across Haiku, Sonnet, and Opus based on task class, then logs every routed task to a local NDJSON with real token + cost numbers. Includes an A/B test subcommand that runs the same task at multiple tiers and scores quality.

- **Routes** — Opus orchestrates, Haiku/Sonnet execute; safety caps (Haiku never spawns subagents, max depth 2, trivial-task floor)
- **Measures** — every routed task → \`.tokenwise/log.ndjson\` with input/output tokens, cost, savings. Zero telemetry. Local-only.
- **Proves** — \`/tokenwise:ab "<task>"\` runs the same task at multiple tiers, scores quality 1-10, writes a markdown comparison
- **5 namespaced commands**: \`/tokenwise:install\`, \`/tokenwise:report\`, \`/tokenwise:summary\`, \`/tokenwise:ab\`, \`/tokenwise:undo\`

## Why this placement

Sits naturally next to \`zscole/model-hierarchy-skill\` which already addresses cost-optimized routing. TokenWise differs in being **measurement-driven** — every routing decision is logged with verified savings, and the A/B test mode validates the routing on the user's real workload instead of trusting a heuristic.

License: MIT