### PR TITLE
Add skill: dong7812/collab-proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -1587,6 +1587,7 @@ Official Google Cloud skills covering Firebase, BigQuery, Cloud Run, GKE, AlloyD
 - **[scarletkc/vexor](https://github.com/scarletkc/vexor)** - Vector-powered CLI for semantic file search with a Claude/Codex skill
 - **[obra/test-driven-development](https://github.com/obra/superpowers/blob/main/skills/test-driven-development/SKILL.md)** - Write tests before implementing code
 - **[obra/subagent-driven-development](https://github.com/obra/superpowers/blob/main/skills/subagent-driven-development/SKILL.md)** - Development using multiple sub-agents
+- **[dong7812/collab-proof](https://github.com/dong7812/collab-proof)** - Infers AI collaboration evidence from development sessions: signal filtering + ADHD 4-frame analysis to capture decisions, alternatives, and exact AI contribution — exports self-contained HTML proof artifact. Zero dependencies, SessionEnd hook for full automation.
 - **[obra/systematic-debugging](https://github.com/obra/superpowers/blob/main/skills/systematic-debugging/SKILL.md)** - Methodical problem-solving in code
 - **[obra/root-cause-tracing](https://github.com/obra/superpowers/blob/main/skills/root-cause-tracing/SKILL.md)** - Investigate and identify fundamental problems
 - **[obra/testing-skills-with-subagents](https://github.com/obra/superpowers/blob/main/skills/testing-skills-with-subagents/SKILL.md)** - Collaborative testing approaches

--- a/README.md
+++ b/README.md
@@ -1587,7 +1587,7 @@ Official Google Cloud skills covering Firebase, BigQuery, Cloud Run, GKE, AlloyD
 - **[scarletkc/vexor](https://github.com/scarletkc/vexor)** - Vector-powered CLI for semantic file search with a Claude/Codex skill
 - **[obra/test-driven-development](https://github.com/obra/superpowers/blob/main/skills/test-driven-development/SKILL.md)** - Write tests before implementing code
 - **[obra/subagent-driven-development](https://github.com/obra/superpowers/blob/main/skills/subagent-driven-development/SKILL.md)** - Development using multiple sub-agents
-- **[dong7812/collab-proof](https://github.com/dong7812/collab-proof)** - Infers AI collaboration evidence from development sessions: signal filtering + ADHD 4-frame analysis to capture decisions, alternatives, and exact AI contribution — exports self-contained HTML proof artifact. Zero dependencies, SessionEnd hook for full automation.
+- **[dong7812/collab-proof](https://github.com/dong7812/collab-proof)** - After a session, calibrates what Claude contributed vs what the developer drove.
 - **[obra/systematic-debugging](https://github.com/obra/superpowers/blob/main/skills/systematic-debugging/SKILL.md)** - Methodical problem-solving in code
 - **[obra/root-cause-tracing](https://github.com/obra/superpowers/blob/main/skills/root-cause-tracing/SKILL.md)** - Investigate and identify fundamental problems
 - **[obra/testing-skills-with-subagents](https://github.com/obra/superpowers/blob/main/skills/testing-skills-with-subagents/SKILL.md)** - Collaborative testing approaches


### PR DESCRIPTION
Adding **[dong7812/collab-proof](https://github.com/dong7812/collab-proof)** to Development and Testing.

Records what Claude contributed vs what the developer drove.