### PR TITLE
Add skill: kiwi-phantomworks/coding-agent-pm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1623,6 +1623,7 @@ Production-grade Agent Skills for every major test automation framework, maintai
 - **[SeanZoR/claude-speed-reader](https://github.com/SeanZoR/claude-speed-reader)** - Speed read Claude's responses at 600+ WPM using RSVP with Spritz-style ORP highlighting
 - **[Charlie85270/Dorothy](https://github.com/Charlie85270/Dorothy)** - Orchestrate multiple AI CLI agents with automations and MCP servers
 - **[Digidai/product-manager-skills](https://github.com/Digidai/product-manager-skills)** - Senior PM agent with 30+ frameworks and SaaS metrics
+- **[kiwi-phantomworks/coding-agent-pm](https://github.com/kiwi-phantomworks/claude-code-pm-starter-pack)** - PM workflow templates for coding agents
 - **[deusyu/translate-book](https://github.com/deusyu/translate-book)** - Translate books (PDF/DOCX/EPUB) via parallel sub-agents with resume
 - **[mvanhorn/last30days-skill](https://github.com/mvanhorn/last30days-skill)** - Research any topic across Reddit, X, YouTube, HN, Polymarket, and the web, ranked by upvotes, likes, and real money instead of editors
 - **[santifer/career-ops](https://github.com/santifer/career-ops)** - 14-skill collection for AI-powered job search: JD evaluation with A-F scoring, ATS-optimized PDF generation, portal scanners (Greenhouse/Ashby/Lever), interview prep with STAR+R, batch processing, and a Go dashboard TUI


### PR DESCRIPTION
Adds the Bridge AI Labs coding-agent-pm community skill to the Productivity and Collaboration section.\n\nFit:\n- Public repo with root SKILL.md and templates\n- README/GitHub release/Gumroad package are live\n- Existing directory surfaces: askill, AwesomeSkills, Skillstore, Build with Claude\n- Current repo traffic from GitHub insights: 94 clones / 56 unique cloners in the visible window\n\nDescription is 6 words and the link points to the skill repo.