### PR TITLE
Add skill: dfbb/dora

### DIFF
--- a/README.md
+++ b/README.md
@@ -1378,6 +1378,7 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[LambdaTest/agent-skills](https://github.com/LambdaTest/agent-skills)** - TestMu AI (Formerly LambdaTest) Skills is a curated collection of Agent Skills that teach AI coding assistants how to write production-grade test automation.
 - **[foryourhealth111-pixel/Vibe-Skills](https://github.com/foryourhealth111-pixel/Vibe-Skills)** - A skills governed plug-and-play harness for staged, test-driven skill orchestration
 - **[metalbear-co/skills](https://github.com/metalbear-co/skills)** - Skills that let agents code and test against your Kubernetes cluster using mirrord
+- **[dfbb/dora](https://github.com/dfbb/dora)** - Automatically discover and load community skills on demand
 
 </details>
 


### PR DESCRIPTION
Adds [dora](https://github.com/dfbb/dora) to **Community Skills > Development and Testing**.

dora lets AI coding agents automatically discover and load community skills on demand — query, security-filter, and execute without pre-installation. ~9,500-skill offline catalog, cross-platform (Claude Code, Codex, Gemini CLI, OpenCode, Qwen Code). MIT.

**Repo:** https://github.com/dfbb/dora

🤖 Generated with [Claude Code](https://claude.com/claude-code)