### PR TITLE
Add Linked API linkedin skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1626,6 +1626,7 @@ Production-grade Agent Skills for every major test automation framework, maintai
 - **[deusyu/translate-book](https://github.com/deusyu/translate-book)** - Translate books (PDF/DOCX/EPUB) via parallel sub-agents with resume
 - **[mvanhorn/last30days-skill](https://github.com/mvanhorn/last30days-skill)** - Research any topic across Reddit, X, YouTube, HN, Polymarket, and the web, ranked by upvotes, likes, and real money instead of editors
 - **[santifer/career-ops](https://github.com/santifer/career-ops)** - 14-skill collection for AI-powered job search: JD evaluation with A-F scoring, ATS-optimized PDF generation, portal scanners (Greenhouse/Ashby/Lever), interview prep with STAR+R, batch processing, and a Go dashboard TUI
+- **[Linked-API/linkedin](https://github.com/Linked-API/linkedin-skills/tree/main/linkedin)** - Fetch LinkedIn profiles, search people and companies, send messages, manage connections, create posts, react, comment, and run custom LinkedIn workflows from Claude Code, Codex, Cursor, and Windsurf.
 - **[pattern-ai-labs/agentcall](https://github.com/pattern-ai-labs/agentcall)** - Let your AI agents join Google Meet, Zoom, Teams calls and collaborate like a real team-mate.
 
 </details>


### PR DESCRIPTION
Adds Linked API skill listing for `linkedin`.

- Skill: General LinkedIn automation
- Listing name: linkedin-skills
- Source: https://github.com/Linked-API/linkedin-skills/tree/main/linkedin
- Docs: https://linkedapi.io/skills/linkedin-skill
- Install runbook: https://linkedapi.io/skills/linkedin/install.md
- Description: Fetch LinkedIn profiles, search people and companies, send messages, manage connections, create posts, react, comment, and run custom LinkedIn workflows from Claude Code, Codex, Cursor, and Windsurf.
- Tags: LinkedIn, automation, social, agent-skill
- Catalog state: /Users/kiril/Documents/Work/LinkedAPI/.claude/skills/publish-skills/catalogs/voltagent-awesome-agent-skills.md

Publication copy:
LinkedIn Skill gives AI agents natural-language access to LinkedIn automation through Linked API. It supports profile and company research, people and company search, messaging, connection requests and management, post creation, reactions, comments, stats, Sales Navigator actions, and custom workflows. It works with Claude Code, Codex, Cursor, and Windsurf and uses dedicated cloud browsers through Linked API.

Assets:
- Logo: assets/logo.png (https://linkedapi.io/logo.png)
- Social card: assets/social-card.png (https://linkedapi.io/opengraph-image?b7d7037e63c6122a)
- Screenshot: assets/screenshots/linkedin-skill.png (https://linkedapi.io/skills/linkedin-skill)