### PR TITLE
Add skill: AKSoftCode/aicrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -1670,6 +1670,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[metalbear-co/skills](https://github.com/metalbear-co/skills)** - Skills that let agents code and test against your Kubernetes cluster using mirrord
 - **[dembrandt/dembrandt-skills](https://github.com/dembrandt/dembrandt-skills)** - UX and design system skills: hierarchy, typography, accessibility, interactions
 - **[GanyuanRan/Aegis](https://github.com/GanyuanRan/Aegis)** - Evidence-driven method pack for AI coding agents
+- **[AKSoftCode/aicrew](https://github.com/AKSoftCode/aicrew)** - TDD-first /dev, /fix, /quick pipeline across AI coding tools
 
 </details>
 


### PR DESCRIPTION
## Summary
- Adds **AKSoftCode/aicrew** to Community Skills → Development and Testing
- TDD-first AI development pipeline with unified `/dev`, `/fix`, and `/quick` commands across Claude Code, Cursor, Codex, Gemini CLI, and Antigravity

## Pipeline summary

| Command | Phases | Use when |
|---------|--------|----------|
| `/dev` | 9 — intake → research → brainstorm → design → implement (TDD) → tests → security → audit → conclude | Features, refactors, anything needing a design spec |
| `/fix` | 5 — intake → bug analysis → implement (TDD) → tests → security → conclude | Bug fixes with mandatory TDD |
| `/quick` | 2 — Scout → Act | Small scoped tasks; graph-first without pipeline overhead |

Every phase in `/dev` and `/fix` stops for explicit user confirmation. All three commands share the same 11-capability token foundation — only pipeline depth differs.

## Benefits

- **TDD-first** — strict RED → GREEN → REFACTOR in `/dev` and `/fix`
- **Phase gates** — agent never invents your response
- **Security review** — `security-reviewer` on changed files; `security-guard.py` blocks secrets on every write
- **Scout → verify** — cheap model maps the problem; capable model acts from a verified summary only
- **Specialist routing** — frontend, backend, db-migration, performance agents by changed file paths

## Token savings (illustrative figures — project-dependent)

- Graph query **~500 tok** vs repo-wide grep **~80 K** (documented ratio from `codebase-memory-mcp`; actual savings vary by repo)
- Scout block **~1–2 K** `SCOUT:` schema from `context-scout` (before main model acts in scout→verify→act) vs reading raw grep/file dumps (often **10–80 K+** depending on repo)
- `/handoff` **~300 tok** vs **~15 K** chat replay (estimated)

Run `aicrew benchmark --report` for repo-specific estimates.

## Links

- [aicrew README](https://github.com/AKSoftCode/aicrew/blob/master/README.md)
- [Pipeline overview](https://github.com/AKSoftCode/aicrew/blob/master/docs/pipeline-overview.md)

## Test plan
- [x] Link resolves to https://github.com/AKSoftCode/aicrew
- [x] Entry follows CONTRIBUTING format (author prefix, ≤10-word description)
- [x] Placed at end of Development and Testing subcategory per guidelines