### PR TITLE
Add Skills by Cypress section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1495,6 +1495,17 @@ Official Google Cloud skills covering Firebase, BigQuery, Cloud Run, GKE, AlloyD
 
 </details>
 
+<details>
+<summary><h3 style="display:inline">Skills by Cypress</h3></summary>
+
+Official skills published by Cypress to help create, maintain, understand, and fix your Cypress tests. 3 skills.
+
+- **[cypress-io/cypress-author](https://github.com/cypress-io/ai-toolkit/tree/main/skills/cypress-author)** - Creates, updates, and fixes Cypress E2E and component tests.
+- **[cypress-io/cypress-explain](https://github.com/cypress-io/ai-toolkit/tree/main/skills/cypress-explain)** - Explains Cypress E2E and component tests, and answers questions about Cypress use and behavior. 
+- **[cypress-io/cypress-docs](https://github.com/cypress-io/ai-toolkit/tree/main/skills/cypress-docs)** - Search and extract Cypress information from official documentation.
+
+</details>
+
 ### Community Skills
 
 <details>


### PR DESCRIPTION
Adding 3 skills for utilizing the [Cypress](https://www.cypress.io) e2e & component testing framework. Skills are developed and maintained by the Cypress.io team, published under the github org. MIT licensed.

[Skills repository](https://www.github.com/cypress-io/ai-toolkit)

Supporting evidence: we have a sizable [NPM install base](https://www.npmjs.com/package/cypress). Early days on these skills but we're seeing steady uptake tracking [skills.sh metrics](https://www.skills.sh/cypress-io/ai-toolkit).

Appreciate your consideration, happy to make any adjustments.