### PR TITLE
Add claude-indie-toolkit to Marketing skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1260,6 +1260,7 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[Eronred/aso-skills](https://github.com/Eronred/aso-skills)** - 30+ App Store Optimization skills for keyword research, metadata optimization, competitor analysis, creative optimization, and mobile growth strategies via Appeeky API
 - **[degausai/wonda](https://github.com/degausai/wonda)** - AI content creation: images, video, music, audio, editing, publishing
 - **[gitroomhq/postiz-agent](https://github.com/gitroomhq/postiz-agent)** - Schedule social media posts across 28+ platforms programmatically
+- **[tastekim/claude-indie-toolkit](https://github.com/tastekim/claude-indie-toolkit)** - Indie hacker / solo founder workflow. 5 agents (idea-validator with kill criteria, pricing-strategist using Van Westendorp, landing-page-architect using AIDA+PAS, cold-outreach-writer with 4-line reply-optimized framework, launch-day-orchestrator with 22-day playbook), 3 skills (mvp-spec-writer with hard ≤4-week/≤5-screen/≤7-action constraints, competitor-deep-dive, revenue-modeler), 2 commands, 1 PreToolUse hook (scope-creep-guard blocks Claude from writing files outside MVP-SPEC.md). Korean adaptation included.
 
 </details>
 


### PR DESCRIPTION
Adding **[claude-indie-toolkit](https://github.com/tastekim/claude-indie-toolkit)** under Community Skills > Marketing (sits naturally alongside ai-marketing-skills, email-marketing-bible, x-twitter-scraper).

## What it is
A workflow toolkit for solo founders shipping side projects with Claude Code. 5 agents + 3 skills + 2 commands + 1 PreToolUse hook. Each agent encodes a concrete methodology (Van Westendorp pricing, AIDA+PAS landing pages, 4-line cold email framework optimized for reply rate) and has explicit kill criteria + "refuse to" clauses, so the agents push back on bad decisions instead of glazing.

## Highlights
- `idea-validator` — 5-pillar GO/NO-GO framework with weighted scoring and kill criteria; demands WebSearch evidence (no hallucinated stats)
- `mvp-spec-writer` — enforces hard constraints (≤4 weeks build, ≤5 screens, ≤7 user actions)
- `scope-creep-guard` PreToolUse hook — blocks Claude from writing files outside the project's MVP-SPEC.md
- Korean adaptation guide for 한국 인디 해커s

Free preview agent + sample output + workflow doc on GitHub (MIT). Full pack on Gumroad.

I'm the author. Happy to move sections, revise wording, or shorten — just let me know what you prefer. Thanks for maintaining the list!