### PR TITLE
Add cowork-to-code-bridge to Development and Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1798,6 +1798,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[dembrandt/dembrandt-skills](https://github.com/dembrandt/dembrandt-skills)** - UX and design system skills: hierarchy, typography, accessibility, interactions
 - **[GanyuanRan/Aegis](https://github.com/GanyuanRan/Aegis)** - Evidence-driven method pack for AI coding agents
 - **[baskduf/codex-fable5](https://github.com/baskduf/FableCodex/tree/main/plugins/codex-fable5/skills/codex-fable5)** - Evidence-based workflow gates for Codex
+- **[abhinaykrupa/cowork-to-code-bridge](https://github.com/abhinaykrupa/cowork-to-code-bridge/blob/main/skill/cowork-to-code-bridge/SKILL.md)** - Let a sandboxed agent run work on your real macOS/Linux machine: local-first async file-based bridge for git push, docker, running the actual test suite, and machine health — no inbound ports or HTTPS tunnel
 
 </details>
 


### PR DESCRIPTION
Adds **[cowork-to-code-bridge](https://github.com/abhinaykrupa/cowork-to-code-bridge)** under **Community Skills → Development and Testing**.

It ships a real `SKILL.md` ([path](https://github.com/abhinaykrupa/cowork-to-code-bridge/blob/main/skill/cowork-to-code-bridge/SKILL.md)) that gives a sandboxed coding agent the ability to run work on the user's actual macOS/Linux machine — `git push`, `docker build`, running the real test suite, checking machine health — through a local-first async file-based bridge. No inbound ports, no HTTPS tunnel, no cloud middleman.

- MIT-licensed, macOS / Linux / WSL2
- Idempotent and reboot-surviving
- Single-line entry, placed alphabetically-adjacent within the existing category

Fits the same infra/automation niche as the existing git/CI/orchestration skills in that section. Thanks for maintaining the list!