### PR TITLE
Add skill: Instafill/instashare

### DIFF
--- a/README.md
+++ b/README.md
@@ -1659,6 +1659,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[foryourhealth111-pixel/Vibe-Skills](https://github.com/foryourhealth111-pixel/Vibe-Skills)** - A skills governed plug-and-play harness for staged, test-driven skill orchestration
 - **[metalbear-co/skills](https://github.com/metalbear-co/skills)** - Skills that let agents code and test against your Kubernetes cluster using mirrord
 - **[dembrandt/dembrandt-skills](https://github.com/dembrandt/dembrandt-skills)** - UX and design system skills: hierarchy, typography, accessibility, interactions
+- **[Instafill/instashare](https://github.com/Instafill/instashare-skill)** - Share Claude Code sessions as public web links
 
 </details>
 


### PR DESCRIPTION
Adds **Instafill/instashare** to *Community Skills → Development and Testing* (appended to end, per CONTRIBUTING).

InstaShare uploads the current Claude Code session to instashare.to and returns a public, shareable link in one shell call. It redacts secrets (API keys, tokens, auth/cookie headers, private keys) before upload.

- Repo: https://github.com/Instafill/instashare-skill (Apache-2.0, public, documented)
- Install: `/plugin marketplace add Instafill/instashare-skill`
- Live example: https://instashare.to/c/YDXusM-verify-instafill-form-completion-and-data

Follows the entry format (author/skill-name prefix, ≤10-word description) and link verified working.