### PR TITLE
Add ABVX Agent Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1600,6 +1600,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[lackeyjb/playwright-skill](https://github.com/lackeyjb/playwright-skill)** - Browser automation with Playwright
 - **[ibelick/ui-skills](https://github.com/ibelick/ui-skills)** - Opinionated, evolving constraints to guide agents when building interfaces
 - **[muthuishere/hand-drawn-diagrams](https://github.com/muthuishere/hand-drawn-diagrams)** - Generate hand-drawn Excalidraw diagrams from a prompt — animated SVG, hosted edit link, and PNG export. Works with Claude Code, Codex, Gemini CLI, and any agent supporting standard skill paths
+- **[markoblogo/abvx-agent-skills](https://github.com/markoblogo/abvx-agent-skills)** - Small, auditable coding-agent skillpack for smaller diffs, evidence-led debugging, token control, browser verification, and reviewable `SKILL.md` workflows with validation and static security audit
 - **[nextlevelbuilder/ui-ux-pro-max-skill](https://github.com/nextlevelbuilder/ui-ux-pro-max-skill)** - UI/UX design patterns and best practices
 - **[ehmo/platform-design-skills](https://github.com/ehmo/platform-design-skills)** - 300+ design rules from Apple HIG, Material Design 3, and WCAG 2.2 for cross-platform apps
 - **[scarletkc/vexor](https://github.com/scarletkc/vexor)** - Vector-powered CLI for semantic file search with a Claude/Codex skill


### PR DESCRIPTION
## Summary
- add `markoblogo/abvx-agent-skills` to the Community Skills / Development and Testing section

## Why
ABVX Agent Skills is a strong fit for this section: it is a coding-agent skillpack focused on smaller diffs, evidence-led debugging, token control, browser verification, and reviewable `SKILL.md` workflows.
