### PR TITLE
Add skill: daman8271/the-perfect-orchestrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1659,6 +1659,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[foryourhealth111-pixel/Vibe-Skills](https://github.com/foryourhealth111-pixel/Vibe-Skills)** - A skills governed plug-and-play harness for staged, test-driven skill orchestration
 - **[metalbear-co/skills](https://github.com/metalbear-co/skills)** - Skills that let agents code and test against your Kubernetes cluster using mirrord
 - **[dembrandt/dembrandt-skills](https://github.com/dembrandt/dembrandt-skills)** - UX and design system skills: hierarchy, typography, accessibility, interactions
+- **[daman8271/the-perfect-orchestrator](https://github.com/daman8271/the-perfect-orchestrator)** - Orchestrate tmux Claude worker fleets with adversarial result verification
 
 </details>
 


### PR DESCRIPTION
Adds **daman8271/the-perfect-orchestrator** to *Community Skills → Development and Testing* (end of section, per CONTRIBUTING).

One lead Claude Code session commands N autonomous workers in tmux over a shared file-based message bus, with adversarial verification of completed worker results before they're trusted. MIT, pure bash + tmux, zero daemons.

**Requirements check:**
- Public repository with a working skill: https://github.com/daman8271/the-perfect-orchestrator (skill at `skill/SKILL.md`, also installable as a Claude Code plugin)
- Documentation: full README + SKILL.md, plus a recorded real fleet run in `docs/realrun-2026-06-06/` as evidence it works
- Author prefix included in the name: yes
- Description is 9 words
- Links verified working

**Full disclosure on the maturity bar:** this is a recently released project (v0.1.0, June 2026) and I won't pretend otherwise — no install counts or popularity claims. The recorded, fidelity-checked fleet run is in the repo so the "adversarial verification" claim can be validated directly rather than taken on trust. If you'd rather see it mature and gain users first, I completely understand — happy to close and resubmit later.
