### PR TITLE
Add MFS to Community Skills > Context Engineering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1729,6 +1729,7 @@ Production-grade Agent Skills for every major test automation framework, maintai
 - **[NeoLabHQ/prompt-engineering](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/customaize-agent/skills/prompt-engineering)** - Widely used prompt engineering techniques and patterns, including Anthropic best practices and agent persuasion principles.
 - **[sametbrr/llm-wiki-manager](https://github.com/sametbrr/llm-wiki-manager)** - Persistent LLM-managed personal wiki — the model writes, cross-references, and maintains the knowledge base while you curate sources. Implements Karpathy's LLM Wiki pattern with 8 operating modes.
 - **[Panniantong/Agent-Reach](https://github.com/Panniantong/Agent-Reach)** - Multi-platform search CLI for 17 sites including Chinese platforms
+- **[zilliztech/mfs](https://github.com/zilliztech/mfs)** - `mfs-find` / `mfs-ingest` skills that search, grep and read across your code, docs, chat (Slack/Gmail/Jira), databases and object stores as one file-like, searchable namespace; self-hosted with local ONNX embeddings
 
 </details>
 


### PR DESCRIPTION
Adds **[zilliztech/mfs](https://github.com/zilliztech/mfs)** (Apache-2.0) to **Community Skills → Context Engineering**. MFS ships agent-agnostic skills — `mfs-ingest` and `mfs-find` — that expose your code, docs, chat, databases and object stores as one file-like, searchable namespace (`ls`/`cat`/`grep` + semantic search), self-hosted with local ONNX embeddings. Works across Claude Code / Codex / Gemini CLI via `npx skills add zilliztech/mfs`; sits well next to entries like `Agent-Reach` and `llm-wiki-manager`.