### PR TITLE
Add skill: santifer/career-ops

### DIFF
--- a/README.md
+++ b/README.md
@@ -1298,6 +1298,7 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 - **[Digidai/product-manager-skills](https://github.com/Digidai/product-manager-skills)** - Senior PM agent with 30+ frameworks and SaaS metrics
 - **[deusyu/translate-book](https://github.com/deusyu/translate-book)** - Translate books (PDF/DOCX/EPUB) via parallel sub-agents with resume
 - **[mvanhorn/last30days-skill](https://github.com/mvanhorn/last30days-skill)** - Research any topic across Reddit, X, YouTube, HN, Polymarket, and the web, ranked by upvotes, likes, and real money instead of editors
+- **[santifer/career-ops](https://github.com/santifer/career-ops)** - 14-skill collection for AI-powered job search: JD evaluation with A-F scoring, ATS-optimized PDF generation, portal scanners (Greenhouse/Ashby/Lever), interview prep with STAR+R, batch processing, and a Go dashboard TUI
 
 </details>
 


### PR DESCRIPTION
Adding **[santifer/career-ops](https://github.com/santifer/career-ops)** to the **Community Skills → Productivity and Collaboration** section.

### What it is

A 14-skill collection that turns Claude Code (and OpenCode / Gemini CLI) into an AI-powered job search command center.

### Skill modes

- JD evaluation — A-F scoring across 10 weighted dimensions
- ATS-optimized PDF generation per job description
- Portal scanners — Greenhouse, Ashby, Lever, Wellfound (45+ companies pre-configured)
- Interview prep with STAR+R story bank
- Negotiation scripts (salary, geographic discount, competing offer leverage)
- Batch processing via parallel `claude -p` sub-agents
- Go dashboard TUI for pipeline browsing

### Meets CONTRIBUTING requirements

| Requirement | Status |
|---|---|
| Public repository | ✅ [santifer/career-ops](https://github.com/santifer/career-ops) |
| Working skill | ✅ Used to evaluate 740+ offers → landed Head of Applied AI role |
| Documentation | ✅ README in 9 languages + per-skill SKILL.md |
| Author/org prefix | ✅ `santifer/career-ops` |
| Real community usage | ✅ **46,511 stars**, 9,725 forks, 151 active issues |
| Not brand new | ✅ Mature project with active community (Discord, contributors) |

Sits naturally alongside [Paramchoudhary/ResumeSkills](https://github.com/Paramchoudhary/ResumeSkills) in the same section — same career-domain shape, complementary scope.