### PR TITLE
Add skill: JerryNee/consumer-dispute-assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -1724,6 +1724,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[meodai/skill.color-expert](https://github.com/meodai/skill.color-expert)** - Color science expert skill with 286K words of reference material covering OKLCH/OKLAB, palette generation, accessibility/contrast, color naming, pigment mixing, and historical color theory
 - **[aklofas/kicad-happy](https://github.com/aklofas/kicad-happy)** - AI-powered KiCad electronics design review and analysis
 - **[bitwize-music-studio/claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills)** - Full-lifecycle AI music album production
+- **[JerryNee/consumer-dispute-assistant](https://github.com/JerryNee/consumer-dispute-agent-skill/tree/main/skills/consumer-dispute-assistant)** - Build refund and billing dispute case packs.
 
 </details>
 


### PR DESCRIPTION
Adds `JerryNee/consumer-dispute-assistant` under Community Skills > Specialized Domains.

Why it fits:
- Public Agent Skill repo with `SKILL.md` and README
- Builds refund, subscription, and billing dispute case packs
- Includes demo output, templates, safety boundaries, and a reproducible example
