### PR TITLE
Add skill: outlit/outlit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1240,6 +1240,16 @@ Official MongoDB Agent Skills for agentic workflows — connection management, s
 </details>
 
 <details>
+<summary><h3 style="display:inline">Skills by Outlit</h3></summary>
+
+Official Outlit skills for customer intelligence and SDK instrumentation.
+
+- **[outlit/outlit](https://github.com/OutlitAI/outlit-agent-skills/tree/main/skills/outlit)** - Query Outlit customer intelligence, timelines, revenue, and SQL
+- **[outlit/outlit-sdk](https://github.com/OutlitAI/outlit-agent-skills/tree/main/skills/outlit-sdk)** - Integrate Outlit tracking across web, server, and native apps
+
+</details>
+
+<details>
 <summary><h3 style="display:inline">Skills by NVIDIA</h3></summary>
 
 Official skills published by NVIDIA across AI/ML infrastructure projects — Megatron, NeMo, TensorRT-LLM, CUDA-Q, cuOpt, DALI, DeepStream, and more. 155 skills across 17 products.


### PR DESCRIPTION
## Summary

Adds the official Outlit agent skills to the curated official skills list:

- `outlit/outlit` for Outlit customer intelligence, timelines, revenue, churn, SQL analytics, and source evidence
- `outlit/outlit-sdk` for Outlit SDK tracking integration across web, server, native, and desktop apps

Both skills are hosted in the public `OutlitAI/outlit-agent-skills` repository.