### PR TITLE
Add skill: stretchvancouver/stretch-ai-yoga

### DIFF
--- a/README.md
+++ b/README.md
@@ -1659,6 +1659,7 @@ Official Google Cloud skills covering Firebase, BigQuery, Cloud Run, GKE, AlloyD
 - **[k-kolomeitsev/data-structure-protocol](https://github.com/k-kolomeitsev/data-structure-protocol)** - Graph-based long-term memory skill for AI (LLM) coding agents — faster context, fewer tokens, safer refactors
 - **[awrshift/claude-memory-kit](https://github.com/awrshift/claude-memory-kit)** - Persistent memory with hooks, wiki, and daily synthesis for multi-project workflows
 - **[NeoLabHQ/prompt-engineering](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/customaize-agent/skills/prompt-engineering)** - Widely used prompt engineering techniques and patterns, including Anthropic best practices and agent persuasion principles.
+- **[stretchvancouver/stretch-ai-yoga](https://github.com/stretchvancouver/stretch-ai-yoga)** - Self-applied cognitive training practices for AI agents
 
 </details>
 


### PR DESCRIPTION
## Skill

**[stretchvancouver/stretch-ai-yoga](https://github.com/stretchvancouver/stretch-ai-yoga)** — Self-applied cognitive training practices for AI agents

## Category

Context Engineering

## About

A structured set of seven practices an agent runs on itself — at session start, before tool use, during long-context work, and at close. Each practice targets a specific failure mode: hasty action, attention drift, premature certainty, objective collapse, approval-seeking, and context noise. Practices are Markdown files with a carry-forward instruction the agent holds for the session.

Built and maintained by [STRETCH](https://stretchvancouver.com), an independent yoga studio in Vancouver.

- Public repo ✓
- SKILL.md present ✓
- MIT license ✓
- 35+ stars, 2 forks