### PR TITLE
Add skill: preset-io/agent-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1734,6 +1734,7 @@ Production-grade Agent Skills for every major test automation framework, maintai
 
 - **[transloadit/skills](https://github.com/transloadit/skills/tree/main/skills)** - Transloadit skill collection (6)
 - **[honeydew-ai/honeydew-ai-coding-agents-plugins](https://github.com/honeydew-ai/honeydew-ai-coding-agents-plugins)** - 11 skills for the Honeydew semantic layer over Snowflake, Databricks, and BigQuery: model exploration, entity/relation/attribute/metric/context/domain creation, validation, query, filtering, and workspace branching
+- **[preset-io/agent-skills](https://github.com/preset-io/agent-skills)** - Agent skills for Preset, Apache Superset, and Snowflake Cortex workflows, including API, MCP, CLI, dashboard, dataset, SQL Lab, export, and CI tasks.
 - **[raintree-technology/apple-hig-skills](https://github.com/raintree-technology/apple-hig-skills)** - Apple Human Interface Guidelines as 14 agent skills covering platforms, foundations, components, patterns, inputs, and technologies for iOS, macOS, visionOS, watchOS, and tvOS
 - **[K-Dense-AI/claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)** - Scientific research and analysis skills
 - **[NotMyself/claude-win11-speckit-update-skill](https://github.com/NotMyself/claude-win11-speckit-update-skill)** - Windows 11 system management


### PR DESCRIPTION
## Summary
- Adds `preset-io/agent-skills` as a single entry under Community Skills > Specialized Domains.
- Follows the maintainer feedback from #648 by avoiding a dedicated category and index entry.

## Checks
- `git diff --check`
- `curl -fsSI https://github.com/preset-io/agent-skills`
