### PR TITLE
Add skill: preset-io/agent-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,21 +53,22 @@ The most contributed Agent Skills repository, built and maintained together with
 
 | | | | | 
 |---|---|---|---|
-| [Claude](#official-claude-skills) | [VoltAgent](#skills-by-voltagent) | [Angular](#skills-by-angular) | [Composio](#skills-by-composio-team) | [Supabase](#skills-by-supabase-team) |
-| [Google Gemini](#skills-by-google-gemini) | [Stripe](#skills-by-stripe-team) | [Courier](#skills-by-courier) | [CallStack](#skills-by-callstack) |
-| [Expo](#skills-by-expo-team) | [Better Auth](#skills-by-better-auth-team) | [Tinybird](#skills-by-tinybird-team) | [HashiCorp](#skills-by-hashicorp-team-for-terraform) |
-| [Sanity](#skills-by-sanity-team) | [Firecrawl](#skills-by-firecrawl-team) | [Neon](#skills-by-neon-team) | [ClickHouse](#skill-by-clickhouse) |
-| [Remotion](#skills-by-remotion) | [Replicate](#skills-by-replicate) | [Typefully](#skills-by-typefully) | [Vercel](#skills-by-vercel-engineering-team) |
-| [Cloudflare](#skills-by-cloudflare-team) | [Netlify](#skills-by-netlify-team) | [Google Labs (Stitch)](#skills-by-google-labs-stitch) | [Google Workspace CLI](#skills-by-google-workspace-cli) |
-| [Hugging Face](#skills-by-hugging-face-team) | [Trail of Bits](#security-skills-by-trail-of-bits-team) | [Sentry](#skills-by-sentry-team-for-their-dev-team) | [Microsoft](#skills-by-microsoft) |
-| [fal.ai](#skills-by-falai-team) | [WordPress](#skills-by-wordpress-development-team) | [OpenAI](#skills-by-openai) | [Figma](#skills-by-figma) |
-| [Corey Haines](#marketing-skills-by-corey-haines) | [Binance](#skills-by-binance) | [Dean Peters](#product-manager-skills-by-dean-peters) | [Paweł Huryn](#product-management-skills-by-pawel-huryn) |
-| [MiniMax](#skills-by-minimax-team) | [DuckDB](#skills-by-duckdb) | [GSAP](#skills-by-gsap-greensock) | [Garry Tan (gstack)](#skills-by-garry-tan-gstack) |
-| [Notion](#skills-by-notion) | [Resend](#skills-by-resend) | [Addy Osmani (Web Quality)](#skills-by-addy-osmani-web-quality) | [MongoDB](#skills-by-mongodb) |
-| [Kim Barrett (Advertising)](#advertising-skills-by-kim-barrett) | [Apollo GraphQL](#skills-by-apollo-graphql) | [Auth0](#skills-by-auth0) | [Brave](#skills-by-brave) |
-| [Browserbase](#skills-by-browserbase) | [CodeRabbit](#skills-by-coderabbit) | [Coinbase](#skills-by-coinbase) | [Datadog Labs](#skills-by-datadog-labs) |
-| [Firebase](#skills-by-firebase) | [Flutter](#skills-by-flutter) | [Venice.ai](#skills-by-veniceai) | [Red Hat](#skills-by-redhat) | [Preset](#skills-by-preset) |
-| [Redis](#skills-by-redis) | [NVIDIA](#skills-by-nvidia) | [Google Cloud](#skills-by-google-cloud) | [Community](#community-skills) | [Quality Standards](#skill-quality-standards) |
+| [Claude](#official-claude-skills) | [VoltAgent](#skills-by-voltagent) | [Angular](#skills-by-angular) | [Composio](#skills-by-composio-team) |
+| [Supabase](#skills-by-supabase-team) | [Google Gemini](#skills-by-google-gemini) | [Stripe](#skills-by-stripe-team) | [Courier](#skills-by-courier) |
+| [CallStack](#skills-by-callstack) | [Expo](#skills-by-expo-team) | [Better Auth](#skills-by-better-auth-team) | [Tinybird](#skills-by-tinybird-team) |
+| [HashiCorp](#skills-by-hashicorp-team-for-terraform) | [Sanity](#skills-by-sanity-team) | [Firecrawl](#skills-by-firecrawl-team) | [Neon](#skills-by-neon-team) |
+| [ClickHouse](#skill-by-clickhouse) | [Remotion](#skills-by-remotion) | [Replicate](#skills-by-replicate) | [Typefully](#skills-by-typefully) |
+| [Vercel](#skills-by-vercel-engineering-team) | [Cloudflare](#skills-by-cloudflare-team) | [Netlify](#skills-by-netlify-team) | [Google Labs (Stitch)](#skills-by-google-labs-stitch) |
+| [Google Workspace CLI](#skills-by-google-workspace-cli) | [Hugging Face](#skills-by-hugging-face-team) | [Trail of Bits](#security-skills-by-trail-of-bits-team) | [Sentry](#skills-by-sentry-team-for-their-dev-team) |
+| [Microsoft](#skills-by-microsoft) | [fal.ai](#skills-by-falai-team) | [WordPress](#skills-by-wordpress-development-team) | [OpenAI](#skills-by-openai) |
+| [Figma](#skills-by-figma) | [Corey Haines](#marketing-skills-by-corey-haines) | [Binance](#skills-by-binance) | [Dean Peters](#product-manager-skills-by-dean-peters) |
+| [Paweł Huryn](#product-management-skills-by-pawel-huryn) | [MiniMax](#skills-by-minimax-team) | [DuckDB](#skills-by-duckdb) | [GSAP](#skills-by-gsap-greensock) |
+| [Garry Tan (gstack)](#skills-by-garry-tan-gstack) | [Notion](#skills-by-notion) | [Resend](#skills-by-resend) | [Addy Osmani (Web Quality)](#skills-by-addy-osmani-web-quality) |
+| [MongoDB](#skills-by-mongodb) | [Kim Barrett (Advertising)](#advertising-skills-by-kim-barrett) | [Apollo GraphQL](#skills-by-apollo-graphql) | [Auth0](#skills-by-auth0) |
+| [Brave](#skills-by-brave) | [Browserbase](#skills-by-browserbase) | [CodeRabbit](#skills-by-coderabbit) | [Coinbase](#skills-by-coinbase) |
+| [Datadog Labs](#skills-by-datadog-labs) | [Firebase](#skills-by-firebase) | [Flutter](#skills-by-flutter) | [Venice.ai](#skills-by-veniceai) |
+| [Red Hat](#skills-by-redhat) | [Preset](#skills-by-preset) | [Redis](#skills-by-redis) | [NVIDIA](#skills-by-nvidia) |
+| [Google Cloud](#skills-by-google-cloud) | [Community](#community-skills) | [Quality Standards](#skill-quality-standards) |  |
 
 
 ## Ecosystem Tools
@@ -1505,14 +1506,14 @@ Extend the power of AI across your organization with a curated library of skills
 
 </details>
 
-<details open>
+<details>
 <summary><h3 style="display:inline">Skills by Preset</h3></summary>
 
 Official skills for Preset, Apache Superset, and Snowflake Cortex workflows.
 
-- **[preset-io/preset-api-skills](https://github.com/preset-io/agent-skills/tree/master/plugins/preset-api-skills)** - Direct Preset, Superset, and Cortex API workflows
-- **[preset-io/preset-mcp-skills](https://github.com/preset-io/agent-skills/tree/master/plugins/preset-mcp-skills)** - Superset MCP workflows for dashboards, datasets, SQL Lab
-- **[preset-io/preset-cli-skills](https://github.com/preset-io/agent-skills/tree/master/plugins/preset-cli-skills)** - Preset sup CLI workflows for exports, SQL, CI
+- **[preset-io/preset-api-skills](https://github.com/preset-io/agent-skills/tree/master/plugins/preset-api-skills)** - Direct Preset, Superset, and Cortex API workflows.
+- **[preset-io/preset-mcp-skills](https://github.com/preset-io/agent-skills/tree/master/plugins/preset-mcp-skills)** - Superset MCP workflows for dashboards, datasets, and SQL Lab.
+- **[preset-io/preset-cli-skills](https://github.com/preset-io/agent-skills/tree/master/plugins/preset-cli-skills)** - Preset CLI (`sup`) workflows for exports, SQL, and CI.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ The most contributed Agent Skills repository, built and maintained together with
 | [Notion](#skills-by-notion) | [Resend](#skills-by-resend) | [Addy Osmani (Web Quality)](#skills-by-addy-osmani-web-quality) | [MongoDB](#skills-by-mongodb) |
 | [Kim Barrett (Advertising)](#advertising-skills-by-kim-barrett) | [Apollo GraphQL](#skills-by-apollo-graphql) | [Auth0](#skills-by-auth0) | [Brave](#skills-by-brave) |
 | [Browserbase](#skills-by-browserbase) | [CodeRabbit](#skills-by-coderabbit) | [Coinbase](#skills-by-coinbase) | [Datadog Labs](#skills-by-datadog-labs) |
-| [Firebase](#skills-by-firebase) | [Flutter](#skills-by-flutter) | [Venice.ai](#skills-by-veniceai) | [Red Hat](#skills-by-redhat) | [Community](#community-skills) |  | [Redis](#skills-by-redis) | [NVIDIA](#skills-by-nvidia) | [Google Cloud](#skills-by-google-cloud) | [Quality Standards](#skill-quality-standards) |
+| [Firebase](#skills-by-firebase) | [Flutter](#skills-by-flutter) | [Venice.ai](#skills-by-veniceai) | [Red Hat](#skills-by-redhat) | [Preset](#skills-by-preset) |
+| [Redis](#skills-by-redis) | [NVIDIA](#skills-by-nvidia) | [Google Cloud](#skills-by-google-cloud) | [Community](#community-skills) | [Quality Standards](#skill-quality-standards) |
 
 
 ## Ecosystem Tools
@@ -1501,6 +1502,20 @@ Extend the power of AI across your organization with a curated library of skills
 - **[redhat/openshift-skillpack](https://catalog.redhat.com/en/ai/skills/detail/agentic-skill-pack-for-red-hat-openshift)** - Provision, inventory, and report on OpenShift clusters — spanning Assisted Installer, OCM, ROSA, ARO, and kubeconfig fleets — through a single conversational workflow.
 
 - **[redhat/openshift-virtualization](https://catalog.redhat.com/en/ai/skills/detail/agentic-skill-pack-for-red-hat-openshift-virtualization)** - Manage the full VM lifecycle on OpenShift Virtualization — create, clone, snapshot, restore, rebalance, and report — through a single conversational workflow.
+
+</details>
+
+<details open>
+<summary><h3 style="display:inline">Skills by Preset</h3></summary>
+
+Official skills for Preset, Apache Superset, and Snowflake Cortex workflows.
+
+- **[preset-io/preset-api-skills](https://github.com/preset-io/agent-skills/tree/master/plugins/preset-api-skills)** - Direct Preset, Superset, and Cortex API workflows
+- **[preset-io/preset-mcp-skills](https://github.com/preset-io/agent-skills/tree/master/plugins/preset-mcp-skills)** - Superset MCP workflows for dashboards, datasets, SQL Lab
+- **[preset-io/preset-cli-skills](https://github.com/preset-io/agent-skills/tree/master/plugins/preset-cli-skills)** - Preset sup CLI workflows for exports, SQL, CI
+
+</details>
+
 <details>
 <summary><h3 style="display:inline">Skills by Cypress</h3></summary>
 


### PR DESCRIPTION
## Summary
- Add a Preset official skills section with package-level links.
- Link Preset API, MCP, and CLI skill packages from preset-io/agent-skills.
- Add Preset to the official skills table of contents.

## Checks
- git diff --check
- Verified all three new GitHub links return HTTP 200