### PR TITLE
Add skill: linhay/harmony-next.skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1798,6 +1798,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[dembrandt/dembrandt-skills](https://github.com/dembrandt/dembrandt-skills)** - UX and design system skills: hierarchy, typography, accessibility, interactions
 - **[GanyuanRan/Aegis](https://github.com/GanyuanRan/Aegis)** - Evidence-driven method pack for AI coding agents
 - **[baskduf/codex-fable5](https://github.com/baskduf/FableCodex/tree/main/plugins/codex-fable5/skills/codex-fable5)** - Evidence-based workflow gates for Codex
+- **[linhay/harmony-next.skills](https://github.com/linhay/harmony-next.skills/tree/master/harmony-next)** - HarmonyOS NEXT development skill for AI coding agents, with offline ArkTS/ArkUI/API references, DevEco/HDC/Emulator workflows, debugging scripts, UI/UX audits, and smoke-test templates.
 
 </details>
 


### PR DESCRIPTION
Adds `linhay/harmony-next.skills` to Community Skills / Development and Testing.

This is a mature HarmonyOS NEXT developer skill for AI coding agents. It includes offline ArkTS/ArkUI/API references, DevEco Studio, HDC and Emulator workflows, debugging scripts, UI/UX audit helpers, and smoke-test templates.

The repository currently has 250+ stars and 20+ forks, and is intended for real HarmonyOS NEXT development workflows rather than a generic documentation mirror.