### PR TITLE
Add plan-agent demo and README entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,13 @@ The most contributed Agent Skills repository, built and maintained together with
 - **[`dropship-agent`](dropship-agent/README.md)** - Generates a static dropshipping storefront in `dropship-agent/dist/`.
 - **[`plan-agent`](plan-agent/README.md)** - Generates a structured 5-step plan from a task description.
 
+Use `plan-agent` directly without a container:
+
+```bash
+cd plan-agent
+node agent.js "Create a launch plan for a new SaaS product"
+```
+
 ## Sponsors ❤️
 
 [Become a Sponsor](https://github.com/sponsors/VoltAgent/sponsorships?tier_id=605663) to feature your logo here and on [officialskills.sh](https://officialskills.sh/) website — 300k+ monthly views.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,11 @@ The most contributed Agent Skills repository, built and maintained together with
 
 
 
+## Local Agent Demos
+
+- **[`dropship-agent`](dropship-agent/README.md)** - Generates a static dropshipping storefront in `dropship-agent/dist/`.
+- **[`plan-agent`](plan-agent/README.md)** - Generates a structured 5-step plan from a task description.
+
 ## Sponsors ❤️
 
 [Become a Sponsor](https://github.com/sponsors/VoltAgent/sponsorships?tier_id=605663) to feature your logo here and on [officialskills.sh](https://officialskills.sh/) website — 300k+ monthly views.

--- a/plan-agent/README.md
+++ b/plan-agent/README.md
@@ -1,0 +1,11 @@
+# Plan Agent
+
+A simple Node.js planning agent that generates a structured plan from a user-provided task description.
+
+## Run
+
+```bash
+node plan-agent/agent.js "Create a launch plan for a new SaaS product"
+```
+
+The agent prints a short five-step plan for the given prompt.

--- a/plan-agent/README.md
+++ b/plan-agent/README.md
@@ -8,4 +8,46 @@ A simple Node.js planning agent that generates a structured plan from a user-pro
 node plan-agent/agent.js "Create a launch plan for a new SaaS product"
 ```
 
+Or use the package script from the `plan-agent` directory:
+
+```bash
+cd plan-agent
+npm run plan -- "Create a launch plan for a new SaaS product"
+```
+
+If you want, install the local package globally to run it as `plan-agent`:
+
+```bash
+cd plan-agent
+npm install -g .
+plan-agent "Create a launch plan for a new SaaS product"
+```
+
 The agent prints a short five-step plan for the given prompt.
+
+## Example output
+
+```bash
+node plan-agent/agent.js "Create a launch plan for a new SaaS product"
+```
+
+```
+=== Plan Agent ===
+
+Task: Create a launch plan for a new SaaS product
+
+1. Clarify the objective
+   - Define the core outcome, target users, and success metrics for: Create a launch plan for a new SaaS product
+
+2. Break into phases
+   - Organize the work into research, design, execution, launch, and review phases
+
+3. Assign priorities
+   - Rank tasks and features by impact, effort, and deadline sensitivity
+
+4. Gather resources
+   - List required tools, stakeholders, team roles, and launch assets
+
+5. Review and refine
+   - Validate the plan, identify risks, and prepare follow-up metrics
+```

--- a/plan-agent/agent.js
+++ b/plan-agent/agent.js
@@ -14,13 +14,14 @@ function createPlan(task) {
   const goal = task.replace(/\.$/, '');
 
   return [
-    formatStep(1, 'Clarify the objective', `Define the core outcome for: ${goal}`),
-    formatStep(2, 'Break into phases', 'Split the work into research, design, execution, review, and follow-up tasks'),
-    formatStep(3, 'Assign priorities', 'Identify the most important actions and map them to deadlines or milestones'),
-    formatStep(4, 'Gather resources', 'List tools, stakeholders, and materials needed to complete each phase'),
-    formatStep(5, 'Review and refine', 'Validate the plan against the objective and update it for risks or missing steps'),
+    formatStep(1, 'Clarify the objective', `Define the core outcome, target users, and success metrics for: ${goal}`),
+    formatStep(2, 'Break into phases', 'Organize the work into research, design, execution, launch, and review phases'),
+    formatStep(3, 'Assign priorities', 'Rank tasks and features by impact, effort, and deadline sensitivity'),
+    formatStep(4, 'Gather resources', 'List required tools, stakeholders, team roles, and launch assets'),
+    formatStep(5, 'Review and refine', 'Validate the plan, identify risks, and prepare follow-up metrics'),
   ].join('\n\n');
 }
 
-console.log(`Planning agent output for: ${prompt}\n`);
+console.log('=== Plan Agent ===\n');
+console.log(`Task: ${prompt}\n`);
 console.log(createPlan(prompt));

--- a/plan-agent/agent.js
+++ b/plan-agent/agent.js
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+const prompt = process.argv.slice(2).join(' ').trim();
+
+if (!prompt) {
+  console.error('Usage: node agent.js "Describe the task to plan."');
+  process.exit(1);
+}
+
+function formatStep(index, title, details) {
+  return `${index}. ${title}\n   - ${details}`;
+}
+
+function createPlan(task) {
+  const goal = task.replace(/\.$/, '');
+
+  return [
+    formatStep(1, 'Clarify the objective', `Define the core outcome for: ${goal}`),
+    formatStep(2, 'Break into phases', 'Split the work into research, design, execution, review, and follow-up tasks'),
+    formatStep(3, 'Assign priorities', 'Identify the most important actions and map them to deadlines or milestones'),
+    formatStep(4, 'Gather resources', 'List tools, stakeholders, and materials needed to complete each phase'),
+    formatStep(5, 'Review and refine', 'Validate the plan against the objective and update it for risks or missing steps'),
+  ].join('\n\n');
+}
+
+console.log(`Planning agent output for: ${prompt}\n`);
+console.log(createPlan(prompt));

--- a/plan-agent/package.json
+++ b/plan-agent/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "plan-agent",
+  "version": "1.0.0",
+  "description": "A lightweight local planning agent demo.",
+  "type": "commonjs",
+  "bin": {
+    "plan-agent": "agent.js"
+  },
+  "scripts": {
+    "plan": "node agent.js"
+  },
+  "author": "VoltAgent demo",
+  "license": "MIT"
+}


### PR DESCRIPTION
Adds a lightweight local plan-agent demo under plan-agent/, and documents it in the root README under Local Agent Demos.