### PR TITLE
Add skill: Neeeophytee/finding-unknowns-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1720,6 +1720,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[Linked-API/linkedin](https://github.com/Linked-API/linkedin-skills/tree/main/linkedin)** - Fetch LinkedIn profiles, search people and companies, send messages, manage connections, create posts, react, comment, and run custom LinkedIn workflows from Claude Code, Codex, Cursor, and Windsurf.
 - **[pattern-ai-labs/agentcall](https://github.com/pattern-ai-labs/agentcall)** - Let your AI agents join Google Meet, Zoom, Teams calls and collaborate like a real team-mate.
 - **[Sendmux/skills](https://github.com/Sendmux/skills)** - Sendmux email and mailbox workflows for agents
+- **[Neeeophytee/finding-unknowns-skills](https://github.com/Neeeophytee/finding-unknowns-skills)** - 8 meta-skills that make a coding agent surface your unknowns before they get expensive: blindspot pass, interview, reference hunt, implementation plan/notes, pitch packager, and a pre-merge change quiz. Works in Claude Code, Codex, and Cursor via the agentskills.io SKILL.md format
 
 </details>
 


### PR DESCRIPTION
Adds **finding-unknowns-skills** under Community Skills → Productivity and Collaboration (alongside the other planning/meta skills).

**Repo:** https://github.com/Neeeophytee/finding-unknowns-skills
**License:** MIT
**Install:** `npx skills add Neeeophytee/finding-unknowns-skills`

A pack of 8 meta-skills that get a coding agent to surface unknowns before they get expensive: blindspot pass, interview-me, reference-hunt, implementation-plan, implementation-notes, pitch-packager, and a pre-merge change-quiz. A community distillation of Thariq Shihipar's 'finding unknowns' essay (not official Anthropic).

Cross-agent: installs into Claude Code, Codex, and Cursor via the agentskills.io `SKILL.md` format that this list is built around.

On the quality bar: this isn't a fresh repo — it's at ~180 stars with real community adoption, not something created a few hours ago.