### PR TITLE
Add skill: whistler/dream

### DIFF
--- a/README.md
+++ b/README.md
@@ -1817,6 +1817,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[NeoLabHQ/prompt-engineering](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/customaize-agent/skills/prompt-engineering)** - Widely used prompt engineering techniques and patterns, including Anthropic best practices and agent persuasion principles.
 - **[sametbrr/llm-wiki-manager](https://github.com/sametbrr/llm-wiki-manager)** - Persistent LLM-managed personal wiki — the model writes, cross-references, and maintains the knowledge base while you curate sources. Implements Karpathy's LLM Wiki pattern with 8 operating modes.
 - **[Panniantong/Agent-Reach](https://github.com/Panniantong/Agent-Reach)** - Multi-platform search CLI for 17 sites including Chinese platforms
+- **[whistler/dream](https://github.com/whistler/dreamer)** - Mine session history for repeated corrections into context file updates
 
 </details>
 


### PR DESCRIPTION
Adds **[whistler/dream](https://github.com/whistler/dreamer)** to Community Skills → Context Engineering.

The /dream skill mines coding-agent session history (via cass, 20 harnesses supported) for corrections the user keeps repeating, and proposes CLAUDE.md / AGENTS.md updates with the original conversations attached as evidence. Changes are applied only after user approval. Everything runs locally.

- Public repo with README and SKILL.md docs: https://github.com/whistler/dreamer
- Install: `npx skills add whistler/dreamer --skill dream -g -y`
- MIT licensed, published on PyPI as `agent-dreamer`

🤖 Generated with [Claude Code](https://claude.com/claude-code)