### PR TITLE
Add seldonframe-agent-business (build → sell → get paid for AI agents)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1646,6 +1646,14 @@ Official skills published by Cypress to help create, maintain, understand, and f
 
 </details>
 
+<details>
+     <summary><h3 style="display:inline">Skills by SeldonFrame</h3></summary>
+
+Official skill published by SeldonFrame for the full agent-business loop from your IDE. 1 skill.
+
+- **[seldonframe/seldonframe-agent-business](https://github.com/seldonframe/seldonframe/tree/main/skills/seldonframe-agent-business)** - Build, eval-gate, deploy, and sell AI agents for real businesses from your IDE via the SeldonFrame MCP (build → test → deploy → sell → get paid)
+
+</details>
 
 ### Community Skills
 


### PR DESCRIPTION
Added SeldonFrame skills section to README.`seldonframe-agent-business` teaches an IDE agent (Claude Code, Cursor, Codex) the complete agent-business loop on SeldonFrame: build an AI agent for a real business from one sentence, test it against the 8-scenario eval suite that gates publishing at ≥ 87.5%, deploy it to a real channel with the human-only connect step handled honestly, list it on the marketplace with per-call or per-outcome usage pricing, and withdraw the earnings. Every tool name is grounded in the real `@seldonframe/mcp` tool surface — no invented tools — including a table of the names agents typically guess wrong. Guardrails: the agent never collects secret keys in chat and never moves real money (payouts, phone provisioning, price changes) without an explicit human ask. First workspace is free with no API key; keys are requested progressively only when a verb needs them.

Added as a new org section (Skills by SeldonFrame) following the existing details/summary pattern, per the repo's per-org layout. Happy to move it to Community Skills instead if you prefer.