### PR TITLE
Add skill: 3060226349kk-cmd/ja-zh-max

### DIFF
--- a/README.md
+++ b/README.md
@@ -1766,6 +1766,7 @@ Production-grade Agent Skills for every major test automation framework, maintai
 - **[meodai/skill.color-expert](https://github.com/meodai/skill.color-expert)** - Color science expert skill with 286K words of reference material covering OKLCH/OKLAB, palette generation, accessibility/contrast, color naming, pigment mixing, and historical color theory
 - **[aklofas/kicad-happy](https://github.com/aklofas/kicad-happy)** - AI-powered KiCad electronics design review and analysis
 - **[bitwize-music-studio/claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills)** - Full-lifecycle AI music album production
+- **[3060226349kk-cmd/ja-zh-max](https://github.com/3060226349kk-cmd/ja-zh-max)** - Japanese→Chinese translation & polish with 20 distilled skills
 
 </details>
 


### PR DESCRIPTION
## Add skill: 3060226349kk-cmd/ja-zh-max

**ja-zh-max** — Japanese→Chinese translation & polish skill for Claude Code, with 20 distilled skills from Gao Ning's textbook.

- **Description**: Japanese→Chinese translation & polish with 20 distilled skills
- **Category**: Community Skills > Specialized Domains
- **Repo**: https://github.com/3060226349kk-cmd/ja-zh-max