### PR TITLE
Add skill: proompteng/bilig

### DIFF
--- a/README.md
+++ b/README.md
@@ -1378,6 +1378,7 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[LambdaTest/agent-skills](https://github.com/LambdaTest/agent-skills)** - TestMu AI (Formerly LambdaTest) Skills is a curated collection of Agent Skills that teach AI coding assistants how to write production-grade test automation.
 - **[foryourhealth111-pixel/Vibe-Skills](https://github.com/foryourhealth111-pixel/Vibe-Skills)** - A skills governed plug-and-play harness for staged, test-driven skill orchestration
 - **[metalbear-co/skills](https://github.com/metalbear-co/skills)** - Skills that let agents code and test against your Kubernetes cluster using mirrord
+- **[proompteng/bilig](https://github.com/proompteng/bilig/tree/main/skills/bilig-workpaper)** - Formula WorkPaper runtime for agent tools
 
 </details>
 


### PR DESCRIPTION
Adds Bilig WorkPaper to Community Skills > Development and Testing.

Bilig gives agents a formula-backed WorkPaper runtime for backend and MCP workflows: write cells through an API, recalculate, verify readback, and persist JSON without driving a spreadsheet UI.

Link verified: https://github.com/proompteng/bilig/tree/main/skills/bilig-workpaper