### PR TITLE
Add plugin: Telegram Customer Support plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1627,6 +1627,7 @@ Production-grade Agent Skills for every major test automation framework, maintai
 - **[mvanhorn/last30days-skill](https://github.com/mvanhorn/last30days-skill)** - Research any topic across Reddit, X, YouTube, HN, Polymarket, and the web, ranked by upvotes, likes, and real money instead of editors
 - **[santifer/career-ops](https://github.com/santifer/career-ops)** - 14-skill collection for AI-powered job search: JD evaluation with A-F scoring, ATS-optimized PDF generation, portal scanners (Greenhouse/Ashby/Lever), interview prep with STAR+R, batch processing, and a Go dashboard TUI
 - **[pattern-ai-labs/agentcall](https://github.com/pattern-ai-labs/agentcall)** - Let your AI agents join Google Meet, Zoom, Teams calls and collaborate like a real team-mate.
+- **[igorrendulic/telegram-support](https://github.com/igorrendulic/tg-customer-support-plugin)** - Telegram support plugin for founders and maintainers
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -1627,7 +1627,7 @@ Production-grade Agent Skills for every major test automation framework, maintai
 - **[mvanhorn/last30days-skill](https://github.com/mvanhorn/last30days-skill)** - Research any topic across Reddit, X, YouTube, HN, Polymarket, and the web, ranked by upvotes, likes, and real money instead of editors
 - **[santifer/career-ops](https://github.com/santifer/career-ops)** - 14-skill collection for AI-powered job search: JD evaluation with A-F scoring, ATS-optimized PDF generation, portal scanners (Greenhouse/Ashby/Lever), interview prep with STAR+R, batch processing, and a Go dashboard TUI
 - **[pattern-ai-labs/agentcall](https://github.com/pattern-ai-labs/agentcall)** - Let your AI agents join Google Meet, Zoom, Teams calls and collaborate like a real team-mate.
-- **[igorrendulic/telegram-support](https://github.com/igorrendulic/tg-customer-support-plugin)** - Telegram support plugin for founders and maintainers
+- **[igorrendulic/telegram-support](https://github.com/igorrendulic/tg-customer-support-plugin)** - A lightweight Telegram customer support plugin for founders and open source maintainers
 
 </details>
 


### PR DESCRIPTION
- **Add skill: igorrendulic/telegram-support**
- **Add Telegram support plugin - A lightweight customer support plugin for founders and open source maintainers.**

## Who this is for
This is for people who already run support inside Telegram:
- solo founders answering users directly
- maintainers of developer tools
- small SaaS teams without a hosted helpdesk
- support engineers who need local searchable context
- projects where support data should stay on the operator's machine

## What is does
- Syncs a configured Telegram support chat into a local profile.
- Crawls website/blog/docs seeds for support knowledge.
- Builds local hybrid search with SQLite FTS5 + sqlite-vec.
- Uses local embeddings for semantic retrieval.
- Searches live repository evidence for product/API/debugging questions.
- Creates evidence-backed reply drafts.
- Requires explicit confirmation before posting to Telegram.
- Works from Codex, Claude, or the tg-support CLI.

