### PR TITLE
Add skill: Hanyuyuan6/remote-gpu-trainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1724,6 +1724,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[meodai/skill.color-expert](https://github.com/meodai/skill.color-expert)** - Color science expert skill with 286K words of reference material covering OKLCH/OKLAB, palette generation, accessibility/contrast, color naming, pigment mixing, and historical color theory
 - **[aklofas/kicad-happy](https://github.com/aklofas/kicad-happy)** - AI-powered KiCad electronics design review and analysis
 - **[bitwize-music-studio/claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills)** - Full-lifecycle AI music album production
+- **[Hanyuyuan6/remote-gpu-trainer](https://github.com/Hanyuyuan6/remote-gpu-trainer)** - Survive rented/remote GPU jobs: teardown, preemption, checkpointing
 
 </details>
 


### PR DESCRIPTION
Adds `remote-gpu-trainer` to the **Specialized Domains** community subcategory.

What it is: an Agent Skill (SKILL.md) for running long GPU jobs on RENTED/remote instances you don't own — AutoDL, RunPod, vast.ai, Lambda, Paperspace, Chinese platforms, bare SSH, Slurm, K8s. Covers the operational reality the big orchestrators skip: stop-vs-terminate billing safety, spot-preemption resilience, resumable checkpointing + disk-budget discipline, plus a DL-debug layer (CUDA OOM, NCCL hang, NaN/loss-spike, throughput, convergence, dataloader bugs).

Fits alongside the existing ML-infra entries in Specialized Domains (e.g. AI-research-SKILLs, Auto-claude GPU deployment). Note: CONTRIBUTING lists this category as "AI and Data" while the README currently renders it as "Specialized Domains" — I placed it under the live README heading; happy to move it if you prefer the other label.

- License: MIT
- Cross-agent: Claude Code, Codex, Cursor, Gemini CLI, and any SKILL.md-compatible agent
- Link verified working.