### PR TITLE
Add skill: currentslab/news-api-currents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1863,6 +1863,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[aklofas/kicad-happy](https://github.com/aklofas/kicad-happy)** - AI-powered KiCad electronics design review and analysis
 - **[bitwize-music-studio/claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills)** - Full-lifecycle AI music album production
 - **[Alisa0808/vibe-creating-skill](https://github.com/Alisa0808/vibe-creating-skill)** - Rewrites a rough idea or shot script into text-to-video prompts
+- **[currentslab/news-api-currents](https://github.com/currentslab/news-api-skills)** - Secure Currents API news reading skill
 
 </details>
 


### PR DESCRIPTION
## What does this PR change?

Adds `currentslab/news-api-currents` to Specialized Domains.

## Why include it?

I maintain this skill and have used it extensively in real Hermes and OpenCode workflows. It provides secure guidance for building Currents API latest-news and search integrations, including server-side API-key handling, validation, UTC filtering, caching, rate limits, and WAF-safe HTTP requests.

## Validation

- Repository link verified
- `./tests/test_install.sh` passed
- `./tests/validate_skills.sh` passed