### PR TITLE
Add skill: csthink/dashmotion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1710,6 +1710,7 @@ Production-grade Agent Skills for every major test automation framework, maintai
 - **[dembrandt/dembrandt-skills](https://github.com/dembrandt/dembrandt-skills)** - UX and design system skills: hierarchy, typography, accessibility, interactions
 - **[GanyuanRan/Aegis](https://github.com/GanyuanRan/Aegis)** - Evidence-driven method pack for AI coding agents
 - **[baskduf/codex-fable5](https://github.com/baskduf/FableCodex/tree/main/plugins/codex-fable5/skills/codex-fable5)** - Evidence-based workflow gates for Codex
+- **[csthink/dashmotion](https://github.com/csthink/dashmotion/tree/main/skills/dashmotion)** - Animated technical diagrams from plain English or Mermaid, self-contained HTML/SVG
 
 </details>
 


### PR DESCRIPTION
Adds `csthink/dashmotion` to **Community Skills → Development and Testing** — one line, links to the skill source path (`skills/dashmotion/`), no other entries touched.

Resubmission of #680 with the requested fix: entry now points to the skill source, not the project page.

Skill source: https://github.com/csthink/dashmotion/tree/main/skills/dashmotion