### PR TITLE
Add otelcol-doctor to Development and Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1671,6 +1671,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[metalbear-co/skills](https://github.com/metalbear-co/skills)** - Skills that let agents code and test against your Kubernetes cluster using mirrord
 - **[dembrandt/dembrandt-skills](https://github.com/dembrandt/dembrandt-skills)** - UX and design system skills: hierarchy, typography, accessibility, interactions
 - **[GanyuanRan/Aegis](https://github.com/GanyuanRan/Aegis)** - Evidence-driven method pack for AI coding agents
+- **[s3onghyun/otelcol-doctor](https://github.com/s3onghyun/otelcol-doctor)** - Write, fix, and validate OpenTelemetry Collector configs — processor order, core-vs-contrib components, pull-vs-push exporters, OTTL, spanmetrics wiring, and tail-sampling topology — then run otelcol validate
 
 </details>
 


### PR DESCRIPTION
Adds [**s3onghyun/otelcol-doctor**](https://github.com/s3onghyun/otelcol-doctor) under Community Skills → Development and Testing.

A vendor-neutral skill that writes, fixes, and validates **OpenTelemetry Collector** configs. It encodes the Collector's failure modes (processor order, core-vs-contrib components, pull-vs-push exporters, OTTL syntax, spanmetrics connector dual-wiring, tail-sampling load-balancing topology) and finishes by running `otelcol validate`. Public repo with `SKILL.md` + `LICENSE` (Apache-2.0); ships a component catalog, an advanced reference, and validated example configs.

- [x] Public repository with a working skill
- [x] Has documentation (README + SKILL.md)
- [x] Author/org prefix included in the name