### PR TITLE
Add skill: Alex0nder/mailagent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1661,6 +1661,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[metalbear-co/skills](https://github.com/metalbear-co/skills)** - Skills that let agents code and test against your Kubernetes cluster using mirrord
 - **[dembrandt/dembrandt-skills](https://github.com/dembrandt/dembrandt-skills)** - UX and design system skills: hierarchy, typography, accessibility, interactions
 - **[GanyuanRan/Aegis](https://github.com/GanyuanRan/Aegis)** - Evidence-driven method pack for AI coding agents
+- **[Alex0nder/mailagent](https://github.com/Alex0nder/MailAgent/tree/main/skills/mailagent)** - Disposable inboxes for signup OTP and magic links
 
 </details>
 


### PR DESCRIPTION
## Alex0nder/mailagent

Disposable inboxes for agent signup flows — OTP and magic link extraction via MCP.

- Repo: https://github.com/Alex0nder/MailAgent
- Skill: `skills/mailagent/SKILL.md`
- Install: `npx skills add Alex0nder/MailAgent --skill mailagent`
- Pin: `gh skill install Alex0nder/MailAgent mailagent --pin skills-0.2.5`
- Docs: https://webmailagent.com/docs/agent-skills.html
- MIT · 23 MCP tools · Playwright + simulate autotests

Category: Community → Development and Testing

Made with [Cursor](https://cursor.com)