### PR TITLE
Add skill: Un1quer23/github-repo-publisher

### DIFF
--- a/README.md
+++ b/README.md
@@ -1671,6 +1671,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[metalbear-co/skills](https://github.com/metalbear-co/skills)** - Skills that let agents code and test against your Kubernetes cluster using mirrord
 - **[dembrandt/dembrandt-skills](https://github.com/dembrandt/dembrandt-skills)** - UX and design system skills: hierarchy, typography, accessibility, interactions
 - **[GanyuanRan/Aegis](https://github.com/GanyuanRan/Aegis)** - Evidence-driven method pack for AI coding agents
+- **[Un1quer23/github-repo-publisher](https://github.com/Un1quer23/github-repo-publisher)** - Audit GitHub repos for publish-ready docs and metadata
 
 </details>
 


### PR DESCRIPTION
## Summary
- Add `Un1quer23/github-repo-publisher` to Community Skills > Development and Testing
- Link to the public, cross-runtime skill repository

## Checks
- Entry follows the documented format
- Description is 8 words
- Link resolves to the public repository
- Branch was rebuilt from the latest upstream `main`
