### PR TITLE
Add skill: pattern-ai-labs/agentcall

### DIFF
--- a/README.md
+++ b/README.md
@@ -1589,6 +1589,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[deusyu/translate-book](https://github.com/deusyu/translate-book)** - Translate books (PDF/DOCX/EPUB) via parallel sub-agents with resume
 - **[mvanhorn/last30days-skill](https://github.com/mvanhorn/last30days-skill)** - Research any topic across Reddit, X, YouTube, HN, Polymarket, and the web, ranked by upvotes, likes, and real money instead of editors
 - **[santifer/career-ops](https://github.com/santifer/career-ops)** - 14-skill collection for AI-powered job search: JD evaluation with A-F scoring, ATS-optimized PDF generation, portal scanners (Greenhouse/Ashby/Lever), interview prep with STAR+R, batch processing, and a Go dashboard TUI
+- **[pattern-ai-labs/agentcall](https://github.com/pattern-ai-labs/agentcall)** - Let your AI agents join Google Meet, Zoom, Teams calls and collaborate like a real team-mate.
 
 </details>
 


### PR DESCRIPTION
Adds pattern-ai-labs/agentcall to Community Skills → Productivity and Collaboration (one line; no other entries touched).

AgentCall is a skill that lets any AI coding agent (Claude Code, Cursor, Codex, Gemini CLI, Windsurf, and more) join Google Meet, Zoom, and Microsoft Teams as a real participant — speaking via text-to-speech, receiving live transcripts, sharing its screen, and showing an avatar — while keeping its full session context.

Repo (MIT): https://github.com/pattern-ai-labs/agentcall
Site: https://agentcall.dev/

Why it meets the bar

Proven, not a brand-new upload — public repo with real adoption (stars and active forks), already independently listed and security-verified on SkillsLLM, and indexed on SkillsMP.
Works across the ecosystem — installs as a Claude Code plugin (join-meeting@agentcall) and runs on 30+ agents; voice/avatar/screenshare modes all documented.
Documented — README plus a complete SKILL.md, with examples/ and references/ covering modes, events, and integration patterns.
Low risk — MIT licensed; clear leave/cleanup and safety guidance in the skill.

CONTRIBUTING checklist: public repo with a working skill ✓ · documentation (README + SKILL.md) ✓ · author/org prefix in the name ✓ · short description ✓ 