### PR TITLE
Add skill: fayerman-source/deslop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1587,6 +1587,7 @@ Production-grade Agent Skills for every major test automation framework, maintai
 - **[indranilbanerjee/digital-marketing-pro](https://github.com/indranilbanerjee/digital-marketing-pro)** - 150-skill engagement methodology — 12-Part Strategy Flow, 25 specialist agents, EU AI Act Article 50 ready (C2PA signing), 6-platform AEO/GEO incl. Google AI Mode
 - **[infrasity-labs/dev-gtm-claude-skills](https://github.com/infrasity-labs/dev-gtm-claude-skills)**: GTM-focused skill collection for developer go-to-market workflows including launch planning, positioning, and outbound sequences.
 - **[nowork-studio/NotFair](https://github.com/nowork-studio/NotFair)** - SEO, GEO, Google Ads, and Meta Ads skills with live data
+- **[fayerman-source/deslop](https://github.com/fayerman-source/deslop)** - Rewrites legalese into plain English, preserving legal terms of art
 
 </details>
 


### PR DESCRIPTION
Adds **deslop** to Community Skills → Marketing, alongside the existing AI-writing-cleanup skills (unslop, humanizer, beautiful_prose).

- **Repo:** https://github.com/fayerman-source/deslop
- **What it does:** A portable `SKILL.md` that rewrites legalese and verbose AI prose into plain English (active voice, subject-verb proximity, no nominalizations or boilerplate) while strictly preserving binding legal terms of art.
- **License:** MIT · Prompt-only (no scripts, no network calls beyond the host agent's own LLM).
- **Docs:** README + SKILL.md, with before/after examples.

Entry format follows CONTRIBUTING (author prefix, description ≤10 words, added to end of the subcategory).