### PR TITLE
Add skill: Xquik-dev/hermes-tweet

### DIFF
--- a/README.md
+++ b/README.md
@@ -1252,6 +1252,7 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[CosmoBlk/email-marketing-bible](https://github.com/CosmoBlk/email-marketing-bible)** - 55K-word email marketing guide as an AI skill
 - **[smixs/creative-director-skill](https://github.com/smixs/creative-director-skill)** - AI creative director with recursive self-assessment: 20+ methodologies (SIT, TRIZ, Bisociation, SCAMPER, Synectics), 3-axis evaluation calibrated against Cannes/D&AD/HumanKind, 5-phase process from brief to presentation
 - **[Xquik-dev/x-twitter-scraper](https://github.com/Xquik-dev/x-twitter-scraper)** - Tweet search, profile tweets, follower export, media, posting, replies, MCP
+- **[Xquik-dev/hermes-tweet](https://github.com/Xquik-dev/hermes-tweet)** - Hermes Agent X/Twitter plugin with approval-gated actions
 - **[Xquik-dev/tweetclaw](https://github.com/Xquik-dev/tweetclaw)** - Post tweets, replies, DMs; search, monitor, run giveaways
 - **[SHADOWPR0/beautiful_prose](https://github.com/SHADOWPR0/beautiful_prose)** - Hard-edged writing style contract for timeless, forceful English prose without AI tics
 - **[blader/humanizer](https://github.com/blader/humanizer)** - Remove signs of AI-generated writing from text, making it sound more natural and human


### PR DESCRIPTION
## Summary
- Add `Xquik-dev/hermes-tweet` to Community Skills > Marketing.
- Keep the entry adjacent to the existing Xquik and TweetClaw listings.
- Scope the description to the Hermes Agent X/Twitter plugin surface.

## Why distinct
- `Xquik-dev/x-twitter-scraper` covers the broader Xquik X/Twitter skill.
- `Xquik-dev/tweetclaw` covers the OpenClaw skill.
- `Xquik-dev/hermes-tweet` is the native Hermes Agent plugin route with approval-gated actions.

## Checks
- Verified the Hermes Tweet repo link returns HTTP 200.
- Checked open and closed PRs/issues for `hermes-tweet` and `Hermes Tweet` duplicates.
- Confirmed the description is 8 words, within the 10-word rule.
- Ran `git diff --cached --check`.
- Checked the added line for common hardcoded token patterns and em dash/en dash characters.