### PR TITLE
Add skill: Tubo2333/obsidian-knowledge-brain

### DIFF
--- a/README.md
+++ b/README.md
@@ -1817,6 +1817,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[NeoLabHQ/prompt-engineering](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/customaize-agent/skills/prompt-engineering)** - Widely used prompt engineering techniques and patterns, including Anthropic best practices and agent persuasion principles.
 - **[sametbrr/llm-wiki-manager](https://github.com/sametbrr/llm-wiki-manager)** - Persistent LLM-managed personal wiki — the model writes, cross-references, and maintains the knowledge base while you curate sources. Implements Karpathy's LLM Wiki pattern with 8 operating modes.
 - **[Panniantong/Agent-Reach](https://github.com/Panniantong/Agent-Reach)** - Multi-platform search CLI for 17 sites including Chinese platforms
+- **[Tubo2333/obsidian-knowledge-brain](https://github.com/Tubo2333/obsidian-knowledge-brain)** - Cross-session knowledge memory and rule evolution for AI coding agents
 
 </details>
 


### PR DESCRIPTION
## Description

Add [obsidian-knowledge-brain](https://github.com/Tubo2333/obsidian-knowledge-brain) to Community Skills → Context Engineering.

## About the skill

**obsidian-knowledge-brain v4.0** — An AI agent skill that remembers every technical decision and bug fix across sessions, and learns from them.

- MIT licensed | 49 stars | Cross-platform (Claude Code, Cursor, Gemini CLI, Codex)
- Zero dependencies — pure markdown + agent protocols
- Automatic [DECISION] and [ERROR] annotation → MECE classification → pattern extraction → rule evolution
- Global cross-project atom table with root-cause dedup
- Pre/During/Post three-phase MUST triggers for knowledge injection

## Checklist
- [x] Public repository with working skill
- [x] Has documentation (README + SKILL.md)
- [x] Author/org prefix included
- [x] Short description (≤10 words)
- [x] Added to appropriate category (Context Engineering)