### PR TITLE
Add skill: sirmarkz/staff-engineer-mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1572,6 +1572,7 @@ Official Google Cloud skills covering Firebase, BigQuery, Cloud Run, GKE, AlloyD
 - **[antonbabenko/terraform-skill](https://github.com/antonbabenko/terraform-skill)** - Terraform and OpenTofu patterns: testing, modules, state, CI/CD.
 - **[zxkane/aws-skills](https://github.com/zxkane/aws-skills)** - AWS development with infrastructure automation and cloud architecture patterns
 - **[Rootly-AI-Labs/rootly-incident-responder](https://github.com/Rootly-AI-Labs/Rootly-MCP-server/blob/main/examples/skills/rootly-incident-responder.md)** - AI-powered incident response with ML similarity matching, solution suggestions, and on-call coordination. Requires [Rootly MCP Server](https://github.com/Rootly-AI-Labs/Rootly-MCP-server)
+- **[sirmarkz/staff-engineer-mode](https://github.com/sirmarkz/staff-engineer-mode)** - Major-outage lessons across engineering design and operations
 - **[conorluddy/ios-simulator-skill](https://github.com/conorluddy/ios-simulator-skill)** - Control iOS Simulator
 - **[ramzesenok/iOS-Accessibility-Audit-Skill](https://github.com/ramzesenok/iOS-Accessibility-Audit-Skill)** - Audit iOS App against Accessibility norms
 - **[truongduy2611/app-store-preflight-skills](https://github.com/truongduy2611/app-store-preflight-skills)** - Scan iOS/macOS projects to catch common mistakes that lead to App Store rejection before submission


### PR DESCRIPTION
Adds Staff Engineer Mode to Community Skills under Development and Testing.

Staff Engineer Mode packages major-outage lessons as one router skill. It routes engineering design, reliability, security, delivery, and operations prompts to 54 specialist references, with documented support across Claude Code, Codex, Cursor, OpenCode, Copilot, and Gemini.

Validation:
- Checked for an existing Staff Engineer Mode entry
- git diff --check