### PR TITLE
Add skill: 0xsarwagya/ontoly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1762,6 +1762,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[omkamal/pypict-skill](https://github.com/omkamal/pypict-claude-skill/blob/main/SKILL.md)** - Pairwise test generation
 - **[alinaqi/claude-bootstrap](https://github.com/alinaqi/claude-bootstrap)** - Opinionated project initialization with security-first guardrails, spec-driven atomic todos, LLM testing patterns, and CLI tool orchestration (gh, vercel, supabase)
 - **[ZhangHanDong/makepad-skills](https://github.com/ZhangHanDong/makepad-skills)** - Makepad UI development skills for Rust apps: setup, patterns, shaders, packaging, and troubleshooting.
+- **[0xsarwagya/ontoly](https://github.com/0xsarwagya/ontoly/tree/main/skills)** - Software Graph skills for codebase intelligence
 - **[massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill)** - Handle long-context tasks (100+ files, 50k+ tokens) through recursive decomposition strategies based on RLM research
 - **[AvdLee/swiftui-expert-skill](https://github.com/AvdLee/SwiftUI-Agent-Skill/tree/main/swiftui-expert-skill)** - Modern SwiftUI best practices and iOS 26+ Liquid Glass adoption
 - **[efremidze/swift-patterns-skill](https://github.com/efremidze/swift-patterns-skill/tree/main/swift-patterns)** - Modern Swift/SwiftUI best practices


### PR DESCRIPTION
## Summary

Adds Ontoly Agent Skills to the Development and Testing community skills section. Ontoly provides Software Graph-backed skills for codebase understanding, architecture review, dependency analysis, impact analysis, request tracing, security review, and related developer-tool workflows.

## Validation

- Verified the linked repository is public.
- Verified `npx --yes skills add 0xsarwagya/ontoly --list` discovers 14 skills from the repository.
- Kept the description short and linked to the canonical skill source in the owning repository.
