### PR TITLE
Add cc-usage (Community Skills → Development and Testing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1798,6 +1798,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[dembrandt/dembrandt-skills](https://github.com/dembrandt/dembrandt-skills)** - UX and design system skills: hierarchy, typography, accessibility, interactions
 - **[GanyuanRan/Aegis](https://github.com/GanyuanRan/Aegis)** - Evidence-driven method pack for AI coding agents
 - **[baskduf/codex-fable5](https://github.com/baskduf/FableCodex/tree/main/plugins/codex-fable5/skills/codex-fable5)** - Evidence-based workflow gates for Codex
+- **[liberzon/cc-usage](https://github.com/liberzon/cc-usage)** - Analyzes local Claude Code token usage and pay-as-you-go API-equivalent cost across all projects — all-time totals, daily/weekly breakdowns, per-model repricing, and top days/weeks. Read-only, Python stdlib only.
 
 </details>
 


### PR DESCRIPTION
Adds **[liberzon/cc-usage](https://github.com/liberzon/cc-usage)** to Community Skills → Development and Testing.

A Claude Code skill that analyzes your **local** token usage and the equivalent **pay-as-you-go (API dollar) cost** across all your projects, reading the JSONL transcripts Claude Code writes to `~/.claude/projects/`.

**What it does**
- All-time totals (input / output / cache-read / cache-write) + pay-as-you-go $
- Daily and weekly breakdowns; top days/weeks by tokens or cost
- Per-model cost at the actual model mix, or reprice everything onto one model
- Weekly min/max/median/mean statistics

Read-only, Python 3 standard-library only, no dependencies, no network calls. Reads token counts and model names — never message content. MIT licensed. Added at the end of the matching subcategory per CONTRIBUTING.

🤖 Generated with [Claude Code](https://claude.com/claude-code)