### PR TITLE
docs: add portability evidence quality criterion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1498,6 +1498,7 @@ As the ecosystem grows, consistent quality helps agents discover and use skills 
 | **Progressive disclosure** | Keep top-level metadata under ~100 tokens. Skill body should stay below 500 lines. Load resources (large docs, schemas) on demand, not inline. |
 | **No absolute paths** | Never hard-code machine-specific paths like `/Users/alice/`. Use relative paths or well-known variables (`$HOME`, `$PROJECT_ROOT`). |
 | **Scoped tools** | Request only the tools the skill actually needs. Avoid blanket `"tools": ["*"]`. Declare tool dependencies explicitly. |
+| **Portability evidence** | When claiming compatibility across agents, document what was actually tested: target tools, native discovery path, manual activation needs, and any known lossy/fallback behavior. Do not present a generic fallback path as equivalent to a native skill/rule surface. |
 
 ## 🤝 Contributing
 


### PR DESCRIPTION
Follow-up to #588.

This adds one vendor-neutral row to the Skill Quality Standards table for cross-agent compatibility claims.

Why:
- the README lists paths for several AI coding assistants;
- many skills now claim compatibility across Claude Code, Codex, Cursor, Gemini, Copilot, Windsurf, etc.;
- a generic fallback path is not always equivalent to a native skill/rule discovery surface.

The proposed criterion asks authors to document what was actually tested: target tools, native discovery path, manual activation needs, and known lossy/fallback behavior.

No tool/vendor requirement is added; this is only a documentation quality bar.