### PR TITLE
Fix dead link: voidborne-d/humanize-chinese → swaylq/humanize-chinese

### DIFF
--- a/README.md
+++ b/README.md
@@ -1543,7 +1543,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[Xquik-dev/tweetclaw](https://github.com/Xquik-dev/tweetclaw)** - Post tweets, replies, DMs; search, monitor, run giveaways
 - **[SHADOWPR0/beautiful_prose](https://github.com/SHADOWPR0/beautiful_prose)** - Hard-edged writing style contract for timeless, forceful English prose without AI tics
 - **[blader/humanizer](https://github.com/blader/humanizer)** - Remove signs of AI-generated writing from text, making it sound more natural and human
-- **[voidborne-d/humanize-chinese](https://github.com/voidborne-d/humanize-chinese)** - Detect and rewrite AI-generated Chinese text; rule-ensemble scoring, 7 style transforms, academic AIGC reduction
+- **[swaylq/humanize-chinese](https://github.com/swaylq/humanize-chinese)** - Detect and rewrite AI-generated Chinese text; rule-ensemble scoring, 7 style transforms, academic AIGC reduction
 - **[MohamedAbdallah-14/unslop](https://github.com/MohamedAbdallah-14/unslop)** - Removes named AI writing tells (tricolons, em-dash pileups, hedging stacks, sycophancy openers, stock vocab like "delve"/"crucial"). Split lint/rewrite modes for auditing your own text without auto-rewriting. Five intensity levels, MIT
 - **[Eronred/aso-skills](https://github.com/Eronred/aso-skills)** - 30+ App Store Optimization skills for keyword research, metadata optimization, competitor analysis, creative optimization, and mobile growth strategies via Appeeky API
 - **[degausai/wonda](https://github.com/degausai/wonda)** - AI content creation: images, video, music, audio, editing, publishing


### PR DESCRIPTION
The entry for `humanize-chinese` under Community Skills → AI and Data points to `voidborne-d/humanize-chinese`, which now returns a 404 (the repo moved). This updates the name and URL to the current home at [`swaylq/humanize-chinese`](https://github.com/swaylq/humanize-chinese) so the link works again.

Verified live: https://github.com/swaylq/humanize-chinese — same skill (AI-Chinese-text detection + rewrite), description unchanged.
