### PR TITLE
Add skill: Bomx/distribb-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1678,6 +1678,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[infrasity-labs/dev-gtm-claude-skills](https://github.com/infrasity-labs/dev-gtm-claude-skills)**: GTM-focused skill collection for developer go-to-market workflows including launch planning, positioning, and outbound sequences.
 - **[nowork-studio/NotFair](https://github.com/nowork-studio/NotFair)** - SEO, GEO, Google Ads, and Meta Ads skills with live data
 - **[aaron-he-zhu/aaron-marketing-skills](https://github.com/aaron-he-zhu/aaron-marketing-skills)** - 69 marketing skills across SEO/GEO, influencer, paid ads, and email on one shared contract, with 5 benchmark-driven auditor gates (CORE-EEAT, CITE, C³, ROAS, SEND) and keyless data connectors
+- **[Bomx/distribb-skill](https://github.com/Bomx/distribb-skill)** - SEO articles, keyword research, CMS publishing, high-DR backlink exchange
 
 </details>
 


### PR DESCRIPTION
Adds [Bomx/distribb-skill](https://github.com/Bomx/distribb-skill) to the end of the Marketing subcategory under Community Skills.

Distribb is an AI SEO skill: keyword research, original data research, SEO article writing, publishing to WordPress/Webflow/Shopify, and a real backlink exchange network between member sites. Works with Claude Code, Codex, and other agents via standard skill paths.

Checklist per CONTRIBUTING.md:
- Public repository with a working skill: yes
- Documentation: README.md and SKILL.md
- Author prefix in name: Bomx/distribb-skill
- Description is 9 words
- Community usage: 133 stars, in active use since June 2026, actively maintained
- Link verified working

🤖 Generated with [Claude Code](https://claude.com/claude-code)