### PR TITLE
Add skill: baskduf/codex-fable5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1661,6 +1661,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[metalbear-co/skills](https://github.com/metalbear-co/skills)** - Skills that let agents code and test against your Kubernetes cluster using mirrord
 - **[dembrandt/dembrandt-skills](https://github.com/dembrandt/dembrandt-skills)** - UX and design system skills: hierarchy, typography, accessibility, interactions
 - **[GanyuanRan/Aegis](https://github.com/GanyuanRan/Aegis)** - Evidence-driven method pack for AI coding agents
+- **[baskduf/codex-fable5](https://github.com/baskduf/FableCodex/tree/main/plugins/codex-fable5/skills/codex-fable5)** - Evidence-based workflow gates for Codex
 
 </details>
 


### PR DESCRIPTION
## Summary

- Add `baskduf/codex-fable5` to Community Skills > Development and Testing.
- Link directly to the FableCodex Codex skill directory.

## Why

FableCodex provides evidence-based workflow gates for Codex work, including planning, findings, and verification discipline.

## Validation

- Read `CONTRIBUTING.md` and followed the required entry and PR title format.
- Verified the linked `SKILL.md` path with GitHub API.
- Ran `git diff --check`.
