### PR TITLE
Add session-teacher skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1581,6 +1581,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[kreuzberg-dev/kreuzberg](https://github.com/kreuzberg-dev/kreuzberg/tree/main/skills/kreuzberg)** - Extract text, tables, and metadata from 62+ document formats
 - **[Paramchoudhary/ResumeSkills](https://github.com/Paramchoudhary/ResumeSkills)** - 20 specialized skills for resume optimization, ATS analysis, interview prep, and career transitions
 - **[RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills)** - Transform docs or codebases into Obsidian StudyVaults with interactive quizzes
+- **[apxxrv/session-teacher](https://github.com/apxxrv/session-teacher)** - Rigorous tutor that teaches incrementally, quizzes you, and won't end until you've demonstrated understanding. Based on a teaching prompt from the Anthropic team
 - **[NeoLabHQ/write-concisely](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/docs/skills/write-concisely)** - Applies the famous *The Elements of Style* book principles to make documentation and writing clearer and more professional by eliminating wordiness and improving structure.
 - **[ReScienceLab/opc-skills](https://github.com/ReScienceLab/opc-skills)** - Agent skills for solopreneurs with SEO, geo, and LLM tools
 - **[SeanZoR/claude-speed-reader](https://github.com/SeanZoR/claude-speed-reader)** - Speed read Claude's responses at 600+ WPM using RSVP with Spritz-style ORP highlighting


### PR DESCRIPTION
Adds [session-teacher](https://github.com/apxxrv/session-teacher) to the Productivity and Collaboration community section.

A Claude skill that tutors you until you actually understand the work — incremental teaching, running checklist, quizzing, no nodding-along allowed. Based on a teaching prompt from the Anthropic team (shared by @trq212).