### PR TITLE
Add mturac/recsys-pipeline-architect (Community Skills · Development and Testing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1378,6 +1378,7 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[LambdaTest/agent-skills](https://github.com/LambdaTest/agent-skills)** - TestMu AI (Formerly LambdaTest) Skills is a curated collection of Agent Skills that teach AI coding assistants how to write production-grade test automation.
 - **[foryourhealth111-pixel/Vibe-Skills](https://github.com/foryourhealth111-pixel/Vibe-Skills)** - A skills governed plug-and-play harness for staged, test-driven skill orchestration
 - **[metalbear-co/skills](https://github.com/metalbear-co/skills)** - Skills that let agents code and test against your Kubernetes cluster using mirrord
+- **[mturac/recsys-pipeline-architect](https://github.com/mturac/recsys-pipeline-architect)** - Composable recommendation pipeline skill: six-stage Source→Hydrator→Filter→Scorer→Selector→SideEffect framework popularized by xAI's open-sourced X For You algorithm. Walks through use case → sources → hydrations → filters → scorers → selector → side effects → scaffold, and emits runnable scaffolds for Strapi v5 (TypeScript), Go (with generics), or Python/FastAPI
 
 </details>
 


### PR DESCRIPTION
Adds **[recsys-pipeline-architect](https://github.com/mturac/recsys-pipeline-architect)** under *Community Skills → Development and Testing*.

**What it is**
A vendor-agnostic Agent Skill (agentskills.io standard) for designing composable recommendation, ranking, and feed pipelines using the six-stage **Source → Hydrator → Filter → Scorer → Selector → SideEffect** framework popularized by xAI's open-sourced [For You algorithm](https://github.com/xai-org/x-algorithm) (Apache 2.0; this skill is MIT and is an independent reimplementation of the pattern).

**Why it fits**
Most "recommendation systems" in production aren't exotic ML — they're pipelines. This skill encodes that pattern, walks the agent through eight clarifying steps (use case → sources → hydrations → filters → scorers → selector → side effects → scaffold), surfaces the architectural trade-offs you'd otherwise default through silently (multi-action vs single-score, candidate isolation vs joint scoring, online vs offline batch), and emits a runnable scaffold in the user's stack.

**Multi-agent compatibility**
Tested via `npx skills add mturac/recsys-pipeline-architect` — installs cleanly to Claude Code, Codex, Cursor, Gemini CLI, Cline, Continue, Windsurf, OpenCode, GitHub Copilot, and 8 more.

**Repo contents**
- `SKILL.md` + 5 load-on-demand reference docs (interfaces in 4 languages, multi-action scoring, candidate isolation, filter cookbook with 12 patterns, scorer cookbook)
- 3 runnable example scaffolds, every one green on its test suite:
  - Strapi v5 plugin — TypeScript / Jest, 3/3 pass
  - Zentra-compatible pipeline — Go with generics, 3/3 pass
  - PMAI task prioritizer — Python / FastAPI / pytest, 3/3 pass
- MIT license, attribution to the xAI pattern in README and LICENSE
- v0.1.0 GitHub release tagged

Appended one entry to the "Development and Testing" sub-section in the existing format. Happy to revise the wording, move to a different sub-section, or shorten further — just let me know.