### PR TITLE
Add skill: Shreyas0786/ticketly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1720,6 +1720,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[Linked-API/linkedin](https://github.com/Linked-API/linkedin-skills/tree/main/linkedin)** - Fetch LinkedIn profiles, search people and companies, send messages, manage connections, create posts, react, comment, and run custom LinkedIn workflows from Claude Code, Codex, Cursor, and Windsurf.
 - **[pattern-ai-labs/agentcall](https://github.com/pattern-ai-labs/agentcall)** - Let your AI agents join Google Meet, Zoom, Teams calls and collaborate like a real team-mate.
 - **[Sendmux/skills](https://github.com/Sendmux/skills)** - Sendmux email and mailbox workflows for agents
+- **[Shreyas0786/ticketly](https://github.com/Shreyas0786/ticketly)** - Turn a spec or codebase into a structured ticket backlog
 
 </details>
 


### PR DESCRIPTION
Adds Ticketly to Community Skills → Productivity and Collaboration.

Ticketly is a skill for Claude Code and Codex that turns a project spec — or an existing codebase — into a structured backlog: epics broken into tickets, each with acceptance criteria, an effort estimate, and dependencies. Exports to Markdown, CSV, and Notion.

- Repo: https://github.com/Shreyas0786/ticketly
- Package: https://pypi.org/project/ticketly/ — [![PyPI downloads](https://static.pepy.tech/badge/ticketly)](https://pepy.tech/project/ticketly)
- Docs: README and a SKILL.md shipped with the package
- Runs on the user's existing Claude/Codex subscription; no API key.

Entry is appended to the end of the category, description is 10 words, and the links are verified working.