### PR TITLE
Add skill: mattjoyce/okf-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1688,6 +1688,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[k-kolomeitsev/data-structure-protocol](https://github.com/k-kolomeitsev/data-structure-protocol)** - Graph-based long-term memory skill for AI (LLM) coding agents — faster context, fewer tokens, safer refactors
 - **[awrshift/claude-memory-kit](https://github.com/awrshift/claude-memory-kit)** - Persistent memory with hooks, wiki, and daily synthesis for multi-project workflows
 - **[NeoLabHQ/prompt-engineering](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/customaize-agent/skills/prompt-engineering)** - Widely used prompt engineering techniques and patterns, including Anthropic best practices and agent persuasion principles.
+- **[mattjoyce/okf-skill](https://github.com/mattjoyce/okf-skill)** - Authors and validates Open Knowledge Format markdown knowledge bundles
 
 </details>
 


### PR DESCRIPTION
Adds **okf** to Community Skills → Context Engineering.

- **Repo:** https://github.com/mattjoyce/okf-skill
- **What it does:** Authors and validates Open Knowledge Format (OKF) bundles — vendor-neutral knowledge represented as a directory of markdown files with YAML frontmatter.
- Public repo, documented (README + SKILL.md), author prefix included, description under 10 words. Link verified.