### PR TITLE
Add skill: marmot-sh/marmot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1443,6 +1443,7 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[czlonkowski/n8n-node-configuration](https://github.com/czlonkowski/n8n-skills/tree/main/skills/n8n-node-configuration)** - Node configuration with dependency rules and AI connections
 - **[czlonkowski/n8n-validation-expert](https://github.com/czlonkowski/n8n-skills/tree/main/skills/n8n-validation-expert)** - Fix n8n validation errors with error catalog
 - **[czlonkowski/n8n-workflow-patterns](https://github.com/czlonkowski/n8n-skills/tree/main/skills/n8n-workflow-patterns)** - Workflow patterns for webhook, HTTP, database, and AI tasks
+- **[marmot-sh/marmot](https://github.com/marmot-sh/marmot/tree/main/skills/marmot)** - Shell CLI for AI, search, scraping, enrichment across many providers
 
 </details>
 


### PR DESCRIPTION
Adds [marmot-sh/marmot](https://github.com/marmot-sh/marmot/tree/main/skills/marmot) to the Community Skills section.

**What it does:** Shell-native CLI agents call for AI generation, web search, scraping, deep research, and people/company enrichment across many providers (OpenRouter, Anthropic, OpenAI, Vercel AI Gateway, Cloudflare Workers AI, Ollama for AI; Brave, Exa, Firecrawl, Parallel, Tavily for web; Apollo, Hunter, PDL, Tomba, etc. for data). The skill teaches the agent Marmot's verb shape, output formats, and provider matrix so it composes calls without bespoke prompts.

**Why it's useful for agents:** instead of teaching the agent a dozen provider CLIs, OpenCode/Codex/Claude Code learn Marmot's shape once and reuse it. Skill installs to `~/.agents/skills/marmot/` and auto-symlinks for each harness.

**Skill repo:** https://github.com/marmot-sh/marmot/tree/main/skills/marmot
**Install:** `npx skills add https://github.com/marmot-sh/marmot --skill marmot`