### PR TITLE
Add skill: aaron-he-zhu/aaron-marketing-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1675,6 +1675,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[indranilbanerjee/digital-marketing-pro](https://github.com/indranilbanerjee/digital-marketing-pro)** - 150-skill engagement methodology — 12-Part Strategy Flow, 25 specialist agents, EU AI Act Article 50 ready (C2PA signing), 6-platform AEO/GEO incl. Google AI Mode
 - **[infrasity-labs/dev-gtm-claude-skills](https://github.com/infrasity-labs/dev-gtm-claude-skills)**: GTM-focused skill collection for developer go-to-market workflows including launch planning, positioning, and outbound sequences.
 - **[nowork-studio/NotFair](https://github.com/nowork-studio/NotFair)** - SEO, GEO, Google Ads, and Meta Ads skills with live data
+- **[aaron-he-zhu/aaron-marketing-skills](https://github.com/aaron-he-zhu/aaron-marketing-skills)** - 69 marketing skills across SEO/GEO, influencer, paid ads, and email on one shared contract, with 5 benchmark-driven auditor gates (CORE-EEAT, CITE, C³, ROAS, SEND) and keyless data connectors
 
 </details>
 


### PR DESCRIPTION
Adds **[aaron-he-zhu/aaron-marketing-skills](https://github.com/aaron-he-zhu/aaron-marketing-skills)** to **Community Skills → Marketing**.

**What it is**: 69 marketing skills across four disciplines — SEO/GEO, influencer (IMPACT), paid ads (ROAS), email (SEND) — all on one shared contract (trigger → quick start → handoff → next-best-skill), with 5 benchmark-driven auditor gates (CORE-EEAT, CITE, C³, ROAS, SEND) that emit machine-checkable verdicts, plus zero-dependency keyless data connectors.

**Checklist per CONTRIBUTING**:
- ✅ Public repo, Apache-2.0, each skill a spec-compliant `SKILL.md` (validated in CI on every commit)
- ✅ Works via `npx skills add aaron-he-zhu/aaron-marketing-skills` (69/69 discovered) and as a Claude Code plugin
- ✅ Documentation: README + per-skill SKILL.md + [agent-compatibility matrix](https://github.com/aaron-he-zhu/aaron-marketing-skills/blob/main/docs/agent-compatibility.md)
- ✅ Adoption: live on [skills.sh](https://skills.sh/aaron-he-zhu/aaron-marketing-skills) (300+ installs), ClawHub, SkillHub.cn; latest release v13.0.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)