### PR TITLE
Add skill: Wei18/upkeep-audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1798,6 +1798,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[dembrandt/dembrandt-skills](https://github.com/dembrandt/dembrandt-skills)** - UX and design system skills: hierarchy, typography, accessibility, interactions
 - **[GanyuanRan/Aegis](https://github.com/GanyuanRan/Aegis)** - Evidence-driven method pack for AI coding agents
 - **[baskduf/codex-fable5](https://github.com/baskduf/FableCodex/tree/main/plugins/codex-fable5/skills/codex-fable5)** - Evidence-based workflow gates for Codex
+- **[Wei18/upkeep-audit](https://github.com/Wei18/Upkeep/tree/main/skills/upkeep-audit)** - Audits repos for docs, spec, and asset drift with evidence
 
 </details>
 


### PR DESCRIPTION
## What it is

[Wei18/upkeep-audit](https://github.com/Wei18/Upkeep/tree/main/skills/upkeep-audit) is a Claude Code plugin that audits a repo for drift between docs, specs, and code/assets — surfacing findings with evidence, ranked by severity, as a self-contained HTML report. Output-only (never modifies files); also ships a reusable GitHub Actions workflow for scheduled CI audits.

Current status, for transparency:
- Repo created 2026-06-05, 4 stars
- Already listed in hesreallyhim/awesome-claude-code

Aware of the community-usage guideline — submitting for your judgment; happy to close and resubmit later if it's too early.

Added to the end of the "Development and Testing" community skills subcategory.

## Test plan

- [x] Link resolves: https://github.com/Wei18/Upkeep/tree/main/skills/upkeep-audit
- [x] Description is 10 words or fewer
- [x] Only README.md changed, one line added

🤖 Generated with [Claude Code](https://claude.com/claude-code)