### PR TITLE
Add skill: wanglihong564/prelaunch-test-audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1798,6 +1798,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[dembrandt/dembrandt-skills](https://github.com/dembrandt/dembrandt-skills)** - UX and design system skills: hierarchy, typography, accessibility, interactions
 - **[GanyuanRan/Aegis](https://github.com/GanyuanRan/Aegis)** - Evidence-driven method pack for AI coding agents
 - **[baskduf/codex-fable5](https://github.com/baskduf/FableCodex/tree/main/plugins/codex-fable5/skills/codex-fable5)** - Evidence-based workflow gates for Codex
+- **[wanglihong564/prelaunch-test-audit](https://github.com/wanglihong564/test-VideCoding/tree/main/prelaunch-test-audit)** - Read-only release readiness audits for AI coding agents
 
 </details>
 


### PR DESCRIPTION
This PR adds `wanglihong564/prelaunch-test-audit`, a reusable Agent Skill for read-only release-readiness audits.

It helps AI coding agents reduce launch risk by checking functional correctness, access-control risks, data safety, security review, regression coverage, deployment readiness, rollback safety, supply-chain risk, and Go / Conditional Go / No Go release decisions.

Repository: https://github.com/wanglihong564/test-VideCoding/tree/main/prelaunch-test-audit