### PR TITLE
Add Quotor — home & auto insurance quotes skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1562,6 +1562,13 @@ Production-grade Agent Skills for every major test automation framework, maintai
 ### Community Skills
 
 <details>
+<summary><h3 style="display:inline">Insurance</h3></summary>
+
+- **[quotor/home-auto-insurance-quotes](https://github.com/quotor/home-auto-insurance-quotes)** - Real, bindable home & auto insurance quotes (US/Texas, expanding) via the Quotor MCP at mcp.quotor.ai — carrier-masked options, human-completed bind
+
+</details>
+
+<details>
 <summary><h3 style="display:inline">Vector Databases</h3></summary>
 
 - **[qdrant/skills](https://github.com/qdrant/skills)** - Agent skills for Qdrant vector search, covering scaling, performance optimization, search quality, monitoring, deployment, model migration, version upgrades, and SDK usage across Python, TypeScript, Rust, Go, .NET, and Java


### PR DESCRIPTION
Adds **Quotor** under Community Skills in a new **Insurance** category — an Agent Skill (SKILL.md) that quotes real, bindable home & auto insurance (US/Texas, expanding) via the Quotor MCP at mcp.quotor.ai; carrier-masked options, human-completed bind by a licensed agency.

- Skill repo: https://github.com/quotor/home-auto-insurance-quotes
- MCP endpoint: https://mcp.quotor.ai (also in the official MCP registry as io.github.quotor/home-auto-insurance-quotes)

Created a new Insurance category since none existed; happy to recategorize if you'd prefer it elsewhere.