### PR TITLE
Add polis-protocol to Community Skills → Productivity and Collaboration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1295,6 +1295,7 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[ReScienceLab/opc-skills](https://github.com/ReScienceLab/opc-skills)** - Agent skills for solopreneurs with SEO, geo, and LLM tools
 - **[SeanZoR/claude-speed-reader](https://github.com/SeanZoR/claude-speed-reader)** - Speed read Claude's responses at 600+ WPM using RSVP with Spritz-style ORP highlighting
 - **[Charlie85270/Dorothy](https://github.com/Charlie85270/Dorothy)** - Orchestrate multiple AI CLI agents with automations and MCP servers
+- **[yehudalevy-collab/polis-protocol](https://github.com/yehudalevy-collab/polis-protocol)** - Markdown coordination protocol for multi-vendor agent teams. Signed capability cards, ε-greedy bandit routing that learns from settled contracts, chavruta paired review, self-amending constitution. Works across Claude Code, Codex, Gemini CLI
 - **[Digidai/product-manager-skills](https://github.com/Digidai/product-manager-skills)** - Senior PM agent with 30+ frameworks and SaaS metrics
 - **[deusyu/translate-book](https://github.com/deusyu/translate-book)** - Translate books (PDF/DOCX/EPUB) via parallel sub-agents with resume
 - **[mvanhorn/last30days-skill](https://github.com/mvanhorn/last30days-skill)** - Research any topic across Reddit, X, YouTube, HN, Polymarket, and the web, ranked by upvotes, likes, and real money instead of editors


### PR DESCRIPTION
## Summary

Adds **polis-protocol** to **Community Skills → Productivity and Collaboration** (next to other multi-agent orchestration entries like Dorothy and obra's dispatching-parallel-agents).

## What it is

A markdown coordination protocol for multi-vendor agent teams:

- **Signed capability cards** per citizen agent
- **ε-greedy multi-armed bandit routing** that learns from settled contracts
- **Chavruta paired review** for high-stakes work
- **Self-amending constitution** with a ratifiable amendment process

Vendor-agnostic — works across Claude Code, Codex, Gemini CLI, and any markdown-capable agent. Packaged as a skill: drop `_polis/` in any project. MIT licensed.

Repo: https://github.com/yehudalevy-collab/polis-protocol
