### PR TITLE
Add skill: runapi-ai/cli-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1593,7 +1593,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[ramzesenok/iOS-Accessibility-Audit-Skill](https://github.com/ramzesenok/iOS-Accessibility-Audit-Skill)** - Audit iOS App against Accessibility norms
 - **[truongduy2611/app-store-preflight-skills](https://github.com/truongduy2611/app-store-preflight-skills)** - Scan iOS/macOS projects to catch common mistakes that lead to App Store rejection before submission
 - **[coderabbitai/skills](https://github.com/coderabbitai/skills)** - Code review and PR autofix workflows for coding agents
-- **[runapi-ai/cli-skill](https://github.com/runapi-ai/cli-skill)** - Use the RunAPI CLI to run AI image, video, music, audio, and other model API jobs
+- **[runapi-ai/cli-skill](https://github.com/runapi-ai/cli-skill)** - Generate AI images, videos, and music/audio through the RunAPI CLI, plus run other model API jobs
 - **[sanjay3290/postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres)** - Execute safe read-only SQL queries against PostgreSQL databases
 - **[sanjay3290/deep-research](https://github.com/sanjay3290/ai-skills/tree/main/skills/deep-research)** - Autonomous multi-step research using Gemini Deep Research Agent
 - **[jthack/ffuf-claude-skill](https://github.com/jthack/ffuf_claude_skill)** - Web fuzzing with ffuf

--- a/README.md
+++ b/README.md
@@ -1593,7 +1593,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[ramzesenok/iOS-Accessibility-Audit-Skill](https://github.com/ramzesenok/iOS-Accessibility-Audit-Skill)** - Audit iOS App against Accessibility norms
 - **[truongduy2611/app-store-preflight-skills](https://github.com/truongduy2611/app-store-preflight-skills)** - Scan iOS/macOS projects to catch common mistakes that lead to App Store rejection before submission
 - **[coderabbitai/skills](https://github.com/coderabbitai/skills)** - Code review and PR autofix workflows for coding agents
-- **[runapi-ai/cli-skill](https://github.com/runapi-ai/cli-skill)** - Run image, video, music, audio, and other model API jobs through the RunAPI CLI
+- **[runapi-ai/cli-skill](https://github.com/runapi-ai/cli-skill)** - Use the RunAPI CLI to run AI image, video, music, audio, and other model API jobs
 - **[sanjay3290/postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres)** - Execute safe read-only SQL queries against PostgreSQL databases
 - **[sanjay3290/deep-research](https://github.com/sanjay3290/ai-skills/tree/main/skills/deep-research)** - Autonomous multi-step research using Gemini Deep Research Agent
 - **[jthack/ffuf-claude-skill](https://github.com/jthack/ffuf_claude_skill)** - Web fuzzing with ffuf

--- a/README.md
+++ b/README.md
@@ -1593,6 +1593,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[ramzesenok/iOS-Accessibility-Audit-Skill](https://github.com/ramzesenok/iOS-Accessibility-Audit-Skill)** - Audit iOS App against Accessibility norms
 - **[truongduy2611/app-store-preflight-skills](https://github.com/truongduy2611/app-store-preflight-skills)** - Scan iOS/macOS projects to catch common mistakes that lead to App Store rejection before submission
 - **[coderabbitai/skills](https://github.com/coderabbitai/skills)** - Code review and PR autofix workflows for coding agents
+- **[runapi-ai/cli-skill](https://github.com/runapi-ai/cli-skill)** - Install and use RunAPI CLI for model API jobs
 - **[sanjay3290/postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres)** - Execute safe read-only SQL queries against PostgreSQL databases
 - **[sanjay3290/deep-research](https://github.com/sanjay3290/ai-skills/tree/main/skills/deep-research)** - Autonomous multi-step research using Gemini Deep Research Agent
 - **[jthack/ffuf-claude-skill](https://github.com/jthack/ffuf_claude_skill)** - Web fuzzing with ffuf

--- a/README.md
+++ b/README.md
@@ -1593,7 +1593,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[ramzesenok/iOS-Accessibility-Audit-Skill](https://github.com/ramzesenok/iOS-Accessibility-Audit-Skill)** - Audit iOS App against Accessibility norms
 - **[truongduy2611/app-store-preflight-skills](https://github.com/truongduy2611/app-store-preflight-skills)** - Scan iOS/macOS projects to catch common mistakes that lead to App Store rejection before submission
 - **[coderabbitai/skills](https://github.com/coderabbitai/skills)** - Code review and PR autofix workflows for coding agents
-- **[runapi-ai/cli-skill](https://github.com/runapi-ai/cli-skill)** - Install and use RunAPI CLI for model API jobs
+- **[runapi-ai/cli-skill](https://github.com/runapi-ai/cli-skill)** - Run image, video, music, audio, and other model API jobs through the RunAPI CLI
 - **[sanjay3290/postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres)** - Execute safe read-only SQL queries against PostgreSQL databases
 - **[sanjay3290/deep-research](https://github.com/sanjay3290/ai-skills/tree/main/skills/deep-research)** - Autonomous multi-step research using Gemini Deep Research Agent
 - **[jthack/ffuf-claude-skill](https://github.com/jthack/ffuf_claude_skill)** - Web fuzzing with ffuf


### PR DESCRIPTION
Adds runapi-ai/cli-skill to Development and Testing for generating AI images, videos, and music/audio from agent workflows, plus running other model API jobs.