### PR TITLE
Add work0r-ai/workorai (talent marketplace skill)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1715,6 +1715,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[mvanhorn/last30days-skill](https://github.com/mvanhorn/last30days-skill)** - Research any topic across Reddit, X, YouTube, HN, Polymarket, and the web, ranked by upvotes, likes, and real money instead of editors
 - **[santifer/career-ops](https://github.com/santifer/career-ops)** - 14-skill collection for AI-powered job search: JD evaluation with A-F scoring, ATS-optimized PDF generation, portal scanners (Greenhouse/Ashby/Lever), interview prep with STAR+R, batch processing, and a Go dashboard TUI
 - **[pattern-ai-labs/agentcall](https://github.com/pattern-ai-labs/agentcall)** - Let your AI agents join Google Meet, Zoom, Teams calls and collaborate like a real team-mate.
+- **[work0r-ai/workorai](https://github.com/work0r-ai/agent-kit/tree/main/skills/workorai)** - Talent-marketplace skill for candidates (job search, applications) and employers (job lifecycle, ranked candidate discovery with white-box match explanations) via the WorkorAI MCP server
 
 </details>
 


### PR DESCRIPTION
Adds WorkorAI to Community Skills / Productivity and Collaboration (end of section, per CONTRIBUTING).

- Skill: https://github.com/work0r-ai/agent-kit/tree/main/skills/workorai (public repo, documented SKILL.md + references)
- Covers candidate workflows (job search, applications) and employer workflows (job lifecycle, ranked candidate discovery with white-box match explanations) through the WorkorAI MCP server (streamable HTTP, also on the official MCP Registry as io.github.work0r-ai/workorai)
- npm: @workorai/agent-kit, MIT licensed
