### PR TITLE
Add kampff-skills — human spectrum analysis from text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1692,6 +1692,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[gokapso/automate-whatsapp](https://github.com/gokapso/agent-skills/tree/master/skills/automate-whatsapp)** - Build WhatsApp automations with workflows and agents
 - **[gokapso/observe-whatsapp](https://github.com/gokapso/agent-skills/tree/master/skills/observe-whatsapp)** - Debug WhatsApp delivery issues and run health checks
 - **[PleasePrompto/notebooklm-skill](https://github.com/PleasePrompto/notebooklm-skill)** - Interact with NotebookLM for document-based conversations
+- **[YangKangSung/kampff-skills](https://github.com/YangKangSung/kampff-skills)** - Human spectrum analysis from text traces — worldview fit, alliance fit, ephemeris, and engage/caution/avoid distance with quoted evidence. spectrograph 7-layer protocol; optional HR and OSINT lenses
 - **[obra/superpowers-lab](https://github.com/obra/superpowers-lab)** - Lab environment for Claude superpowers
 - **[obra/brainstorming](https://github.com/obra/superpowers/blob/main/skills/brainstorming/SKILL.md)** - Generate and explore ideas
 - **[obra/writing-plans](https://github.com/obra/superpowers/blob/main/skills/writing-plans/SKILL.md)** - Create strategic documentation


### PR DESCRIPTION
## Summary

Adds [kampff-skills](https://github.com/YangKangSung/kampff-skills) under **Community Skills → Productivity and Collaboration**.

Agent skill for analyzing people from posts, comments, and board traces:
- worldview / alliance fit
- ephemeris (temporal drift)
- distance: engage · neutral · caution · avoid
- spectrograph 7-layer protocol (HR/OSINT lenses optional)

MIT · SKILL.md · Grok / Claude / Hermes compatible