### PR TITLE
Add skill: Luckycat133/gemini-web-mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -1798,6 +1798,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[dembrandt/dembrandt-skills](https://github.com/dembrandt/dembrandt-skills)** - UX and design system skills: hierarchy, typography, accessibility, interactions
 - **[GanyuanRan/Aegis](https://github.com/GanyuanRan/Aegis)** - Evidence-driven method pack for AI coding agents
 - **[baskduf/codex-fable5](https://github.com/baskduf/FableCodex/tree/main/plugins/codex-fable5/skills/codex-fable5)** - Evidence-based workflow gates for Codex
+- **[Luckycat133/gemini-web-mcp](https://github.com/Luckycat133/gemini-web-mcp/tree/main/.agents/skills/gemini-web-mcp)** - Guides safe Gemini Web MCP tool usage
 
 </details>
 


### PR DESCRIPTION
## Summary
- Add Luckycat133/gemini-web-mcp to Community Skills / Development and Testing.

## Link
- https://github.com/Luckycat133/gemini-web-mcp/tree/main/.agents/skills/gemini-web-mcp

## Notes
The skill guides safe Gemini Web MCP usage with manifest-first tool selection and narrow tool profiles.
