### PR TITLE
Add skill: BESSER-PEARL/besser-skills, BESSER-PEARL/uml-drawing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1798,6 +1798,8 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[dembrandt/dembrandt-skills](https://github.com/dembrandt/dembrandt-skills)** - UX and design system skills: hierarchy, typography, accessibility, interactions
 - **[GanyuanRan/Aegis](https://github.com/GanyuanRan/Aegis)** - Evidence-driven method pack for AI coding agents
 - **[baskduf/codex-fable5](https://github.com/baskduf/FableCodex/tree/main/plugins/codex-fable5/skills/codex-fable5)** - Evidence-based workflow gates for Codex
+- **[BESSER-PEARL/besser-skills](https://github.com/BESSER-PEARL/besser-skills)** - Model-driven engineering skills for BESSER: B-UML modeling and code generation
+- **[BESSER-PEARL/uml-drawing](https://github.com/BESSER-PEARL/uml-drawing)** - Generate correct UML class diagrams as embeddable SVG/PNG images
 
 </details>
 


### PR DESCRIPTION
## Summary
Adds two skill repos from the BESSER-PEARL org (BESSER is an open-source low-code/model-driven-engineering platform) to the Development and Testing section:

- **[BESSER-PEARL/besser-skills](https://github.com/BESSER-PEARL/besser-skills)** - Model-driven engineering skills for BESSER: B-UML modeling and code generation across ~19 generators (Django, FastAPI, SQLAlchemy, React, etc.)
- **[BESSER-PEARL/uml-drawing](https://github.com/BESSER-PEARL/uml-drawing)** - Turns a description or existing code into a correct UML class diagram, rendered as an embeddable SVG/PNG for docs/READMEs

Both are public repos with a SKILL.md and documented install via `npx skills add`, follow the open Agent Skills standard, and are maintained by the BESSER-PEARL dev team.

