### PR TITLE
Add skill: jbegarek/potato-review

### DIFF
--- a/README.md
+++ b/README.md
@@ -1578,6 +1578,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[deusyu/translate-book](https://github.com/deusyu/translate-book)** - Translate books (PDF/DOCX/EPUB) via parallel sub-agents with resume
 - **[mvanhorn/last30days-skill](https://github.com/mvanhorn/last30days-skill)** - Research any topic across Reddit, X, YouTube, HN, Polymarket, and the web, ranked by upvotes, likes, and real money instead of editors
 - **[santifer/career-ops](https://github.com/santifer/career-ops)** - 14-skill collection for AI-powered job search: JD evaluation with A-F scoring, ATS-optimized PDF generation, portal scanners (Greenhouse/Ashby/Lever), interview prep with STAR+R, batch processing, and a Go dashboard TUI
+- **[jbegarek/potato-review](https://github.com/jbegarek/potato-review-skill/tree/main/potato-review)** - Audit documents and sources with configurable POTATO review rigor
 
 </details>
 


### PR DESCRIPTION
Adds the POTATO Review skill to the Community Skills / Productivity and Collaboration section. The skill provides configurable artifact, document, source, and citation review using POTATO review variants and rigor levels.