### PR TITLE
Add skill: ohad6k/emulo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1823,7 +1823,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[NeoLabHQ/prompt-engineering](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/customaize-agent/skills/prompt-engineering)** - Widely used prompt engineering techniques and patterns, including Anthropic best practices and agent persuasion principles.
 - **[sametbrr/llm-wiki-manager](https://github.com/sametbrr/llm-wiki-manager)** - Persistent LLM-managed personal wiki — the model writes, cross-references, and maintains the knowledge base while you curate sources. Implements Karpathy's LLM Wiki pattern with 8 operating modes.
 - **[Panniantong/Agent-Reach](https://github.com/Panniantong/Agent-Reach)** - Multi-platform search CLI for 17 sites including Chinese platforms
-- **[ohad6k/ditto](https://github.com/ohad6k/ditto)** - Mines AI coding logs into personal agent profiles
+- **[ohad6k/emulo](https://github.com/ohad6k/emulo)** - Mines AI coding logs into personal agent profiles
 - **[Tubo2333/obsidian-knowledge-brain](https://github.com/Tubo2333/obsidian-knowledge-brain)** - Cross-session knowledge memory and rule evolution for AI coding agents
 
 </details>

--- a/README.md
+++ b/README.md
@@ -1818,6 +1818,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[NeoLabHQ/prompt-engineering](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/customaize-agent/skills/prompt-engineering)** - Widely used prompt engineering techniques and patterns, including Anthropic best practices and agent persuasion principles.
 - **[sametbrr/llm-wiki-manager](https://github.com/sametbrr/llm-wiki-manager)** - Persistent LLM-managed personal wiki — the model writes, cross-references, and maintains the knowledge base while you curate sources. Implements Karpathy's LLM Wiki pattern with 8 operating modes.
 - **[Panniantong/Agent-Reach](https://github.com/Panniantong/Agent-Reach)** - Multi-platform search CLI for 17 sites including Chinese platforms
+- **[ohad6k/ditto](https://github.com/ohad6k/ditto)** - Mines AI coding logs into personal agent profiles
 
 </details>
 


### PR DESCRIPTION
Adds [ohad6k/emulo](https://github.com/ohad6k/emulo) to Community Skills → Context Engineering.

Emulo mines your local Claude/Codex/Cursor session logs into a `you.md` profile your agents read before every task: how you decide, what "done" means to you, what you reject.

Community adoption: merged external PRs and active issue discussions. Zero-dependency single Python file, MIT.

Note: the project renamed from ditto to emulo since this PR was opened (the old name collided with existing products). The entry and links are updated to the current name.