### PR TITLE
Add skill: drogers0/github-image-upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -1804,6 +1804,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[GanyuanRan/Aegis](https://github.com/GanyuanRan/Aegis)** - Evidence-driven method pack for AI coding agents
 - **[baskduf/codex-fable5](https://github.com/baskduf/FableCodex/tree/main/plugins/codex-fable5/skills/codex-fable5)** - Evidence-based workflow gates for Codex
 - **[csthink/dashmotion](https://github.com/csthink/dashmotion/tree/main/skills/dashmotion)** - Animated technical diagrams from plain English or Mermaid, self-contained HTML/SVG
+- **[drogers0/github-image-upload](https://github.com/drogers0/gh-image/tree/main/skills/github-image-upload)** - Attach screenshots, PDFs, logs, zips, and videos to GitHub PRs, issues, and comments, returning canonical user-attachments URLs. GitHub has no public attachment-upload API. Works with Claude Code, Codex, Cursor, and Gemini CLI
 
 </details>
 


### PR DESCRIPTION
Adds the `github-image-upload` Agent Skill to Community Skills → Development and Testing.

GitHub has no public API for the attachment uploads its web UI accepts via drag-and-drop, so agents cannot attach a screenshot or a log file to a PR or issue. This skill drives the [`gh-image`](https://github.com/drogers0/gh-image) `gh` CLI extension to upload a local file and return a canonical `user-attachments` URL, then embeds it in the PR/issue/comment.

- Handles any GitHub-supported attachment: images render inline, videos as players, and other files (PDF, zip, log) as download links.
- Uploads on private repos stay private, URLs inherit repository visibility.
- SKILL.md: https://github.com/drogers0/gh-image/tree/main/skills/github-image-upload
- MIT licensed, public repo, actively maintained (latest release v1.1.0).
- Adoption: 140 stars, 14 forks, 23,000+ release downloads across 9 releases.
- Agent-agnostic: Claude Code, Codex, Cursor, Gemini CLI.
- Install the underlying extension: `gh extension install drogers0/gh-image`

Previously opened as #716, which was closed without comment during the July 10 backlog cleanup. Resubmitting with an expanded scope (all attachment types, not just images) and the entry pointing directly at the SKILL.md — happy to adjust if there is anything specific you would like changed.