### PR TITLE
Add skill: clockless-org/html-anything

### DIFF
--- a/README.md
+++ b/README.md
@@ -1270,6 +1270,7 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[notiondevs/Notion Skills for Claude](https://www.notion.so/notiondevs/Notion-Skills-for-Claude-28da4445d27180c7af1df7d8615723d0)** - Skills for working with Notion
 - **[op7418/NanoBanana-PPT-Skills](https://github.com/op7418/NanoBanana-PPT-Skills)** - AI-powered PPT generation with document analysis and styled images
 - **[zarazhangrui/frontend-slides](https://github.com/zarazhangrui/frontend-slides)** - Generate animation-rich HTML presentations with visual style previews
+- **[clockless-org/html-anything](https://github.com/clockless-org/html-anything)** - Turn any file, folder, URL, or export into a polished single-file HTML page; auto picks the page system from 16 design styles
 - **[gokapso/integrate-whatsapp](https://github.com/gokapso/agent-skills/tree/master/skills/integrate-whatsapp)** - Connect WhatsApp, set up webhooks, and send messages
 - **[gokapso/automate-whatsapp](https://github.com/gokapso/agent-skills/tree/master/skills/automate-whatsapp)** - Build WhatsApp automations with workflows and agents
 - **[gokapso/observe-whatsapp](https://github.com/gokapso/agent-skills/tree/master/skills/observe-whatsapp)** - Debug WhatsApp delivery issues and run health checks


### PR DESCRIPTION
Adds [`clockless-org/html-anything`](https://github.com/clockless-org/html-anything) to **Community Skills → Productivity and Collaboration**.

> **Install once. Your agent answers as polished web pages whenever the content is actually a page, not a chat message.**

[`clockless-org/html-anything`](https://github.com/clockless-org/html-anything) turns rich agent answers — and any file, folder, URL, or service export — into a polished single-file HTML page. The skill auto-routes to one of 16 design systems (`teaching`, `relationship`, `timeline-story`, `map-atlas`, `network-map`, `document`, `dashboard`, `developer`, `living-essay`, `editorial-carousel`, `paper-trail`, `kinetic-scoreboard`, `soft-saas`, `digital-eguide`, `interactive-learning`, `default`), builds the HTML, verifies it in a browser, and hands it back. Short chats stay short.

**Install:** `npx skills add clockless-org/html-anything`

**Live gallery (22 demos):** https://clockless-org.github.io/html-anything/examples/

Sample outputs across the catalog:
- [Kindle highlights → `living-essay`](https://clockless-org.github.io/html-anything/examples/kindle-highlights/output.html)
- [Solar system brief → `teaching`](https://clockless-org.github.io/html-anything/examples/solar-system-studio/output.html)
- [WhatsApp / WeChat → `relationship`](https://clockless-org.github.io/html-anything/examples/wechat-couple/output.html)
- [Google Maps saved places → `map-atlas`](https://clockless-org.github.io/html-anything/examples/google-maps-stars/output.html)
- [LinkedIn connections → `network-map`](https://clockless-org.github.io/html-anything/examples/linkedin-connections/output.html)
- [PR review → `developer`](https://clockless-org.github.io/html-anything/examples/pr-review/output.html)

Apache 2.0 · cross-agent (Claude Code, Codex, Cursor, Cline, Windsurf via the open `npx skills` CLI) · already on [skills.sh](https://skills.sh/clockless-org/html-anything) · active maintenance (22 demos, 16 design systems, 34 source parsers).

### Submission checklist
- ✅ Public GitHub repo with `SKILL.md` (YAML frontmatter, `name`, `description`, `when_to_use`)
- ✅ Description under 200 chars
- ✅ Author/org prefix included
- ✅ Cross-agent (Claude Code, Codex, Cursor, Cline, Windsurf)
- ✅ Real community usage — already on skills.sh with installs