### PR TITLE
Add readme-skill to Community Skills (Development and Testing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1804,6 +1804,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[GanyuanRan/Aegis](https://github.com/GanyuanRan/Aegis)** - Evidence-driven method pack for AI coding agents
 - **[baskduf/codex-fable5](https://github.com/baskduf/FableCodex/tree/main/plugins/codex-fable5/skills/codex-fable5)** - Evidence-based workflow gates for Codex
 - **[csthink/dashmotion](https://github.com/csthink/dashmotion/tree/main/skills/dashmotion)** - Animated technical diagrams from plain English or Mermaid, self-contained HTML/SVG
+- **[evol1228/readme-skill](https://github.com/evol1228/readme-skill)** - Design and write professional, hand-crafted README.md files: reads the repo first so every command and env var is real, adapts structure per project type, bans badge walls and emoji headings
 
 </details>
 


### PR DESCRIPTION
Adds [evol1228/readme-skill](https://github.com/evol1228/readme-skill) — an agent skill that designs and writes professional README.md files.

- Reads the actual repo (manifest, scripts, .env.example, LICENSE) before writing, so every command and env var in the output is real
- Anti-slop style rules: no badge walls, no emoji headings, concrete claims over superlatives
- Adapts structure per project type (app, library, CLI); works across agents via `npx skills add evol1228/readme-skill`
- Listed on [skills.sh](https://www.skills.sh/evol1228/readme-skill) with passing security audits, MIT licensed