### PR TITLE
Add skill: hedging8563/tokenlab-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1804,6 +1804,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[GanyuanRan/Aegis](https://github.com/GanyuanRan/Aegis)** - Evidence-driven method pack for AI coding agents
 - **[baskduf/codex-fable5](https://github.com/baskduf/FableCodex/tree/main/plugins/codex-fable5/skills/codex-fable5)** - Evidence-based workflow gates for Codex
 - **[csthink/dashmotion](https://github.com/csthink/dashmotion/tree/main/skills/dashmotion)** - Animated technical diagrams from plain English or Mermaid, self-contained HTML/SVG
+- **[hedging8563/tokenlab-skills](https://github.com/hedging8563/tokenlab-skills)** - TokenLab API, model, and native endpoint integration
 
 </details>
 


### PR DESCRIPTION
## Summary\n\nAdds the public TokenLab skills repository to the Community Skills / Development and Testing section.\n\n## Why it fits\n\n- Public repository with maintained SKILL.md files: https://github.com/hedging8563/tokenlab-skills\n- Covers practical coding-agent workflows for TokenLab API integration, model selection, and native endpoint routing.\n- Includes documentation and install commands in the repository README.\n\n## Notes\n\nThe repository is a public distribution mirror for TokenLab agent skills. I kept the entry short and linked the repository rather than adding generated content to this list.