### PR TITLE
Add skill-doctor (installed-skill-library auditor)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1561,6 +1561,8 @@ Production-grade Agent Skills for every major test automation framework, maintai
 
 ### Community Skills
 
+- [skill-doctor](https://github.com/ssamba1/skill-doctor) - Audits your installed Claude Code skill library: per-turn context cost, never-fired skills (from transcripts), trigger collisions, duplicates, unused MCP servers, and reversible disable-model-invocation fixes.
+
 <details>
 <summary><h3 style="display:inline">Vector Databases</h3></summary>
 


### PR DESCRIPTION
Adds [skill-doctor](https://github.com/ssamba1/skill-doctor) to Community Skills. Audits your *installed* Claude Code skill library: per-turn context cost (A–F grades + budget check), never-fired skills mined from transcripts, trigger collisions, duplicates, unused MCP servers, and reversible disable-model-invocation fixes. Stdlib-only, MIT, CI-tested.