### PR TITLE
Add dino-markets-skills to Specialized Domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -1854,6 +1854,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[meodai/skill.color-expert](https://github.com/meodai/skill.color-expert)** - Color science expert skill with 286K words of reference material covering OKLCH/OKLAB, palette generation, accessibility/contrast, color naming, pigment mixing, and historical color theory
 - **[aklofas/kicad-happy](https://github.com/aklofas/kicad-happy)** - AI-powered KiCad electronics design review and analysis
 - **[bitwize-music-studio/claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills)** - Full-lifecycle AI music album production
+- **[nusantara-ventures/dino-markets-skills](https://github.com/nusantara-ventures/dino-markets-skills)** - Cross-venue sports prediction-market data: Kalshi x Polymarket arbitrage, settlement disclosure, real-time stream
 
 </details>
 


### PR DESCRIPTION
Adds 6 Agent Skills for dino.markets — cross-venue sports prediction-market data (Kalshi x Polymarket), live arbitrage, settlement disclosure, real-time stream. Repo: https://github.com/nusantara-ventures/dino-markets-skills