### PR TITLE
Add multi-code-review project link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1798,6 +1798,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[dembrandt/dembrandt-skills](https://github.com/dembrandt/dembrandt-skills)** - UX and design system skills: hierarchy, typography, accessibility, interactions
 - **[GanyuanRan/Aegis](https://github.com/GanyuanRan/Aegis)** - Evidence-driven method pack for AI coding agents
 - **[baskduf/codex-fable5](https://github.com/baskduf/FableCodex/tree/main/plugins/codex-fable5/skills/codex-fable5)** - Evidence-based workflow gates for Codex
+- **[szarkans/multi-code-review](https://github.com/szarkans/multi-code-review)** - consensus code reviews using Claude, Codex, and Antigravity in parallel.
 
 </details>
 


### PR DESCRIPTION
Multi Code Review is a Claude Code plugin and Agent Skill that runs Claude, OpenAI Codex, and optionally Google Antigravity against the same diff in parallel. It reconciles overlapping findings, verifies issues reported by only one reviewer, filters false positives, and produces a single ranked consensus report. It supports uncommitted changes, branch comparisons, individual commits, and an optional fix-and-review loop.