### PR TITLE
Add skill: nitinjain999/platform-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1307,6 +1307,7 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[robzolkos/skill-rails-upgrade](https://github.com/robzolkos/skill-rails-upgrade)** - Analyze Rails apps and provide upgrade assessments
 - **[Shpigford/screenshots](https://github.com/Shpigford/skills/tree/main/screenshots)** - Generate marketing screenshots with Playwright
 - **[antonbabenko/terraform-skill](https://github.com/antonbabenko/terraform-skill)** - Terraform and OpenTofu patterns: testing, modules, state, CI/CD.
+- **[nitinjain999/platform-skills](https://github.com/nitinjain999/platform-skills)** - Kubernetes, Terraform, GitOps, KEDA, Linkerd, OPA, Kyverno, AWS/Azure platform patterns
 - **[zxkane/aws-skills](https://github.com/zxkane/aws-skills)** - AWS development with infrastructure automation and cloud architecture patterns
 - **[Rootly-AI-Labs/rootly-incident-responder](https://github.com/Rootly-AI-Labs/Rootly-MCP-server/blob/main/examples/skills/rootly-incident-responder.md)** - AI-powered incident response with ML similarity matching, solution suggestions, and on-call coordination. Requires [Rootly MCP Server](https://github.com/Rootly-AI-Labs/Rootly-MCP-server)
 - **[conorluddy/ios-simulator-skill](https://github.com/conorluddy/ios-simulator-skill)** - Control iOS Simulator


### PR DESCRIPTION
## Add skill: nitinjain999/platform-skills

Production-grade Claude Code skill for platform engineers covering Kubernetes, Terraform, GitOps (FluxCD/ArgoCD), KEDA, Linkerd, OPA, Kyverno, AWS/Azure landing zones, Datadog, and Dynatrace.

- **Repo**: https://github.com/nitinjain999/platform-skills
- **Category**: Community Skills → Development and Testing
- **Compatible with**: Claude Code
- **Description** (10 words): Kubernetes, Terraform, GitOps, KEDA, Linkerd, OPA, Kyverno, AWS/Azure platform patterns