### PR TITLE
Add skill: jin-s13/ai-research-writing-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1679,6 +1679,7 @@ Official Google Cloud skills covering Firebase, BigQuery, Cloud Run, GKE, AlloyD
 - **[wanshuiyin/Auto-claude-code-research-in-sleep](https://github.com/wanshuiyin/Auto-claude-code-research-in-sleep)** - Autonomous ML research with cross-model review loops and GPU deployment
 - **[zechenzhangAGI/AI-research-SKILLs](https://github.com/zechenzhangAGI/AI-research-SKILLs)** - 77 AI research skills for model training, inference, and MLOps
 - **[Orchestra-Research/AI-research-SKILLs](https://github.com/Orchestra-Research/AI-research-SKILLs)** - 20-module AI research skill library for model architecture, training, and ML paper writing
+- **[jin-s13/ai-research-writing-skill](https://github.com/jin-s13/ai-research-writing-skill)** - Evidence-backed AI research paper drafting
 - **[komal-SkyNET/claude-skill-homeassistant](https://github.com/komal-SkyNET/claude-skill-homeassistant)** - Supercharge and manage Home Assistant workflows
 - **[more-io/apple-bridges](https://github.com/more-io/claude-apple-bridges)** - Native macOS app access — manage Apple Reminders, Calendar, Contacts, Notes, Mail, and tmux sessions via Swift CLI bridges
 - **[prompt-security/clawsec](https://github.com/prompt-security/clawsec)** - Security skill suite with drift detection, automated audits, and skill integrity verification


### PR DESCRIPTION
Adds AI Research Writing Skill, a Codex-compatible research writing skill for turning ML/AI repositories into evidence-backed, build-ready LaTeX paper drafts.

Repository:
https://github.com/jin-s13/ai-research-writing-skill

Highlights:
- Root SKILL.md entrypoint
- Claim-evidence workflow
- Citation verification and submission checks
- LaTeX templates for ML/AI venues
- End-to-end demo paper included