### PR TITLE
Add skill: fr33dr4g0n/agentry-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1710,6 +1710,7 @@ Production-grade Agent Skills for every major test automation framework, maintai
 - **[dembrandt/dembrandt-skills](https://github.com/dembrandt/dembrandt-skills)** - UX and design system skills: hierarchy, typography, accessibility, interactions
 - **[GanyuanRan/Aegis](https://github.com/GanyuanRan/Aegis)** - Evidence-driven method pack for AI coding agents
 - **[baskduf/codex-fable5](https://github.com/baskduf/FableCodex/tree/main/plugins/codex-fable5/skills/codex-fable5)** - Evidence-based workflow gates for Codex
+- **[fr33dr4g0n/agentry-skill](https://github.com/fr33dr4g0n/agentry-skill)** - Agent-native analytics, logging, and deploy attribution
 
 </details>
 


### PR DESCRIPTION
## Summary
- Add Agentry Observability to the community Development and Testing skills list.
- Link to the public Agentry skill repository: https://github.com/fr33dr4g0n/agentry-skill

## Notes
- The repository contains a root SKILL.md and skill-loader copy at skills/agentry/SKILL.md.
- The README documents the skill, supported agent surfaces, and canonical Agentry docs.
- Agentry covers agent-native product analytics, error logging, and deploy attribution for coding agents.