### PR TITLE
Add skill: yehudalevy-collab/polis-protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -1279,6 +1279,7 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[obra/writing-plans](https://github.com/obra/superpowers/blob/main/skills/writing-plans/SKILL.md)** - Create strategic documentation
 - **[obra/executing-plans](https://github.com/obra/superpowers/blob/main/skills/executing-plans/SKILL.md)** - Implement and run strategic plans
 - **[obra/dispatching-parallel-agents](https://github.com/obra/superpowers/blob/main/skills/dispatching-parallel-agents/SKILL.md)** - Coordinate multiple simultaneous agents
+- **[yehudalevy-collab/polis-protocol](https://github.com/yehudalevy-collab/polis-protocol/blob/main/SKILL.md)** - Coordinate multi-vendor agents with markdown contracts
 - **[obra/sharing-skills](https://github.com/obra/superpowers/blob/main/skills/sharing-skills/SKILL.md)** - Distribute and communicate capabilities
 - **[obra/using-superpowers](https://github.com/obra/superpowers/blob/main/skills/using-superpowers/SKILL.md)** - Leverage core platform capabilities
 - **[op7418/Youtube-clipper-skill](https://github.com/op7418/Youtube-clipper-skill)** - YouTube clip generation and editing with automated workflows


### PR DESCRIPTION
Adds Polis Protocol to Community Skills > Productivity and Collaboration.

This is a small SKILL.md-based protocol for coordinating multiple AI coding assistants across Claude Code, Codex, Gemini, and other markdown-aware agents. The entry uses the requested author/skill-name format and keeps the description under 10 words.

I know the list has a quality bar around proven/community-used skills; happy for you to hold this until Polis has more adoption if that is the better fit.

Link verified: https://github.com/yehudalevy-collab/polis-protocol/blob/main/SKILL.md
