### PR TITLE
Add skill: shouldnotappearcalm/a-share-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1724,6 +1724,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[meodai/skill.color-expert](https://github.com/meodai/skill.color-expert)** - Color science expert skill with 286K words of reference material covering OKLCH/OKLAB, palette generation, accessibility/contrast, color naming, pigment mixing, and historical color theory
 - **[aklofas/kicad-happy](https://github.com/aklofas/kicad-happy)** - AI-powered KiCad electronics design review and analysis
 - **[bitwize-music-studio/claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills)** - Full-lifecycle AI music album production
+- **[shouldnotappearcalm/a-share-skill](https://github.com/shouldnotappearcalm/a-share-skill)** - China A-share stock data, indicators, events, and paper trading
 
 </details>
 


### PR DESCRIPTION
Adds the community skill **[shouldnotappearcalm/a-share-skill](https://github.com/shouldnotappearcalm/a-share-skill)** to the **Specialized Domains** category.

Agent Skills for the China A-share (Shanghai/Shenzhen) market: real-time quotes, K-line history, technical indicators, events, capital flows, sector heatmaps, and paper trading. Works with Claude Code, Cursor, Codex, and Qoder.

- Public repo with SKILL.md documentation
- Author/org prefix included in the name
- Description is short (≤10 words)
- Existing community usage (160+ stars, 25+ forks)