### PR TITLE
Add skill: nowork-studio/NotFair

### DIFF
--- a/README.md
+++ b/README.md
@@ -1550,6 +1550,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[gitroomhq/postiz-agent](https://github.com/gitroomhq/postiz-agent)** - Schedule social media posts across 28+ platforms programmatically
 - **[indranilbanerjee/digital-marketing-pro](https://github.com/indranilbanerjee/digital-marketing-pro)** - 150-skill engagement methodology — 12-Part Strategy Flow, 25 specialist agents, EU AI Act Article 50 ready (C2PA signing), 6-platform AEO/GEO incl. Google AI Mode
 - **[infrasity-labs/dev-gtm-claude-skills](https://github.com/infrasity-labs/dev-gtm-claude-skills)**: GTM-focused skill collection for developer go-to-market workflows including launch planning, positioning, and outbound sequences.
+- **[nowork-studio/NotFair](https://github.com/nowork-studio/NotFair)** - SEO, GEO, Google Ads, and Meta Ads skills with live data
 
 </details>
 


### PR DESCRIPTION
Thanks for maintaining this list — it's become a great reference for real, community-used skills.

I'd like to add NotFair, a set of open-source (MIT) Claude Code skills for marketing work: SEO and GEO (site analysis, keyword research, meta tags, schema markup, content writing), Google Ads (audits, wasted-spend detection, search-term cleanup, bid/keyword management), and Meta Ads (ROAS, creative fatigue, audience overlap). It fits the Community Skills > Marketing subcategory alongside the other SEO/ads/marketing skills already listed.

What makes it a bit different is it works against live data via the Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP, so the skills can audit and act on real accounts rather than just generate text. It's at ~2.9k stars if that helps as a signal.

I added it as the last entry in the Marketing subcategory and kept the description short to match the surrounding format. Happy to reword, trim, or move it wherever you think it fits best.