### PR TITLE
Add Hermes Tweet skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1665,6 +1665,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[CosmoBlk/email-marketing-bible](https://github.com/CosmoBlk/email-marketing-bible)** - 55K-word email marketing guide as an AI skill
 - **[smixs/creative-director-skill](https://github.com/smixs/creative-director-skill)** - AI creative director with recursive self-assessment: 20+ methodologies (SIT, TRIZ, Bisociation, SCAMPER, Synectics), 3-axis evaluation calibrated against Cannes/D&AD/HumanKind, 5-phase process from brief to presentation
 - **[Xquik-dev/x-twitter-scraper](https://github.com/Xquik-dev/x-twitter-scraper)** - Tweet search, profile tweets, follower export, media, posting, replies, MCP
+- **[Xquik-dev/hermes-tweet](https://github.com/Xquik-dev/hermes-tweet/tree/master/skills/hermes-tweet)** - X/Twitter automation through Hermes Agent
 - **[Xquik-dev/tweetclaw](https://github.com/Xquik-dev/tweetclaw)** - Post tweets, replies, DMs; search, monitor, run giveaways
 - **[SHADOWPR0/beautiful_prose](https://github.com/SHADOWPR0/beautiful_prose)** - Hard-edged writing style contract for timeless, forceful English prose without AI tics
 - **[blader/humanizer](https://github.com/blader/humanizer)** - Remove signs of AI-generated writing from text, making it sound more natural and human


### PR DESCRIPTION
Summary:
- add Hermes Tweet to the Marketing community skills list
- place it next to related X/Twitter skill resources

Validation:
- `git diff --check`
- checked the Hermes Tweet skill link returns HTTP 200
- checked for existing Hermes Tweet PRs or entries before opening
