### PR TITLE
feat: add Chase-Key/aurelion-skills to Context Engineering section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1659,6 +1659,7 @@ Official Google Cloud skills covering Firebase, BigQuery, Cloud Run, GKE, AlloyD
 - **[k-kolomeitsev/data-structure-protocol](https://github.com/k-kolomeitsev/data-structure-protocol)** - Graph-based long-term memory skill for AI (LLM) coding agents — faster context, fewer tokens, safer refactors
 - **[awrshift/claude-memory-kit](https://github.com/awrshift/claude-memory-kit)** - Persistent memory with hooks, wiki, and daily synthesis for multi-project workflows
 - **[NeoLabHQ/prompt-engineering](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/customaize-agent/skills/prompt-engineering)** - Widely used prompt engineering techniques and patterns, including Anthropic best practices and agent persuasion principles.
+- **[Chase-Key/aurelion-skills](https://github.com/Chase-Key/aurelion-skills)** - AURELION 5-floor cognitive architecture skill suite: structured knowledge templates (Foundation → Vision), persistent session context, and agentic reasoning scaffolds. Compatible with Claude Code, Cursor, Codex, Copilot, Windsurf, Gemini CLI, and all Open Plugins-compatible agents.
 
 </details>
 


### PR DESCRIPTION
## Summary

Adding **[Chase-Key/aurelion-skills](https://github.com/Chase-Key/aurelion-skills)** to the Context Engineering community section.

## About this skill suite

AURELION is a 5-floor cognitive architecture framework for structured knowledge management in agentic AI systems. The skill suite provides:

- **Structured context templates** organized on a 5-floor hierarchy (Foundation → Vision) that prevent context drift in long-running agent sessions
- **Session continuity scaffolds** for multi-session work with persistent knowledge state
- **Domain-specific reasoning patterns** for knowledge retrieval, strategic planning, and agent orchestration
- **Open Plugins spec compliant** — includes \.plugin/plugin.json\ manifest for auto-detection

Compatible with Claude Code (\.claude/skills/\), Cursor (\.cursor/skills/\), Codex (\.agents/skills/\), GitHub Copilot (\.github/skills/\), Windsurf (\.windsurf/skills/\), Gemini CLI (\.gemini/skills/\), and all Open Plugins-compatible agents.

## Why Context Engineering

The 5-floor architecture directly addresses the core problems this section covers: context degradation over long sessions, context poisoning from ambiguous instructions, and lost-in-middle failures. Each floor (Foundation, Operations, Relations, Strategy, Vision) scopes what context is loaded and when — which is a structural solution to context management rather than a prompt-engineering workaround.

The skills have been in active use across multiple AI agent projects (memoria-engine, rell-eco, aurelion-eco) since February 2026.