### PR TITLE
Add Agent-Reach: multi-platform search CLI for 17 sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -1688,6 +1688,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[awrshift/claude-memory-kit](https://github.com/awrshift/claude-memory-kit)** - Persistent memory with hooks, wiki, and daily synthesis for multi-project workflows
 - **[NeoLabHQ/prompt-engineering](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/customaize-agent/skills/prompt-engineering)** - Widely used prompt engineering techniques and patterns, including Anthropic best practices and agent persuasion principles.
 - **[sametbrr/llm-wiki-manager](https://github.com/sametbrr/llm-wiki-manager)** - Persistent LLM-managed personal wiki — the model writes, cross-references, and maintains the knowledge base while you curate sources. Implements Karpathy's LLM Wiki pattern with 8 operating modes.
+- **[Panniantong/Agent-Reach](https://github.com/Panniantong/Agent-Reach)** - Multi-platform search CLI for 17 sites including Chinese platforms
 
 </details>
 


### PR DESCRIPTION
## Summary

Add [Agent-Reach](https://github.com/Panniantong/Agent-Reach) to Community Skills / Context Engineering.

Agent-Reach (36,000+ ⭐, MIT) gives AI agents the ability to read and search across 17 platforms — including Twitter, Reddit, YouTube, GitHub, Bilibili, Xiaohongshu (小红书), Douyin (抖音), Weibo (微博), and more — through a single CLI interface, MCP, curl, or Python scripts. Zero API keys required for 8 channels.

## Why it fits

- Mature project with real community usage (36k+ stars, actively maintained)
- Provides external context sources for AI agents
- Unique coverage of Chinese platforms (not available in most similar tools)
- Compatible with Claude Code, Codex, Cursor, OpenClaw, and more