### PR TITLE
Add k-skincare — skincare + wellness consultation skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1711,7 +1711,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[meodai/skill.color-expert](https://github.com/meodai/skill.color-expert)** - Color science expert skill with 286K words of reference material covering OKLCH/OKLAB, palette generation, accessibility/contrast, color naming, pigment mixing, and historical color theory
 - **[aklofas/kicad-happy](https://github.com/aklofas/kicad-happy)** - AI-powered KiCad electronics design review and analysis
 - **[bitwize-music-studio/claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills)** - Full-lifecycle AI music album production
-- **[seonglae/k-skincare](https://github.com/seonglae/k-skincare)** - Skincare and wellness consultation. Two skills: skin (acne, pigmentation, retinoid protocols, Korean derm procedures) and wellness (supplement stacks with dosing and timing, sleep, cortisol, cutting, gut). Checks drug interactions, multi-language, flags cases for professional referral, standalone interactive CLI.
+- **[seonglae/k-skincare](https://github.com/seonglae/k-skincare)** - Skincare and wellness consultation. Two skills: skin (acne, pigmentation, retinoid protocols, Korean derm procedures) and wellness (supplement stacks with dosing and timing, sleep, cortisol, cutting, gut). Checks drug interactions, multi-language, flags cases for professional referral.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -1711,7 +1711,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[meodai/skill.color-expert](https://github.com/meodai/skill.color-expert)** - Color science expert skill with 286K words of reference material covering OKLCH/OKLAB, palette generation, accessibility/contrast, color naming, pigment mixing, and historical color theory
 - **[aklofas/kicad-happy](https://github.com/aklofas/kicad-happy)** - AI-powered KiCad electronics design review and analysis
 - **[bitwize-music-studio/claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills)** - Full-lifecycle AI music album production
-- **[seonglae/k-skincare](https://github.com/seonglae/k-skincare)** - Skincare and wellness consultation. Two skills: skin (acne, pigmentation, retinoid protocols, Korean derm procedures) and wellness (supplements, sleep, cortisol, gut health). Multi-language, flags cases for professional referral, standalone interactive CLI.
+- **[seonglae/k-skincare](https://github.com/seonglae/k-skincare)** - Skincare and wellness consultation. Two skills: skin (acne, pigmentation, retinoid protocols, Korean derm procedures) and wellness (supplement stacks with dosing and timing, sleep, cortisol, cutting, gut). Checks drug interactions, multi-language, flags cases for professional referral, standalone interactive CLI.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -1711,6 +1711,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[meodai/skill.color-expert](https://github.com/meodai/skill.color-expert)** - Color science expert skill with 286K words of reference material covering OKLCH/OKLAB, palette generation, accessibility/contrast, color naming, pigment mixing, and historical color theory
 - **[aklofas/kicad-happy](https://github.com/aklofas/kicad-happy)** - AI-powered KiCad electronics design review and analysis
 - **[bitwize-music-studio/claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills)** - Full-lifecycle AI music album production
+- **[seonglae/k-skincare](https://github.com/seonglae/k-skincare)** - Evidence-based skincare and wellness consultation. Two RCT-grounded skills: skin (acne, pigmentation, retinoid protocols, Korean derm procedures) and wellness (supplements, sleep, cutting, cortisol, gut). Multi-language, refer-out safety rails, plus a standalone interactive CLI.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -1711,7 +1711,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[meodai/skill.color-expert](https://github.com/meodai/skill.color-expert)** - Color science expert skill with 286K words of reference material covering OKLCH/OKLAB, palette generation, accessibility/contrast, color naming, pigment mixing, and historical color theory
 - **[aklofas/kicad-happy](https://github.com/aklofas/kicad-happy)** - AI-powered KiCad electronics design review and analysis
 - **[bitwize-music-studio/claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills)** - Full-lifecycle AI music album production
-- **[seonglae/k-skincare](https://github.com/seonglae/k-skincare)** - Evidence-based skincare and wellness consultation. Two RCT-grounded skills: skin (acne, pigmentation, retinoid protocols, Korean derm procedures) and wellness (supplements, sleep, cutting, cortisol, gut). Multi-language, refer-out safety rails, plus a standalone interactive CLI.
+- **[seonglae/k-skincare](https://github.com/seonglae/k-skincare)** - Skincare and wellness consultation. Two skills: skin (acne, pigmentation, retinoid protocols, Korean derm procedures) and wellness (supplements, sleep, cortisol, gut health). Multi-language, flags cases for professional referral, standalone interactive CLI.
 
 </details>
 


### PR DESCRIPTION
Adds **k-skincare** to Community → Specialized Domains.

[seonglae/k-skincare](https://github.com/seonglae/k-skincare) ships two skills:
- **k-skincare** — acne, pigmentation, retinoid protocols, Korean derm procedures
- **k-wellness** — personalized supplement stacks (what to take, dose, timing, interactions), sleep, cortisol, cutting, gut, eye fatigue

Multi-language, cites peer-reviewed sources, flags cases for professional referral.

Install: `npx skills add seonglae/k-skincare`