### PR TITLE
Add skill: Hanyuyuan6/remote-gpu-trainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1671,6 +1671,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[metalbear-co/skills](https://github.com/metalbear-co/skills)** - Skills that let agents code and test against your Kubernetes cluster using mirrord
 - **[dembrandt/dembrandt-skills](https://github.com/dembrandt/dembrandt-skills)** - UX and design system skills: hierarchy, typography, accessibility, interactions
 - **[GanyuanRan/Aegis](https://github.com/GanyuanRan/Aegis)** - Evidence-driven method pack for AI coding agents
+- **[Hanyuyuan6/remote-gpu-trainer](https://github.com/Hanyuyuan6/remote-gpu-trainer)** - Deploy, train, monitor, tear down GPU jobs on rented instances
 
 </details>
 


### PR DESCRIPTION
Adds Hanyuyuan6/remote-gpu-trainer to Community Skills > Development and Testing.

An MIT-licensed Agent Skill for deploying, training, monitoring, and tearing down long GPU jobs on rented/remote instances (AutoDL, RunPod, vast.ai, Lambda, Slurm, bare SSH): billing/teardown safety, spot resilience, disk budgeting, and durable monitoring. Public repo with SKILL.md, references, and runnable scripts.

Placed under Development and Testing (the existing Community subcategory closest to infra/MLOps tooling, alongside aws-skills/terraform/metalbear); happy to recategorize if you prefer.