### PR TITLE
Add Pluribus context receipt skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1674,6 +1674,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[muratcankoylan/tool-design](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/tool-design)** - Build tools that agents can use effectively, including architectural reduction patterns
 - **[muratcankoylan/evaluation](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/evaluation)** - Build evaluation frameworks for agent systems
 - **[k-kolomeitsev/data-structure-protocol](https://github.com/k-kolomeitsev/data-structure-protocol)** - Graph-based long-term memory skill for AI (LLM) coding agents — faster context, fewer tokens, safer refactors
+- **[caioribeiroclw-pixel/pluribus](https://github.com/caioribeiroclw-pixel/pluribus/tree/main/skills)** - Context receipt skills for AI coding agents: capture which instruction bundles, skills, MCP/tool scopes, and policy constraints were active, withheld, or unverified across tools.
 - **[awrshift/claude-memory-kit](https://github.com/awrshift/claude-memory-kit)** - Persistent memory with hooks, wiki, and daily synthesis for multi-project workflows
 - **[NeoLabHQ/prompt-engineering](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/customaize-agent/skills/prompt-engineering)** - Widely used prompt engineering techniques and patterns, including Anthropic best practices and agent persuasion principles.
 


### PR DESCRIPTION
Adds Pluribus' two Agent Skills (`context-receipts` and `skill-policy-receipts`) under the Context Engineering section.

Why I think it fits this list:
- the repo exposes canonical `skills/*/SKILL.md` files and is packaged on npm as `pluribus-context@0.3.37`
- the skills are about context/provenance boundaries, not persistent memory or orchestration
- `context-receipts` is already indexed by ClaudSkills, and the source paths are kept stable for directory consumers

I kept this to one line and linked to the `skills/` folder so reviewers can inspect both recipes directly.