### PR TITLE
feat: add collab-proof — AI collaboration evidence skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1587,6 +1587,7 @@ Official Google Cloud skills covering Firebase, BigQuery, Cloud Run, GKE, AlloyD
 - **[scarletkc/vexor](https://github.com/scarletkc/vexor)** - Vector-powered CLI for semantic file search with a Claude/Codex skill
 - **[obra/test-driven-development](https://github.com/obra/superpowers/blob/main/skills/test-driven-development/SKILL.md)** - Write tests before implementing code
 - **[obra/subagent-driven-development](https://github.com/obra/superpowers/blob/main/skills/subagent-driven-development/SKILL.md)** - Development using multiple sub-agents
+- **[dong7812/collab-proof](https://github.com/dong7812/collab-proof)** - Infers AI collaboration evidence from development sessions: signal filtering + ADHD 4-frame analysis to capture decisions, alternatives, and exact AI contribution — exports self-contained HTML proof artifact. Zero dependencies, SessionEnd hook for full automation.
 - **[obra/systematic-debugging](https://github.com/obra/superpowers/blob/main/skills/systematic-debugging/SKILL.md)** - Methodical problem-solving in code
 - **[obra/root-cause-tracing](https://github.com/obra/superpowers/blob/main/skills/root-cause-tracing/SKILL.md)** - Investigate and identify fundamental problems
 - **[obra/testing-skills-with-subagents](https://github.com/obra/superpowers/blob/main/skills/testing-skills-with-subagents/SKILL.md)** - Collaborative testing approaches


### PR DESCRIPTION
 ## What this adds
  
  **[collab-proof](https://github.com/dong7812/collab-proof)** — a Claude Code skill that infers AI collaboration evidence from development
  sessions.
  
  - Command: `/collab-proof`
  - Install: `git clone + ./install.sh` (zero external dependencies, Python stdlib only)
  - Full automation via `SessionEnd` hook
  
  ## Why it's different
  
  Existing session loggers record what was said. collab-proof **infers what mattered** — specifically the `AI contribution` field:
  
  > *"Claude identified the TOCTOU window between ZCARD and ZADD"*
  > vs
  > *"Developer-driven session. Claude executed instructions."*
  
  ## Pipeline
  
  1. **Signal detection** — git log + diff → HIGH / MEDIUM / LOW. Silences on routine sessions.
  2. **ADHD 4-frame analysis** — Technical / Uncertainty / Fork / AI-contribution lenses, scores and prunes weak frames.
  3. **Output** — DECISIONS.md + session narrative + self-contained HTML proof + WORKLOG
  
  ## Checklist
  
  - [x] Zero external dependencies (Python stdlib only)
  - [x] Single command install (`./install.sh`)
  - [x] SessionEnd hook for full automation
  - [x] Demo GIF included
  - [x] MIT license
