### PR TITLE
Add llm-wiki-manager and prompt-architect to Context Engineering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 <a href="https://github.com/VoltAgent/voltagent">
      <img width="1500" alt="claude-skills" src="https://github.com/user-attachments/assets/0db54cfc-f3dd-4683-abbb-e4c01d9dfb5d" />
 </a>
@@ -1660,7 +1659,6 @@ Official Google Cloud skills covering Firebase, BigQuery, Cloud Run, GKE, AlloyD
 - **[awrshift/claude-memory-kit](https://github.com/awrshift/claude-memory-kit)** - Persistent memory with hooks, wiki, and daily synthesis for multi-project workflows
 - **[NeoLabHQ/prompt-engineering](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/customaize-agent/skills/prompt-engineering)** - Widely used prompt engineering techniques and patterns, including Anthropic best practices and agent persuasion principles.
 - **[sametbrr/llm-wiki-manager](https://github.com/sametbrr/llm-wiki-manager)** - Persistent LLM-managed personal wiki — the model writes, cross-references, and maintains the knowledge base while you curate sources. Implements Karpathy's LLM Wiki pattern with 8 operating modes.
-- **[sametbrr/prompt-architect](https://github.com/sametbrr/prompt-architect)** - Turns any rough idea into a domain-classified, quality-reviewed expert prompt — 25-domain taxonomy, 8 quality gates, TR and EN support.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -1659,6 +1659,8 @@ Official Google Cloud skills covering Firebase, BigQuery, Cloud Run, GKE, AlloyD
 - **[k-kolomeitsev/data-structure-protocol](https://github.com/k-kolomeitsev/data-structure-protocol)** - Graph-based long-term memory skill for AI (LLM) coding agents — faster context, fewer tokens, safer refactors
 - **[awrshift/claude-memory-kit](https://github.com/awrshift/claude-memory-kit)** - Persistent memory with hooks, wiki, and daily synthesis for multi-project workflows
 - **[NeoLabHQ/prompt-engineering](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/customaize-agent/skills/prompt-engineering)** - Widely used prompt engineering techniques and patterns, including Anthropic best practices and agent persuasion principles.
+- **[sametbrr/llm-wiki-manager](https://github.com/sametbrr/llm-wiki-manager)** - Persistent LLM-managed personal wiki — the model writes, cross-references, and maintains the knowledge base while you curate sources. Implements Karpathy's LLM Wiki pattern with 8 operating modes.
+- **[sametbrr/prompt-architect](https://github.com/sametbrr/prompt-architect)** - Turns any rough idea into a domain-classified, quality-reviewed expert prompt — 25-domain taxonomy, 8 quality gates, TR and EN support.
 
 </details>
 


### PR DESCRIPTION
## What this adds

Two Claude Code skills in the **Context Engineering** section:

### [llm-wiki-manager](https://github.com/sametbrr/llm-wiki-manager)
Persistent LLM-managed personal wiki — the model writes, cross-references, and maintains the knowledge base while you curate sources. Implements Karpathy's LLM Wiki pattern with 8 operating modes (bootstrap, ingest, query, update, diff-sweep, lint, audit, teach).
- ⭐ 37 stars | 7 forks
- License: MIT

### [prompt-architect](https://github.com/sametbrr/prompt-architect)
Turns any rough idea into a domain-classified, quality-reviewed expert prompt — 25-domain taxonomy, 8 quality gates, works in TR and EN. Classifies the domain, selects the right prompting patterns, drafts a refined prompt, and runs a self-review pass.
- License: MIT