### PR TITLE
Add skill: unifapi-agent/kol-pricing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1522,6 +1522,7 @@ Official Google Cloud skills covering Firebase, BigQuery, Cloud Run, GKE, AlloyD
 - **[degausai/wonda](https://github.com/degausai/wonda)** - AI content creation: images, video, music, audio, editing, publishing
 - **[gitroomhq/postiz-agent](https://github.com/gitroomhq/postiz-agent)** - Schedule social media posts across 28+ platforms programmatically
 - **[indranilbanerjee/digital-marketing-pro](https://github.com/indranilbanerjee/digital-marketing-pro)** - 150-skill engagement methodology — 12-Part Strategy Flow, 25 specialist agents, EU AI Act Article 50 ready (C2PA signing), 6-platform AEO/GEO incl. Google AI Mode
+- **[unifapi-agent/kol-pricing](https://github.com/unifapi-agent/skills/tree/main/skills/kol-pricing)** - Price creator campaigns with public social data
 
 </details>
 


### PR DESCRIPTION
## Summary

Adds the UnifAPI KOL pricing skill to the Community Skills > Marketing section.

## Notes

- The link points to the public skill package in `unifapi-agent/skills`.
- The skill includes a `SKILL.md` and supports creator campaign pricing workflows over public social data.
- The description stays under the repository's 10-word guideline.

## Validation

- Verified the skill URL returns HTTP 200.
- Ran `git diff --check`.
