### PR TITLE
Add frank (anti-sycophancy skill)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1817,6 +1817,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[NeoLabHQ/prompt-engineering](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/customaize-agent/skills/prompt-engineering)** - Widely used prompt engineering techniques and patterns, including Anthropic best practices and agent persuasion principles.
 - **[sametbrr/llm-wiki-manager](https://github.com/sametbrr/llm-wiki-manager)** - Persistent LLM-managed personal wiki — the model writes, cross-references, and maintains the knowledge base while you curate sources. Implements Karpathy's LLM Wiki pattern with 8 operating modes.
 - **[Panniantong/Agent-Reach](https://github.com/Panniantong/Agent-Reach)** - Multi-platform search CLI for 17 sites including Chinese platforms
+- **[huxleyli15/frank](https://github.com/huxleyli15/frank)** - Anti-sycophancy skill: stops the agent from flattering, hedging, and caving under pushback. Verdict-first, steelmans then challenges, holds its ground on evidence.
 
 </details>
 


### PR DESCRIPTION
Adds **frank** — a single-file anti-sycophancy agent skill.

- Repo: https://github.com/huxleyli15/frank
- What it does: stops the assistant from flattering, hedging, and caving under
  pushback. Verdict-first, steelman-then-challenge, confidence-labeled, holds
  on evidence instead of tone.
- Cross-platform SKILL.md (Claude Code / Cursor / Codex), MIT, bilingual EN/中文,
  with before/after examples.