### PR TITLE
Add skill: wordbricks/onequery-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -1694,6 +1694,7 @@ Official Google Cloud skills covering Firebase, BigQuery, Cloud Run, GKE, AlloyD
 - **[meodai/skill.color-expert](https://github.com/meodai/skill.color-expert)** - Color science expert skill with 286K words of reference material covering OKLCH/OKLAB, palette generation, accessibility/contrast, color naming, pigment mixing, and historical color theory
 - **[aklofas/kicad-happy](https://github.com/aklofas/kicad-happy)** - AI-powered KiCad electronics design review and analysis
 - **[bitwize-music-studio/claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills)** - Full-lifecycle AI music album production
+- **[wordbricks/onequery-cli](https://github.com/wordbricks/skills/tree/main/skills/onequery-cli)** - Governed data-source queries for AI agents
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -1694,7 +1694,7 @@ Official Google Cloud skills covering Firebase, BigQuery, Cloud Run, GKE, AlloyD
 - **[meodai/skill.color-expert](https://github.com/meodai/skill.color-expert)** - Color science expert skill with 286K words of reference material covering OKLCH/OKLAB, palette generation, accessibility/contrast, color naming, pigment mixing, and historical color theory
 - **[aklofas/kicad-happy](https://github.com/aklofas/kicad-happy)** - AI-powered KiCad electronics design review and analysis
 - **[bitwize-music-studio/claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills)** - Full-lifecycle AI music album production
-- **[wordbricks/onequery-cli](https://github.com/wordbricks/skills/tree/main/skills/onequery-cli)** - CLI skill for safe, auditable agent queries against approved data sources
+- **[wordbricks/onequery-cli](https://github.com/wordbricks/skills/tree/main/skills/onequery-cli)** - CLI skill for safe, auditable queries for agents against approved data sources
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -1694,7 +1694,7 @@ Official Google Cloud skills covering Firebase, BigQuery, Cloud Run, GKE, AlloyD
 - **[meodai/skill.color-expert](https://github.com/meodai/skill.color-expert)** - Color science expert skill with 286K words of reference material covering OKLCH/OKLAB, palette generation, accessibility/contrast, color naming, pigment mixing, and historical color theory
 - **[aklofas/kicad-happy](https://github.com/aklofas/kicad-happy)** - AI-powered KiCad electronics design review and analysis
 - **[bitwize-music-studio/claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills)** - Full-lifecycle AI music album production
-- **[wordbricks/onequery-cli](https://github.com/wordbricks/skills/tree/main/skills/onequery-cli)** - Governed data-source queries for AI agents
+- **[wordbricks/onequery-cli](https://github.com/wordbricks/skills/tree/main/skills/onequery-cli)** - CLI skill for safe, auditable agent queries against approved data sources
 
 </details>
 


### PR DESCRIPTION
Adds wordbricks/onequery-cli to Community Skills / Specialized Domains.

OneQuery CLI is a skill for safe, auditable queries for agents against approved data sources.

Guideline check:
- Public skill link with author/org prefix.
- Short description, under 10 words in the README entry.
- Link works and no duplicate OneQuery entry was found before submission.
- Disclosure: I am affiliated with Wordbricks/OneQuery.