### PR TITLE
Add skill: hanhuark/mechanical-engineering-research-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1698,6 +1698,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[Orchestra-Research/AI-research-SKILLs](https://github.com/Orchestra-Research/AI-research-SKILLs)** - 20-module AI research skill library for model architecture, training, and ML paper writing
 - **[komal-SkyNET/claude-skill-homeassistant](https://github.com/komal-SkyNET/claude-skill-homeassistant)** - Supercharge and manage Home Assistant workflows
 - **[more-io/apple-bridges](https://github.com/more-io/claude-apple-bridges)** - Native macOS app access — manage Apple Reminders, Calendar, Contacts, Notes, Mail, and tmux sessions via Swift CLI bridges
+- **[hanhuark/mechanical-engineering-research-skill](https://github.com/hanhuark/mechanical-engineering-research-skill)** - Thermal-fluid research writing, proposals, DOE, and presentation feedback
 - **[prompt-security/clawsec](https://github.com/prompt-security/clawsec)** - Security skill suite with drift detection, automated audits, and skill integrity verification
 - **[BehiSecc/vibesec](https://github.com/BehiSecc/VibeSec-Skill)** - Helps write secure code by preventing common vulnerabilities including IDOR, XSS, SQL injection, SSRF, and weak authentication, approaching code from a bug hunter's perspective
 - **[lawvable/awesome-legal-skills](https://github.com/lawvable/awesome-legal-skills)** - Curated agent skills for automating legal workflows


### PR DESCRIPTION
﻿## Summary

Adds `hanhuark/mechanical-engineering-research-skill` to Community Skills > Specialized Domains.

The skill supports thermal-fluid mechanical engineering research workflows across writing, proposals, DOE, presentations, and first-pass research feedback.

## Checklist

- Link verified
- Description kept short
- Added to matching community category
