### PR TITLE
Add skill: csthink/dashmotion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1671,6 +1671,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[metalbear-co/skills](https://github.com/metalbear-co/skills)** - Skills that let agents code and test against your Kubernetes cluster using mirrord
 - **[dembrandt/dembrandt-skills](https://github.com/dembrandt/dembrandt-skills)** - UX and design system skills: hierarchy, typography, accessibility, interactions
 - **[GanyuanRan/Aegis](https://github.com/GanyuanRan/Aegis)** - Evidence-driven method pack for AI coding agents
+- **[csthink/dashmotion](https://github.com/csthink/dashmotion)** - Animated technical diagrams from plain English or Mermaid, self-contained HTML/SVG
 
 </details>
 


### PR DESCRIPTION
Adds `csthink/dashmotion` to **Community Skills → Development and Testing** (one line; no other entries touched).

dashmotion is a Claude skill that turns plain English or Mermaid source into dark-themed, animated technical diagrams as self-contained HTML/SVG — flowcharts whose connectors visibly flow, and architecture diagrams where requests travel as light dots through the system.

- **Repo (MIT):** https://github.com/csthink/dashmotion
- **Live demo:** https://csthink.github.io/dashmotion/

**Why it meets the bar**
- **Proven, maintained skill — not a brand-new upload.** Released through v2.0 → v2.2.4 with a published CHANGELOG, docs (`docs/how-it-works.md`), a committed eval harness, and a live demo.
- **Validated:** `claude plugin validate --strict` passes; standard `skills/dashmotion/SKILL.md` bundle that installs and loads cleanly.
- **Zero data footprint:** no hooks, no MCP servers, no network access, no telemetry — it only generates local HTML/SVG files.
- **Follows the Quality Criteria:** third-person description; progressive disclosure (mode references and templates loaded on demand, not inline); no absolute paths; no blanket tool grants.

**CONTRIBUTING checklist:** public repo with a working skill ✓ · documentation (README + SKILL.md + `docs/`) ✓ · author/org prefix ✓ · description ≤ 10 words ✓ · links verified ✓ · single line added ✓
