### PR TITLE
Add skills: nusantara-ventures goldprice-skills + exchangerate-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1854,6 +1854,8 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[meodai/skill.color-expert](https://github.com/meodai/skill.color-expert)** - Color science expert skill with 286K words of reference material covering OKLCH/OKLAB, palette generation, accessibility/contrast, color naming, pigment mixing, and historical color theory
 - **[aklofas/kicad-happy](https://github.com/aklofas/kicad-happy)** - AI-powered KiCad electronics design review and analysis
 - **[bitwize-music-studio/claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills)** - Full-lifecycle AI music album production
+- **[nusantara-ventures/goldprice-skills](https://github.com/nusantara-ventures/goldprice-skills)** - Gold, silver & copper price API integration skills
+- **[nusantara-ventures/exchangerate-skills](https://github.com/nusantara-ventures/exchangerate-skills)** - FX rates & currency conversion API integration skills
 
 </details>
 


### PR DESCRIPTION
Adds two public Agent Skills repositories to **Community Skills → Specialized Domains**:

- **[nusantara-ventures/goldprice-skills](https://github.com/nusantara-ventures/goldprice-skills)** — 4 skills for the goldprice.dev gold / silver / copper price API (retail per-gram/karat conversion, price alerts, historical charting, integration basics).
- **[nusantara-ventures/exchangerate-skills](https://github.com/nusantara-ventures/exchangerate-skills)** — 6 skills for the exchangerate.dev FX-rates API.

Both are public, Apache-2.0, follow the `SKILL.md` convention, and are keyless-friendly (usable without an API key). Entries follow the existing format; descriptions are under 10 words.