### PR TITLE
Add Mamba Labs GTM Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1675,6 +1675,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[indranilbanerjee/digital-marketing-pro](https://github.com/indranilbanerjee/digital-marketing-pro)** - 150-skill engagement methodology — 12-Part Strategy Flow, 25 specialist agents, EU AI Act Article 50 ready (C2PA signing), 6-platform AEO/GEO incl. Google AI Mode
 - **[infrasity-labs/dev-gtm-claude-skills](https://github.com/infrasity-labs/dev-gtm-claude-skills)**: GTM-focused skill collection for developer go-to-market workflows including launch planning, positioning, and outbound sequences.
 - **[nowork-studio/NotFair](https://github.com/nowork-studio/NotFair)** - SEO, GEO, Google Ads, and Meta Ads skills with live data
+- **[mambalabsdev/mamba-labs-skills](https://github.com/mambalabsdev/mamba-labs-skills)** - Free GTM skills: ICP, cold email, deliverability, hiring signals
 
 </details>
 


### PR DESCRIPTION
Adding [Mamba Labs GTM Skills](https://github.com/mambalabsdev/mamba-labs-skills), a collection of 4 free, MIT-licensed GTM skills for signal-based outbound workflows.

Skills included:
- **ICP Definition Builder**: Guided interview that outputs a structured ICP block for Clay, CRM filters, or targeting briefs.
- **Cold Email Structure Checker**: Audits cold email drafts against a 7-point framework with pass/fail scorecard and revised version.
- **Domain Health Pre-Check**: Scans SPF, DKIM, DMARC, and blacklist status via the Mamba Labs Domain Deliverability Checker MCP server.
- **Hiring Signal Spotter**: Detects GTM hiring signals on Greenhouse, Lever, and Ashby via the Mamba Labs GTM Hiring Signal Scraper MCP server.

Compatible with Claude Code, Codex CLI, Cursor, Gemini CLI, and MCP-compatible agents. Each skill includes YAML frontmatter with name, description, license, metadata (category + tags), compatibility, and version fields. The repo ships with a `.claude-plugin/marketplace.json` manifest.
