### PR TITLE
Add skill: vostride/agent-qa skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1798,6 +1798,9 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[dembrandt/dembrandt-skills](https://github.com/dembrandt/dembrandt-skills)** - UX and design system skills: hierarchy, typography, accessibility, interactions
 - **[GanyuanRan/Aegis](https://github.com/GanyuanRan/Aegis)** - Evidence-driven method pack for AI coding agents
 - **[baskduf/codex-fable5](https://github.com/baskduf/FableCodex/tree/main/plugins/codex-fable5/skills/codex-fable5)** - Evidence-based workflow gates for Codex
+- **[vostride/agent-qa-authoring](https://github.com/vostride/agent-qa/tree/main/skills/agent-qa-authoring)** - Author natural-language web and mobile QA tests
+- **[vostride/agent-qa-debug-fix](https://github.com/vostride/agent-qa/tree/main/skills/agent-qa-debug-fix)** - Debug failed agent-qa runs and propose fixes
+- **[vostride/agent-qa-result-triage](https://github.com/vostride/agent-qa/tree/main/skills/agent-qa-result-triage)** - Triage agent-qa results by failure category
 
 </details>
 


### PR DESCRIPTION
## Summary
- add three published agent-qa skills under Development and Testing
- link to the authoring, debug/fix, and result triage SKILL.md directories
- keep descriptions within the 10-word contribution guideline

## Checks
- git diff --check