### PR TITLE
Add Awesome Bio Agent Skills to Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1517,6 +1517,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 <details>
 <summary><h3 style="display:inline">Vector Databases</h3></summary>
 
+- **[Awesome Bio Agent Skills](https://github.com/BioTender-max/awesome-bio-agent-skills)** - 1,676 deduplicated SKILL.md skills for biomedical research (genomics, proteomics, single-cell, clinical AI, protein design) from 20 open-source repos. One-command install via `npx bioskill install`.
 - **[qdrant/skills](https://github.com/qdrant/skills)** - Agent skills for Qdrant vector search, covering scaling, performance optimization, search quality, monitoring, deployment, model migration, version upgrades, and SDK usage across Python, TypeScript, Rust, Go, .NET, and Java
 
 </details>

--- a/README.md
+++ b/README.md
@@ -1517,8 +1517,14 @@ Official skills published by Cypress to help create, maintain, understand, and f
 <details>
 <summary><h3 style="display:inline">Vector Databases</h3></summary>
 
-- **[Awesome Bio Agent Skills](https://github.com/BioTender-max/awesome-bio-agent-skills)** - 1,676 deduplicated SKILL.md skills for biomedical research (genomics, proteomics, single-cell, clinical AI, protein design) from 20 open-source repos. One-command install via `npx bioskill install`.
 - **[qdrant/skills](https://github.com/qdrant/skills)** - Agent skills for Qdrant vector search, covering scaling, performance optimization, search quality, monitoring, deployment, model migration, version upgrades, and SDK usage across Python, TypeScript, Rust, Go, .NET, and Java
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Research &amp; Science</h3></summary>
+
+- **[Awesome Bio Agent Skills](https://github.com/BioTender-max/awesome-bio-agent-skills)** - 1,676 deduplicated SKILL.md skills for biomedical research (genomics, proteomics, single-cell, clinical AI, protein design) aggregated from 20 open-source repositories.
 
 </details>
 


### PR DESCRIPTION
Hi, thanks for maintaining this list!

Adding [**Awesome Bio Agent Skills**](https://github.com/BioTender-max/awesome-bio-agent-skills) — a curated, deduplicated collection of **1,676 SKILL.md agent skills for biomedical research** (genomics, proteomics, single-cell, clinical AI, protein design), aggregated from 20 open-source repositories. Each skill is a self-contained `SKILL.md` folder compatible with Claude-based agent frameworks, and the whole set is installable in one command: `npx bioskill install`.

It fits well alongside the existing entries in this section. Thanks for considering!