### PR TITLE
Add skills: indranilbanerjee/contentforge + socialforge; refresh digital-marketing-pro count

### DIFF
--- a/README.md
+++ b/README.md
@@ -1538,7 +1538,9 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[Eronred/aso-skills](https://github.com/Eronred/aso-skills)** - 30+ App Store Optimization skills for keyword research, metadata optimization, competitor analysis, creative optimization, and mobile growth strategies via Appeeky API
 - **[degausai/wonda](https://github.com/degausai/wonda)** - AI content creation: images, video, music, audio, editing, publishing
 - **[gitroomhq/postiz-agent](https://github.com/gitroomhq/postiz-agent)** - Schedule social media posts across 28+ platforms programmatically
-- **[indranilbanerjee/digital-marketing-pro](https://github.com/indranilbanerjee/digital-marketing-pro)** - 150-skill engagement methodology — 12-Part Strategy Flow, 25 specialist agents, EU AI Act Article 50 ready (C2PA signing), 6-platform AEO/GEO incl. Google AI Mode
+- **[indranilbanerjee/digital-marketing-pro](https://github.com/indranilbanerjee/digital-marketing-pro)** - 158-skill engagement methodology — 12-Part Strategy Flow, 25 specialist agents, EU AI Act Article 50 ready (C2PA signing), 6-platform AEO/GEO incl. Google AI Mode. Native on 8 platforms incl. Hermes Agent + OpenClaw
+- **[indranilbanerjee/contentforge](https://github.com/indranilbanerjee/contentforge)** - 11-phase enterprise content pipeline — 21 skills, 13 agents, 29-pattern AI humanizer, fact-checker subagent, real .docx output with C2PA signing for EU AI Act Article 50
+- **[indranilbanerjee/socialforge](https://github.com/indranilbanerjee/socialforge)** - Asset-first social media production — 16 skills, 25 commands, AI image (Vertex AI Nano Banana Pro) + AI video (Kling v3.0 Pro), 7-platform copy adaptation, C2PA signing
 
 </details>
 


### PR DESCRIPTION
## What this PR does

Under **Community Skills → Marketing**:

### 1. Update — `indranilbanerjee/digital-marketing-pro`
The existing entry was last updated when DMP was 150 skills. Refreshing to current state:
- **150 → 158 skills** (v3.7.5 added 3 close-the-loop skills, v3.10.0 added GSC AI Performance, v3.11.0 added 4 SEO skills)
- Added note that it now runs natively on **8 platforms** (Claude Code · Cowork · OpenAI Codex · Cursor 2.5+ · GitHub Copilot CLI · Google Antigravity 2.0 · **Hermes Agent** · **OpenClaw**)

### 2. Add — `indranilbanerjee/contentforge`
Sister plugin in the same suite. Enterprise content production:
- **21 skills + 13 specialist agents** orchestrating an 11-phase pipeline
- **29-pattern AI-detection humanizer** (drafts pass GPTZero / Originality.ai)
- **Fact-checker subagent** with three-layer verification
- **Real .docx output** with embedded SEO + Quality + Production + Internal-Link appendices
- **C2PA-signed** for EU AI Act Article 50 compliance
- **Per-phase checkpoint resume** — interrupted runs continue from last completed phase
- **53 release-consistency tests passing**

### 3. Add — `indranilbanerjee/socialforge`
Third plugin in the suite. Agency-grade social media production:
- **16 skills + 25 commands + 5 agents** for monthly content calendar production
- **Asset-first compositing** — brand assets stay pixel-faithful, AI generates the scene around them (so no more "AI enhanced our logo into something else")
- **AI image** via Vertex AI Nano Banana Pro
- **AI video** via WaveSpeed Kling v3.0 Pro
- **7-platform copy adaptation** (Instagram, TikTok, LinkedIn, Threads, X, Facebook, YouTube Shorts) in one pass
- **C2PA signing** for EU AI Act Article 50
- **54 release-consistency tests passing**

## Why all three are worth listing together

All three plugins:
- Are MIT-licensed and ship from one marketplace ([`indranilbanerjee/neels-plugins`](https://github.com/indranilbanerjee/neels-plugins))
- Use the open **Agent Skills format** byte-portable across all 41+ Agent Skills clients
- Ship **8 native platform manifests** (Claude Code · Cowork · Codex · Cursor · Copilot CLI · Antigravity · Hermes Agent · OpenClaw)
- Have **zero global hooks** and **zero auto-connecting MCPs** — compose cleanly with other plugins
- Pass full release-consistency tests (DMP 114 + CF 53 + SF 54 = **221 tests** across the suite)
- Are EU AI Act Article 50 ready (Article 50 applies 2 August 2026)

Built for marketing agencies, in-house teams running 50–200 brands, and consultancies — the same audience already targeted by the other Marketing-section entries.

## Compliance with CONTRIBUTING.md

- ✅ Entries added to the correct section (Community Skills → Marketing)
- ✅ Each entry has author/repo prefix, working GitHub URL, brief description
- ✅ Each repository has a working README/SKILL.md
- ✅ All repos have demonstrated community usage (open source for months, active commits, GitHub Releases pages with full version history)