### PR TITLE
Add skill: dekart-xyz/geosql

### DIFF
--- a/README.md
+++ b/README.md
@@ -1430,6 +1430,7 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[meodai/skill.color-expert](https://github.com/meodai/skill.color-expert)** - Color science expert skill with 286K words of reference material covering OKLCH/OKLAB, palette generation, accessibility/contrast, color naming, pigment mixing, and historical color theory
 - **[aklofas/kicad-happy](https://github.com/aklofas/kicad-happy)** - AI-powered KiCad electronics design review and analysis
 - **[bitwize-music-studio/claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills)** - Full-lifecycle AI music album production
+- **[dekart-xyz/geosql](https://github.com/dekart-xyz/geosql)** - Geospatial SQL skill for BigQuery and Snowflake with map rendering
 
 </details>
 


### PR DESCRIPTION
Adds [dekart-xyz/geosql](https://github.com/dekart-xyz/geosql) to Community Skills > Specialized Domains. Geospatial SQL skill for Claude, Codex, and other agents; cost-safe queries on BigQuery and Snowflake with interactive map rendering via Dekart.

Disclosure: I'm the author/maintainer of GeoSQL.