### PR TITLE
Add Riffkit to Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1675,6 +1675,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[indranilbanerjee/digital-marketing-pro](https://github.com/indranilbanerjee/digital-marketing-pro)** - 150-skill engagement methodology — 12-Part Strategy Flow, 25 specialist agents, EU AI Act Article 50 ready (C2PA signing), 6-platform AEO/GEO incl. Google AI Mode
 - **[infrasity-labs/dev-gtm-claude-skills](https://github.com/infrasity-labs/dev-gtm-claude-skills)**: GTM-focused skill collection for developer go-to-market workflows including launch planning, positioning, and outbound sequences.
 - **[nowork-studio/NotFair](https://github.com/nowork-studio/NotFair)** - SEO, GEO, Google Ads, and Meta Ads skills with live data
+- **[riffkit/skill](https://github.com/riffkit/skill)** - Riff a winning TikTok into your own short video — recreate a proven video's formula with your product, character, and language (EN/ES)
 
 </details>
 


### PR DESCRIPTION
Adds **Riffkit** — an agent skill for recreating the *formula* of a winning short video.

Riffkit takes one proven short video, studies the hook, pacing, and emotional beats that made it retain viewers, and generates a brand-new video around the user's own product, character, and language (English/Spanish). It never re-uploads the source; the output is an original.

- Open-source skill spec (MIT): https://github.com/riffkit/skill
- Live skill + examples: https://riffkit.ai/SKILL.md
- Rendering runs on Riffkit's hosted backend (account required), consistent with other hosted entries already in the list.

One entry, added to the **Community Skills** section in the existing format.
