### PR TITLE
Add b2-cloud-storage skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1244,6 +1244,13 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 </details>
 
 <details>
+<summary><h3 style="display:inline">Cloud Storage</h3></summary>
+
+- **[backblaze-labs/b2-cloud-storage](https://github.com/backblaze-labs/claude-skill-b2-cloud-storage)** - Manage Backblaze B2 cloud storage from the terminal: list buckets and objects, audit usage, clean up stale data, run security reviews, configure lifecycle rules. S3-compatible; works with rclone, the B2 CLI, and any S3 client.
+
+</details>
+
+<details>
 <summary><h3 style="display:inline">Marketing</h3></summary>
 
 - **[BrianRWagner/ai-marketing-skills](https://github.com/BrianRWagner/ai-marketing-skills)** - 17 marketing frameworks for cold outreach, homepage audit, social cards, and more


### PR DESCRIPTION
## What this PR adds

A new community-skills entry under a new **Cloud Storage** category for [`backblaze-labs/b2-cloud-storage`](https://github.com/backblaze-labs/claude-skill-b2-cloud-storage), a Claude/Codex skill for managing Backblaze B2 from any S3-compatible workflow.

````markdown
<details>
<summary><h3 style="display:inline">Cloud Storage</h3></summary>

- **[backblaze-labs/b2-cloud-storage](https://github.com/backblaze-labs/claude-skill-b2-cloud-storage)** - Manage Backblaze B2 cloud storage from the terminal: list buckets and objects, audit usage, clean up stale data, run security reviews, configure lifecycle rules. S3-compatible; works with rclone, the B2 CLI, and any S3 client.

</details>
````

## Why a new category

No existing community-skills section covers cloud-object-storage operations (the closest, "Vector Databases", is database-centric, and the per-vendor "Cloud & Infrastructure" official sections are scoped to that vendor's products). Cloud Storage fits alongside Vector Databases as a peer infrastructure category and gives a home to future S3/R2/GCS/Azure-Blob skill submissions.

## Requirements checklist (per CONTRIBUTING.md)

- [x] Public repository with a working skill: https://github.com/backblaze-labs/claude-skill-b2-cloud-storage
- [x] Has documentation: README.md, CONTRIBUTING.md, RELEASE.md, CHANGELOG.md, and a SKILL.md following the open Agent Skills standard
- [x] Author/org prefix included in the name (`backblaze-labs/b2-cloud-storage`)
- [x] Added to the end of a community-skills category (new section, alphabetised between Marketing and Vector Databases would also work, happy to move)

## About the skill

Backblaze B2 is an S3-compatible object store; the skill wraps `b2`, `rclone`, and the AWS SDK so the agent can list, audit, clean up, and secure buckets without leaving the terminal. MIT licensed, maintained by Backblaze Labs.

## Notes

If you'd prefer this under an existing category instead of a new "Cloud Storage" section, happy to adjust. Suggested alternative: a new top-level `## Cloud & Infrastructure` peer to the existing community categories.
