### PR TITLE
Add skill: Rohan27s/posthell-cli (social post scheduling)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1674,6 +1674,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[degausai/wonda](https://github.com/degausai/wonda)** - AI content creation: images, video, music, audio, editing, publishing
 - **[gitroomhq/postiz-agent](https://github.com/gitroomhq/postiz-agent)** - Schedule social media posts across 28+ platforms programmatically
 - **[taisly/agent](https://github.com/taisly/agent)** - Codex plugin, Agent Skill, CLI, and MCP server for publishing approved short-form videos to TikTok, Instagram Reels, YouTube Shorts, X, and Facebook through Taisly
+- **[Rohan27s/posthell-cli](https://github.com/Rohan27s/posthell-cli)** - Draft, schedule, and publish social posts to 15 networks via posthell: agents draft into a human-approval queue by default, publishing is per-key opt-in with spend caps
 - **[indranilbanerjee/digital-marketing-pro](https://github.com/indranilbanerjee/digital-marketing-pro)** - 150-skill engagement methodology — 12-Part Strategy Flow, 25 specialist agents, EU AI Act Article 50 ready (C2PA signing), 6-platform AEO/GEO incl. Google AI Mode
 - **[infrasity-labs/dev-gtm-claude-skills](https://github.com/infrasity-labs/dev-gtm-claude-skills)**: GTM-focused skill collection for developer go-to-market workflows including launch planning, positioning, and outbound sequences.
 - **[nowork-studio/NotFair](https://github.com/nowork-studio/NotFair)** - SEO, GEO, Google Ads, and Meta Ads skills with live data


### PR DESCRIPTION
Adds posthell-cli: an agent skill + zero-dependency CLI for scheduling social media posts through posthell (15 networks: X, LinkedIn, Instagram, TikTok, YouTube, Threads, Bluesky, and more).

- SKILL.md: https://github.com/Rohan27s/posthell-cli/blob/main/SKILL.md (hard-rules-first: drafting into a human-approval queue is the default; publishing is a per-key opt-in and metered X spend is hard-capped by a prepaid wallet)
- Install: `npm i -g posthell-cli` or `npx skills add Rohan27s/posthell-cli`
- Under the hood it speaks JSON-RPC to posthell's hosted MCP server, so it inherits the same auth, rate limits, and safety gates
- Placed next to the other social-publishing skills (postiz-agent, taisly)