### PR TITLE
Add skill: berkayturk/appstore-precheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -1798,6 +1798,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[dembrandt/dembrandt-skills](https://github.com/dembrandt/dembrandt-skills)** - UX and design system skills: hierarchy, typography, accessibility, interactions
 - **[GanyuanRan/Aegis](https://github.com/GanyuanRan/Aegis)** - Evidence-driven method pack for AI coding agents
 - **[baskduf/codex-fable5](https://github.com/baskduf/FableCodex/tree/main/plugins/codex-fable5/skills/codex-fable5)** - Evidence-based workflow gates for Codex
+- **[berkayturk/appstore-precheck](https://github.com/berkayturk/appstore-precheck)** - iOS App Store pre-submission gate with GREEN/YELLOW/RED verdict
 
 </details>
 


### PR DESCRIPTION
Adds **[berkayturk/appstore-precheck](https://github.com/berkayturk/appstore-precheck)** to the end of the Community Skills > Development and Testing section.

- Read-only iOS App Store pre-submission gate: 42 static rejection-vector checks plus 28 semantic deep-review checks, ending in a GREEN/YELLOW/RED verdict.
- One SKILL.md (at `skills/appstore-precheck/SKILL.md`, following the agentskills.io open standard) runs on Claude Code, Codex, Cursor, and Gemini CLI; also available as an npx CLI and a GitHub Action.
- Public repo, MIT licensed, documented (README + SKILL.md), published on npm.

Entry follows CONTRIBUTING.md: added to end of the matching subcategory, author-prefixed name, description under 10 words, links verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XUSQGcNvjS14UmnYG1yX1r