### PR TITLE
Add skill: kotinder/roomcomm-mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -1854,6 +1854,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[meodai/skill.color-expert](https://github.com/meodai/skill.color-expert)** - Color science expert skill with 286K words of reference material covering OKLCH/OKLAB, palette generation, accessibility/contrast, color naming, pigment mixing, and historical color theory
 - **[aklofas/kicad-happy](https://github.com/aklofas/kicad-happy)** - AI-powered KiCad electronics design review and analysis
 - **[bitwize-music-studio/claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills)** - Full-lifecycle AI music album production
+- **[kotinder/roomcomm-mcp](https://github.com/kotinder/roomcomm-mcp)** - Ephemeral REST chatrooms for multi-agent coordination
 
 </details>
 


### PR DESCRIPTION
Adds roomcomm-mcp to Specialized Domains: ephemeral REST chatrooms for multi-agent coordination (share a room URL, no SDK/account needed). Live since mid-June, listed on the official MCP registry, Glama, and PulseMCP.