### PR TITLE
Add autopunk-media-skills (354 media production skills)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1502,6 +1502,7 @@ Official Google Cloud skills covering Firebase, BigQuery, Cloud Run, GKE, AlloyD
 - **[degausai/wonda](https://github.com/degausai/wonda)** - AI content creation: images, video, music, audio, editing, publishing
 - **[gitroomhq/postiz-agent](https://github.com/gitroomhq/postiz-agent)** - Schedule social media posts across 28+ platforms programmatically
 - **[indranilbanerjee/digital-marketing-pro](https://github.com/indranilbanerjee/digital-marketing-pro)** - 150-skill engagement methodology — 12-Part Strategy Flow, 25 specialist agents, EU AI Act Article 50 ready (C2PA signing), 6-platform AEO/GEO incl. Google AI Mode
+- **[ur-grue/autopunk-media-skills](https://github.com/ur-grue/autopunk-media-skills)** - 354 media production skills: TV documentary, journalism, YouTube, podcast, radio, newsletter, PR, screenwriting, data journalism, image prompting, translation. Quality-tested with G-Eval framework.
 
 </details>
 


### PR DESCRIPTION
## New Entry: autopunk-media-skills

**Section:** Community Skills > Marketing

354 Claude skills covering the full media production workflow. Built for TV producers,
journalists, podcasters, YouTubers, radio producers, newsletter writers, PR professionals,
screenwriters, and data journalists.

- 176 stable + 178 beta skills across 21 categories
- Quality-tested with G-Eval framework (7 dimensions, threshold 4.0/5)
- Includes image prompting, translation/localization, and media business skills
- MIT licensed

Repository: https://github.com/ur-grue/autopunk-media-skills
License: MIT