### PR TITLE
Add skill: Alisa0808/vibe-creating-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1766,6 +1766,7 @@ Production-grade Agent Skills for every major test automation framework, maintai
 - **[meodai/skill.color-expert](https://github.com/meodai/skill.color-expert)** - Color science expert skill with 286K words of reference material covering OKLCH/OKLAB, palette generation, accessibility/contrast, color naming, pigment mixing, and historical color theory
 - **[aklofas/kicad-happy](https://github.com/aklofas/kicad-happy)** - AI-powered KiCad electronics design review and analysis
 - **[bitwize-music-studio/claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills)** - Full-lifecycle AI music album production
+- **[Alisa0808/vibe-creating-skill](https://github.com/Alisa0808/vibe-creating-skill)** - Rewrites a rough idea or shot script into text-to-video prompts
 
 </details>
 


### PR DESCRIPTION
## Add skill: Alisa0808/vibe-creating-skill

Adds an entry to **Community Skills → Specialized Domains**, following the entry format in `CONTRIBUTING.md` (author/org prefix, description 10 words or fewer).

- **Repo:** https://github.com/Alisa0808/vibe-creating-skill
- **What it is:** A bilingual (EN/中文) Claude Agent Skill (single `SKILL.md`) that rewrites a rough idea or an over-specified shot script into a clean, model-ready text-to-video prompt. A faithful port of ByteDance's "Vibe Creating" paradigm (Seedance 2.0). Judgment-first (declines UI demos, tutorials, exact dialogue-sync). Works with Seedance 2.0, Kling, Veo, Hailuo, Wan, Vidu.
- **Install:** `npx github:Alisa0808/vibe-creating-skill`
- **License:** MIT

Links verified. I acknowledge `CONTRIBUTING.md` notes that brand-new skills may not be accepted; submitting for consideration regardless, formatted to spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
