### PR TITLE
Add Chinese market AI skills: Xiaohongshu, WeChat, MCP development

### DIFF
--- a/README.md
+++ b/README.md
@@ -1259,7 +1259,8 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[MohamedAbdallah-14/unslop](https://github.com/MohamedAbdallah-14/unslop)** - Removes named AI writing tells (tricolons, em-dash pileups, hedging stacks, sycophancy openers, stock vocab like "delve"/"crucial"). Split lint/rewrite modes for auditing your own text without auto-rewriting. Five intensity levels, MIT
 - **[Eronred/aso-skills](https://github.com/Eronred/aso-skills)** - 30+ App Store Optimization skills for keyword research, metadata optimization, competitor analysis, creative optimization, and mobile growth strategies via Appeeky API
 - **[degausai/wonda](https://github.com/degausai/wonda)** - AI content creation: images, video, music, audio, editing, publishing
-- **[gitroomhq/postiz-agent](https://github.com/gitroomhq/postiz-agent)** - Schedule social media posts across 28+ platforms programmatically
+- **[gitroomhq/postiz-agent](https://github.com/gitroomhq/postiz-agent)**
+- **[demo112/yunqu-ai-skills](https://github.com/demo112/yunqu-ai-skills)** - Chinese market AI skills collection: Xiaohongshu content strategy, WeChat Official Account optimization, multi-platform Chinese content engineering, and MCP tool development - Schedule social media posts across 28+ platforms programmatically
 
 </details>
 


### PR DESCRIPTION
## Added Skills

Adding a collection of Chinese market AI skills to the Marketing section of Community Skills:

### Chinese Market Skills
- **Xiaohongshu Content Strategist** - AI-powered content strategy for Xiaohongshu (Little Red Book): trend analysis, title optimization, engagement tactics, and platform-specific content planning
- **WeChat Official Account Strategist** - WeChat Official Account content strategy, audience growth, article optimization, and monetization planning
- **Chinese Market Content Engineer** - Multi-platform Chinese content creation for WeChat, Xiaohongshu, Douyin, Zhihu, and Bilibili with platform-specific optimization

### Developer Tools
- **MCP Tool Developer** - Build Model Context Protocol (MCP) servers and tools with TypeScript/Python, testing, deployment, and registry publishing

These skills fill a gap in the Chinese market content strategy space - there are currently no Xiaohongshu or WeChat skills in this repository.

Repository: https://github.com/demo112/yunqu-ai-skills
GitHub Pages: https://demo112.github.io/yunqu-ai-skills/