### PR TITLE
Add skill: jianshuo/claude-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1430,6 +1430,7 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[meodai/skill.color-expert](https://github.com/meodai/skill.color-expert)** - Color science expert skill with 286K words of reference material covering OKLCH/OKLAB, palette generation, accessibility/contrast, color naming, pigment mixing, and historical color theory
 - **[aklofas/kicad-happy](https://github.com/aklofas/kicad-happy)** - AI-powered KiCad electronics design review and analysis
 - **[bitwize-music-studio/claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills)** - Full-lifecycle AI music album production
+- **[jianshuo/claude-skills](https://github.com/jianshuo/claude-skills)** - 13 video-production skills: transcribe, translate, dub, multicam sync/auto-edit, topic segmenting, MediaPipe reframing, subtitle burn-in, YouTube/WeChat publishing
 
 </details>
 


### PR DESCRIPTION
## Adding `jianshuo/claude-skills` to Specialized Domains

Adds one community entry — a curated, real-world video-production skill collection.

- **Repo**: https://github.com/jianshuo/claude-skills
- **Author**: Jianshuo Wang (王建硕)
- **License**: MIT
- **Format**: 13 standard `SKILL.md` skills (no AI-slop generated; authored and used in production by the maintainer for his own YouTube/WeChat video pipeline)
- **Cross-compatible**: Claude Code, OpenAI Codex CLI, Cursor, Gemini CLI (open SKILL.md standard)
- **Category chosen**: Community Skills → Specialized Domains (neighbor: `video-db/skills`, `bitwize-music-studio/claude-ai-music-skills`)

### What the skills do

End-to-end video production pipeline, each skill scoped and composable:

- `wjs-transcribing-audio` — language-routed ASR (Volcano for Chinese, Whisper word-level for others) → SRT
- `wjs-translating-subtitles` — punctuation-bounded re-segmentation, bilingual output
- `wjs-dubbing-video` — time-aligned TTS dub with optional speaker diarization
- `wjs-burning-subtitles` — final mux/burn-in
- `wjs-syncing-multicam` — audio cross-correlation alignment, emits `.sync.json` sidecars
- `wjs-editing-multicam` — audio-energy-driven automatic cam-switching + PiP
- `wjs-segmenting-video` — long-form → 3–6 topical short clips
- `wjs-overlaying-video` — HyperFrames post-production overlays
- `wjs-reframing-video` — horizontal ↔ vertical with MediaPipe speaker tracking
- `wjs-uploading-video` — YouTube Data API v3 batch upload
- `wjs-publishing-wechat` — WeChat Official Account draft + publish
- `wjs-localizing-video` — orchestrator for the full localize pipeline
- `wjs-auditing-project` — sanity-check video projects before publish

### Checklist

- [x] Public repo with working skills
- [x] Documentation present (`SKILL.md` per skill + repo README)
- [x] Author/org prefix in entry name (`jianshuo/...`)
- [x] Single line in correct category, matching existing format
- [x] Verified no existing entry for `jianshuo/claude-skills`