### PR TITLE
Add skill: widelab-development/repo-to-landing-page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1502,6 +1502,7 @@ Official Google Cloud skills covering Firebase, BigQuery, Cloud Run, GKE, AlloyD
 - **[degausai/wonda](https://github.com/degausai/wonda)** - AI content creation: images, video, music, audio, editing, publishing
 - **[gitroomhq/postiz-agent](https://github.com/gitroomhq/postiz-agent)** - Schedule social media posts across 28+ platforms programmatically
 - **[indranilbanerjee/digital-marketing-pro](https://github.com/indranilbanerjee/digital-marketing-pro)** - 150-skill engagement methodology — 12-Part Strategy Flow, 25 specialist agents, EU AI Act Article 50 ready (C2PA signing), 6-platform AEO/GEO incl. Google AI Mode
+- **[widelab-development/repo-to-landing-page](https://github.com/widelab-development/repo-to-landing-page)** - Generate landing pages from existing product repositories
 
 </details>
 


### PR DESCRIPTION
## Summary\n- Add widelab-development/repo-to-landing-page to Community Skills → Marketing.\n\n## Validation\n- Verified the entry follows the documented format.\n- Description is 7 words, under the 10-word limit.\n- Verified the target repo is installable with `npx skills add widelab-development/repo-to-landing-page --list`.\n\n## Notes\nThis skill generates static landing pages from existing software/SaaS product repositories.