### PR TITLE
Add skill: W-Y-P/credit-risk-model

### DIFF
--- a/README.md
+++ b/README.md
@@ -1694,6 +1694,7 @@ Official Google Cloud skills covering Firebase, BigQuery, Cloud Run, GKE, AlloyD
 - **[meodai/skill.color-expert](https://github.com/meodai/skill.color-expert)** - Color science expert skill with 286K words of reference material covering OKLCH/OKLAB, palette generation, accessibility/contrast, color naming, pigment mixing, and historical color theory
 - **[aklofas/kicad-happy](https://github.com/aklofas/kicad-happy)** - AI-powered KiCad electronics design review and analysis
 - **[bitwize-music-studio/claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills)** - Full-lifecycle AI music album production
+- **[W-Y-P/credit-risk-model](https://github.com/W-Y-P/credit-risk-model)** - Credit-risk modeling workflow for scorecards, LightGBM/XGBoost-style models, validation reports, and strategy analysis
 
 </details>
 


### PR DESCRIPTION
## Summary

- Adds W-Y-P/credit-risk-model to the Specialized Domains community skills section.
- The skill covers credit-risk scorecards, WOE/logistic regression, LightGBM/XGBoost-style modeling, validation reports, and strategy analysis.

## Validation

- Ran `git diff --check`.

## Notes

- Canonical skill repository: https://github.com/W-Y-P/credit-risk-model
- Indexed on Awesome Skills / skills.sh.