### PR TITLE
Add skill: PGYER/pgyer-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The most contributed Agent Skills repository, built and maintained together with
 | [Kim Barrett (Advertising)](#advertising-skills-by-kim-barrett) | [Apollo GraphQL](#skills-by-apollo-graphql) | [Auth0](#skills-by-auth0) | [Brave](#skills-by-brave) |
 | [Browserbase](#skills-by-browserbase) | [CodeRabbit](#skills-by-coderabbit) | [Coinbase](#skills-by-coinbase) | [Datadog Labs](#skills-by-datadog-labs) |
 | [Firebase](#skills-by-firebase) | [Flutter](#skills-by-flutter) | [Venice.ai](#skills-by-veniceai) | [Community](#community-skills) |
-| [Redis](#skills-by-redis) | [Quality Standards](#skill-quality-standards) |  |  |
+| [Redis](#skills-by-redis) | [PGYER](#skills-by-pgyer-team) | [Quality Standards](#skill-quality-standards) |  |
 
 
 
@@ -1231,6 +1231,15 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 <summary><h3 style="display:inline">Skills by Redis</h3></summary>
 
 - **[redis/redis-development](https://github.com/redis/agent-skills/tree/main/skills/redis-development)** - Redis development best practices — data structures, query engine, vector search, caching, and performance optimization.
+
+</details>
+
+<details open>
+<summary><h3 style="display:inline">Skills by PGYER Team</h3></summary>
+
+Official skill by [PGYER (蒲公英)](https://www.pgyer.com), the leading Chinese app beta-distribution platform (since 2014). Companion to the official MCP server [`PGYER/pgyer-mcp-server`](https://github.com/PGYER/pgyer-mcp-server).
+
+- **[PGYER/pgyer-skill](https://github.com/PGYER/pgyer-skill)** - Upload iOS/Android/HarmonyOS builds to PGYER for beta distribution
 
 </details>
 


### PR DESCRIPTION
## Summary

Adds **PGYER/pgyer-skill** — the official Claude Code / agent skill from [PGYER (蒲公英)](https://www.pgyer.com), the leading Chinese app beta-distribution platform.

A new \"Skills by PGYER Team\" section is added directly before \"Community Skills\", matching the existing pattern for other official vendor sections (Stripe, Cloudflare, Sanity, etc.). The Table of Contents is updated as well.

## Why this fits

- **Official vendor skill, not a community side-project.** PGYER has operated since 2014 (12+ years, hundreds of thousands of mobile developers in China). The repo lives in the official `PGYER/` GitHub organization and is published as the AI-agent companion to PGYER's existing official MCP server [`PGYER/pgyer-mcp-server`](https://github.com/PGYER/pgyer-mcp-server) (also on npm).
- **Cross-agent.** Listed as compatible with the open agent-skills CLI (\`npx skills add PGYER/pgyer-skill -a <agent>\`), so it's relevant to Claude Code, Codex, Cursor, Gemini CLI, etc. — matching this list's positioning.
- **Real coverage.** Covers iOS, Android, and HarmonyOS; ships GitHub Actions / GitLab CI templates; includes a routing test scenarios file (\`tests/scenarios.md\`).

## On the \"brand new\" guideline

I read CONTRIBUTING.md and understand the preference for community-adopted skills. Submitting under the official-vendor lane since this is the vendor's own integration (not a third-party wrapper), which is the same pattern already used by other \"Skills by X Team\" sections here. Happy to wait if maintainers prefer to revisit after the skill accumulates more public usage — please feel free to close and I'll resubmit once there's more traction.

## Test plan

- [x] Link to PGYER/pgyer-skill resolves
- [x] Description is under 10 words (per CONTRIBUTING.md)
- [x] Author/org prefix included
- [x] TOC anchor matches the new section heading