### PR TITLE
Add idea-hunt skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1678,6 +1678,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[infrasity-labs/dev-gtm-claude-skills](https://github.com/infrasity-labs/dev-gtm-claude-skills)**: GTM-focused skill collection for developer go-to-market workflows including launch planning, positioning, and outbound sequences.
 - **[nowork-studio/NotFair](https://github.com/nowork-studio/NotFair)** - SEO, GEO, Google Ads, and Meta Ads skills with live data
 - **[aaron-he-zhu/aaron-marketing-skills](https://github.com/aaron-he-zhu/aaron-marketing-skills)** - 69 marketing skills across SEO/GEO, influencer, paid ads, and email on one shared contract, with 5 benchmark-driven auditor gates (CORE-EEAT, CITE, C³, ROAS, SEND) and keyless data connectors
+- **[ANVEAI/idea-hunt-skill](https://github.com/ANVEAI/idea-hunt-skill)** - Evidence-first AI business idea discovery and validation: finds a painful, already-paid-for workflow AI can replace, then runs pain mining, kill-gates, the Mom Test, and a proof-of-wallet test before you build
 
 </details>
 


### PR DESCRIPTION
### Adding: idea-hunt

**Repo:** https://github.com/ANVEAI/idea-hunt-skill · MIT · single self-contained `SKILL.md` — no API key or paid subscription required to function.

**What it does:** Evidence-first AI business idea discovery & validation. It inverts the usual "invent an idea" prompt: it hunts for an existing, already-paid-for workflow AI can now do as *completed work*, then runs a 7-stage pipeline — pain mining → kill-gates → the Mom Test → a proof-of-wallet test — so weak ideas get rejected on paper before any build.

- [x] Actively maintained, documented (README + FAQ)
- [x] No commercial-API / paid-subscription dependency
- [x] Real value for Claude / Claude Code users
- [x] Concise, single-sentence description