### PR TITLE
Add skill: AutomateLab-tech/agency-os

### DIFF
--- a/README.md
+++ b/README.md
@@ -1561,6 +1561,7 @@ Official Google Cloud skills covering Firebase, BigQuery, Cloud Run, GKE, AlloyD
 - **[deusyu/translate-book](https://github.com/deusyu/translate-book)** - Translate books (PDF/DOCX/EPUB) via parallel sub-agents with resume
 - **[mvanhorn/last30days-skill](https://github.com/mvanhorn/last30days-skill)** - Research any topic across Reddit, X, YouTube, HN, Polymarket, and the web, ranked by upvotes, likes, and real money instead of editors
 - **[santifer/career-ops](https://github.com/santifer/career-ops)** - 14-skill collection for AI-powered job search: JD evaluation with A-F scoring, ATS-optimized PDF generation, portal scanners (Greenhouse/Ashby/Lever), interview prep with STAR+R, batch processing, and a Go dashboard TUI
+- **[AutomateLab-tech/agency-os](https://github.com/AutomateLab-tech/agency-os)** - Run an AI agency from a single Notion board
 
 </details>
 


### PR DESCRIPTION
Adds [agency-os](https://github.com/AutomateLab-tech/agency-os) to the **Productivity and Collaboration** community section.

agency-os turns a Notion board into the control plane for a small AI agency. Claude Code (or any MCP-compatible agent) plans incoming work into dependency-sequenced subtasks, dispatches each to the right model, and collects results back into Notion. Ships as both a Claude Code plugin and an MCP server — install with `/plugin install https://github.com/AutomateLab-tech/agency-os` or point any MCP host at the server.

- MIT licensed, actively maintained
- Works with Claude Code, Cursor, Cline, and any MCP-compatible agent runtime
- Production-derived: extracted from the editorial + client pipeline running automatelab.tech