### PR TITLE
Add skill: pachca/openapi

### DIFF
--- a/README.md
+++ b/README.md
@@ -1715,6 +1715,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[mvanhorn/last30days-skill](https://github.com/mvanhorn/last30days-skill)** - Research any topic across Reddit, X, YouTube, HN, Polymarket, and the web, ranked by upvotes, likes, and real money instead of editors
 - **[santifer/career-ops](https://github.com/santifer/career-ops)** - 14-skill collection for AI-powered job search: JD evaluation with A-F scoring, ATS-optimized PDF generation, portal scanners (Greenhouse/Ashby/Lever), interview prep with STAR+R, batch processing, and a Go dashboard TUI
 - **[pattern-ai-labs/agentcall](https://github.com/pattern-ai-labs/agentcall)** - Let your AI agents join Google Meet, Zoom, Teams calls and collaborate like a real team-mate.
+- - **[pachca/openapi](https://github.com/pachca/openapi)** - Pachca messenger skills: chats, messages, tasks, bots
 
 </details>
 


### PR DESCRIPTION
Adds `pachca/openapi` to Community Skills → Productivity and Collaboration.

Pachca is a corporate messenger. This repository publishes official Agent Skills for it (chats, messages, tasks, bots, users, profile, search, etc.), each defined via SKILL.md and compatible with Claude Code, Codex, Cursor, and other agents.

Entry:
- **[pachca/openapi](https://github.com/pachca/openapi)** - Pachca messenger skills: chats, messages, tasks, bots

The skills are already indexed and installable through open skill registries — including skills.sh (the pachca/openapi skill family) and SkillsMP — so they're discoverable and in real-world use, not newly created for this submission.