### PR TITLE
Add skill: Vladimir-Human/humanizer-ru

### DIFF
--- a/README.md
+++ b/README.md
@@ -1678,6 +1678,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[infrasity-labs/dev-gtm-claude-skills](https://github.com/infrasity-labs/dev-gtm-claude-skills)**: GTM-focused skill collection for developer go-to-market workflows including launch planning, positioning, and outbound sequences.
 - **[nowork-studio/NotFair](https://github.com/nowork-studio/NotFair)** - SEO, GEO, Google Ads, and Meta Ads skills with live data
 - **[aaron-he-zhu/aaron-marketing-skills](https://github.com/aaron-he-zhu/aaron-marketing-skills)** - 69 marketing skills across SEO/GEO, influencer, paid ads, and email on one shared contract, with 5 benchmark-driven auditor gates (CORE-EEAT, CITE, C³, ROAS, SEND) and keyless data connectors
+- **[Vladimir-Human/humanizer-ru](https://github.com/Vladimir-Human/humanizer-ru)** - Removes AI-writing markers from Russian text
 
 </details>
 


### PR DESCRIPTION
## Summary
Adds `Vladimir-Human/humanizer-ru`, an MIT-licensed Agent Skill for editing Russian AI-generated prose.

## Why it fits
- Russian-specific: 38 style patterns and 35 deterministic regex markers
- Public and documented with `SKILL.md`, examples, and installation instructions
- Portable across Claude Code, Codex, Cursor, Gemini CLI, and OpenCode
- Community usage: 61 GitHub stars, 266+ installs on skills.sh
- No network service or paid dependency required

I checked the list and existing pull requests for the repository URL before submitting.