### PR TITLE
Add skill: redamancy231-create/claude-skills/kill-test-first

### DIFF
--- a/README.md
+++ b/README.md
@@ -1804,6 +1804,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[GanyuanRan/Aegis](https://github.com/GanyuanRan/Aegis)** - Evidence-driven method pack for AI coding agents
 - **[baskduf/codex-fable5](https://github.com/baskduf/FableCodex/tree/main/plugins/codex-fable5/skills/codex-fable5)** - Evidence-based workflow gates for Codex
 - **[csthink/dashmotion](https://github.com/csthink/dashmotion/tree/main/skills/dashmotion)** - Animated technical diagrams from plain English or Mermaid, self-contained HTML/SVG
+- **[redamancy231-create/claude-skills/kill-test-first](https://github.com/redamancy231-create/claude-skills/tree/main/kill-test-first)** - Pre-registration decision audit: falsifiable hypothesis, prior-art check, adversarial review, death criteria, GO/STOP/REDESIGN
 
 </details>
 


### PR DESCRIPTION
## Skill

- **Name:** kill-test-first
- **Repo:** https://github.com/redamancy231-create/claude-skills/tree/main/kill-test-first
- **Category:** Development and Testing

## What it does

Pre-registration decision audit for new research directions, quant strategies, or architecture proposals. Two-gate protocol: Gate 1 (pre-build veto) runs falsifiable hypothesis → prior-art check → adversarial review → death criteria → cheapest falsification → GO/STOP/REDESIGN. Gate 2 (pre-registration freeze) locks protocol before confirmatory testing.

## Why it belongs

Fills a gap in the Development and Testing category: tools that help decide *whether* to build something, not just *how* to build it. Complementary to existing decision-support skills like Aegis and codex-fable5, but focused on pre-registration methodology with quant strategy redlines.

## Quality signals

- License: CC BY 4.0
- Actively maintained (battle-tested through 50+ rounds of cross-model independent review)
- Comprehensive docs: SKILL.md + EXAMPLES.md + 6 reference files
- Includes worked examples with real quant strategy data