### PR TITLE
Add Mutagent: runtime-agnostic prompt eval skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1378,6 +1378,7 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[LambdaTest/agent-skills](https://github.com/LambdaTest/agent-skills)** - TestMu AI (Formerly LambdaTest) Skills is a curated collection of Agent Skills that teach AI coding assistants how to write production-grade test automation.
 - **[foryourhealth111-pixel/Vibe-Skills](https://github.com/foryourhealth111-pixel/Vibe-Skills)** - A skills governed plug-and-play harness for staged, test-driven skill orchestration
 - **[metalbear-co/skills](https://github.com/metalbear-co/skills)** - Skills that let agents code and test against your Kubernetes cluster using mirrord
+- **[mutagent-io/skills](https://github.com/mutagent-io/skills)** - Runtime-agnostic skill (Claude Code, Cursor, Aider, Continue) for prompt eval, optimization, and framework tracing. 9.6k monthly installs.
 
 </details>
 


### PR DESCRIPTION
Adds Mutagent to the **Community Skills → Development and Testing** section.

**What it is**: Open-source ([MIT](https://github.com/mutagent-io/skills/blob/main/LICENSE)) Claude Code plugin + bare Agent Skills bundle that gives AI engineers an eval-driven loop for prompt and agent optimization: capture traces → curate datasets → score against rubrics → optimize prompts against measurable targets.

**Why it fits**: Sits alongside `hamelsmu/eval-audit`, `hamelsmu/error-analysis`, and `hamelsmu/write-judge-prompt` already in this section, but bundles the full capture → curate → score → optimize loop as a single skill that works across any Agent Skills-compatible runtime (Claude Code, Cursor, Aider, Continue) — not just one workflow stage.

**Credibility**: 9.6k npm downloads/30d on `@mutagent/cli`. Framework adapters for Mastra, LangChain, LangGraph, Vercel AI SDK. Runtime-agnostic (works in Claude Code, Cursor, Aider, Continue).

**Source**: https://github.com/mutagent-io/skills
**Docs**: https://docs.mutagent.io
**Install**: `npm install -g @mutagent/cli && mutagent skills install`

Happy to revise placement/wording if it's a better fit elsewhere.