### PR TITLE
Add skill: rogerdigital/vault-inspector

### DIFF
--- a/README.md
+++ b/README.md
@@ -1580,6 +1580,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[kreuzberg-dev/kreuzberg](https://github.com/kreuzberg-dev/kreuzberg/tree/main/skills/kreuzberg)** - Extract text, tables, and metadata from 62+ document formats
 - **[Paramchoudhary/ResumeSkills](https://github.com/Paramchoudhary/ResumeSkills)** - 20 specialized skills for resume optimization, ATS analysis, interview prep, and career transitions
 - **[RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills)** - Transform docs or codebases into Obsidian StudyVaults with interactive quizzes
+- **[rogerdigital/vault-inspector](https://github.com/rogerdigital/vault-inspector/tree/main/skills/vault-inspector)** - Read-only Obsidian vault checks
 - **[NeoLabHQ/write-concisely](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/docs/skills/write-concisely)** - Applies the famous *The Elements of Style* book principles to make documentation and writing clearer and more professional by eliminating wordiness and improving structure.
 - **[ReScienceLab/opc-skills](https://github.com/ReScienceLab/opc-skills)** - Agent skills for solopreneurs with SEO, geo, and LLM tools
 - **[SeanZoR/claude-speed-reader](https://github.com/SeanZoR/claude-speed-reader)** - Speed read Claude's responses at 600+ WPM using RSVP with Spritz-style ORP highlighting


### PR DESCRIPTION
## Summary

- Add the Vault Inspector Agent Skill to Community Skills > Productivity and Collaboration.

## Notes

- Skill source: https://github.com/rogerdigital/vault-inspector/tree/main/skills/vault-inspector
- Published tag: skill-vault-inspector-v0.1.0
- Verified install paths: `gh skill install` and `npx skills add`
