### PR TITLE
Add skill: drogers0/gh-image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1710,6 +1710,7 @@ Production-grade Agent Skills for every major test automation framework, maintai
 - **[dembrandt/dembrandt-skills](https://github.com/dembrandt/dembrandt-skills)** - UX and design system skills: hierarchy, typography, accessibility, interactions
 - **[GanyuanRan/Aegis](https://github.com/GanyuanRan/Aegis)** - Evidence-driven method pack for AI coding agents
 - **[baskduf/codex-fable5](https://github.com/baskduf/FableCodex/tree/main/plugins/codex-fable5/skills/codex-fable5)** - Evidence-based workflow gates for Codex
+- **[drogers0/gh-image](https://github.com/drogers0/gh-image)** - Upload images to GitHub from the command line
 
 </details>
 


### PR DESCRIPTION
Adds **[drogers0/gh-image](https://github.com/drogers0/gh-image)** to *Community Skills → Development and Testing*.

`gh-image` is a `gh` CLI extension that ships a packaged Agent Skill (SKILL.md) so agents (Claude Code, Codex, etc.) can upload local images to GitHub and get back ready-to-embed `user-attachments` URLs for PRs, issues, and comments — GitHub has no public image-upload API, so this fills a real gap.

- Public repo, MIT, 102★, actively maintained.
- Ships `skills/github-image-upload/SKILL.md`.
- Entry is 9 words (within the 10-word limit); link verified.