### PR TITLE
Add skill: echennells/sparkbtcbot-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1430,6 +1430,7 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[meodai/skill.color-expert](https://github.com/meodai/skill.color-expert)** - Color science expert skill with 286K words of reference material covering OKLCH/OKLAB, palette generation, accessibility/contrast, color naming, pigment mixing, and historical color theory
 - **[aklofas/kicad-happy](https://github.com/aklofas/kicad-happy)** - AI-powered KiCad electronics design review and analysis
 - **[bitwize-music-studio/claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills)** - Full-lifecycle AI music album production
+- **[echennells/sparkbtcbot-skill](https://github.com/echennells/sparkbtcbot-skill)** - Spark Bitcoin L2 wallet for agents — Lightning, L402, tokens
 
 </details>
 


### PR DESCRIPTION
Adds **sparkbtcbot-skill** under Community Skills → Specialized Domains, alongside the existing Solana skill (helius-labs/helius-skills).

**What it does:** Gives an AI agent a non-custodial Bitcoin wallet on Spark (Bitcoin L2). The skill covers wallet init from BIP39 mnemonic, instant zero-fee Spark transfers, Lightning Network interop (create/pay BOLT11 invoices), L402 paywall payment, BTKN/LRC20 tokens, L1 deposits and cooperative withdrawals, and message signing. Seed is encrypted at rest (scrypt + AES-256-GCM); decrypted at boot from `SPARK_PASSPHRASE`.

**Why this list:** Existing crypto/wallet skills are well-represented (Coinbase, Binance, helius-labs Solana, Venice x402). Bitcoin-L2 / Lightning is the missing piece.

**Skill repo:** https://github.com/echennells/sparkbtcbot-skill
**SKILL.md path:** `skills/sparkbtcbot/SKILL.md`
**Plugin install:** `claude plugin marketplace add https://github.com/echennells/sparkbtcbot-skill && claude plugin install sparkbtcbot`