### PR TITLE
Add skill: shouldnotappearcalm/a-share-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1736,6 +1736,7 @@ Production-grade Agent Skills for every major test automation framework, maintai
 <details>
 <summary><h3 style="display:inline">Specialized Domains</h3></summary>
 
+- **[shouldnotappearcalm/a-share-skill](https://github.com/shouldnotappearcalm/a-share-skill)** - China A-share (Shanghai/Shenzhen) skills: real-time quotes, K-line history, technical indicators, events, capital flows, sector heatmaps, and paper trading. Works with Claude Code, Cursor, Codex, and Qoder
 - **[transloadit/skills](https://github.com/transloadit/skills/tree/main/skills)** - Transloadit skill collection (6)
 - **[honeydew-ai/honeydew-ai-coding-agents-plugins](https://github.com/honeydew-ai/honeydew-ai-coding-agents-plugins)** - 11 skills for the Honeydew semantic layer over Snowflake, Databricks, and BigQuery: model exploration, entity/relation/attribute/metric/context/domain creation, validation, query, filtering, and workspace branching
 - **[raintree-technology/apple-hig-skills](https://github.com/raintree-technology/apple-hig-skills)** - Apple Human Interface Guidelines as 14 agent skills covering platforms, foundations, components, patterns, inputs, and technologies for iOS, macOS, visionOS, watchOS, and tvOS


### PR DESCRIPTION
Adds the community skill [shouldnotappearcalm/a-share-skill](https://github.com/shouldnotappearcalm/a-share-skill) to the **Specialized Domains** category.

Agent Skills for the China A-share (Shanghai/Shenzhen) market: real-time quotes, K-line history, technical indicators, events, capital flows, sector heatmaps, and paper trading. Works with Claude Code, Cursor, Codex, and Qoder.

This resubmits #701, which was closed because the documentation was not in English. The repository's primary README is now in English; the Chinese version has been moved to `README.zh.md` and is linked from the top.

- English README as the primary documentation
- Public repo with `SKILL.md` documentation
- Author/org prefix included in the name
- Existing community usage (160+ stars, 25+ forks)