### PR TITLE
Add marketing & AEO curated resource lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,13 @@ Official skills by VoltAgent for building AI agents with the VoltAgent TypeScrip
 - **[sanity-io/seo-aeo-best-practices](https://officialskills.sh/sanity-io/skills/seo-aeo-best-practices)** - SEO and answer engine optimization patterns for content sites
 - **[sanity-io/content-experimentation-best-practices](https://officialskills.sh/sanity-io/skills/content-experimentation-best-practices)** - Content A/B testing and experimentation workflows
 
+### Marketing & AEO Resources
+
+Curated reference lists for engineers building answer engine optimisation and marketing agent skills.
+
+- **[awesome-aeo-seo-agents](https://github.com/discoveredlabs/awesome-aeo-seo-agents)** - Agentic GEO/AEO frameworks, MCP servers for SEO data, agent skill packages, and autonomous content optimisation pipelines - the companion reference for building AEO agent skills.
+- **[awesome-aeo-seo](https://github.com/discoveredlabs/awesome-aeo-seo)** - Research, architecture, and measurement guides for answer engine optimisation - foundational reading for engineers building AEO skills.
+
 ### Skills by Firecrawl Team
 - **[firecrawl/firecrawl-build](https://officialskills.sh/firecrawl/skills/firecrawl-build)** - Integrate Firecrawl into application code for web search, scraping, extraction, and browser interaction
 - **[firecrawl/firecrawl-build-interact](https://officialskills.sh/firecrawl/skills/firecrawl-build-interact)** - Multi-step Firecrawl browser flows: clicks, form fills, pagination, and auth-aware navigation


### PR DESCRIPTION
Hey - adding a couple of curated reference lists for folks building AEO/answer engine agent skills.

You've already got the Sanity \`seo-aeo-best-practices\` skill in here - these sit alongside it as broader reference lists covering the AEO agent space: frameworks, MCP servers for SEO data, and the research behind what drives AI search citations.

- **awesome-aeo-seo-agents** - agentic GEO/AEO frameworks, MCP servers for SEO data, agent skill packages, and continuous optimisation pipelines
- **awesome-aeo-seo** - research, tooling, and measurement guides for answer engine optimisation

All maintained by myself at Discovered. Happy to tweak the placement.

**Alternatively, if individual links are a better fit for this repo, these are the most relevant from our work:**

- [Agentic Browsing Checker](https://discoveredlabs.com/tools/agentic-browsing-checker) - free tool running 19 OPERABLE framework checks on any site: WebMCP registration, form annotation, accessibility tree quality, llms.txt validation, ARIA live regions, keyboard operability, and AI crawler robots.txt access
- [AI Assist Widget](https://discoveredlabs.com/tools/ai-assist-widget) - free single script tag that adds a floating button bar opening ChatGPT, Claude, Perplexity, Grok, or Gemini with the current page pre-filled; zero external dependencies, fully configurable
- [How Gemini Works: AI Agent Architecture Deep Dive](https://discoveredlabs.com/blog/how-gemini-works-ai-agent-architecture-deepdive) - protocol-level analysis cataloguing 227 RPC calls, 138 feature flags, and 6 query routing modes per session - documents how structured data and entity relationships influence citation decisions at the session level