### PR TITLE
Add skill: sergebulaev/linkedin-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1678,6 +1678,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[infrasity-labs/dev-gtm-claude-skills](https://github.com/infrasity-labs/dev-gtm-claude-skills)**: GTM-focused skill collection for developer go-to-market workflows including launch planning, positioning, and outbound sequences.
 - **[nowork-studio/NotFair](https://github.com/nowork-studio/NotFair)** - SEO, GEO, Google Ads, and Meta Ads skills with live data
 - **[aaron-he-zhu/aaron-marketing-skills](https://github.com/aaron-he-zhu/aaron-marketing-skills)** - 69 marketing skills across SEO/GEO, influencer, paid ads, and email on one shared contract, with 5 benchmark-driven auditor gates (CORE-EEAT, CITE, C³, ROAS, SEND) and keyless data connectors
+- **[sergebulaev/linkedin-skills](https://github.com/sergebulaev/linkedin-skills)** - LinkedIn marketing skills: viral hooks, comment drafting, algorithm audit, humanizer
 
 </details>
 


### PR DESCRIPTION
Resubmitting per your note on #436 ("open a new PR once it has matured").

**[sergebulaev/linkedin-skills](https://github.com/sergebulaev/linkedin-skills)** is now well past new: 378 stars, 55 forks, months in production, and MIT licensed. It is a bundle of 11 LinkedIn marketing skills (viral hook formulas validated against a corpus, comment drafting, a 20-point pre-publish algorithm audit, an AI-tell humanizer, hook extractor, content planner, profile optimizer, and more), packaged as a native Claude Code and Codex plugin.

Added one short entry to the end of the **Community Skills > Marketing** subcategory, following the CONTRIBUTING format (author/skill-name + a short description). Links verified.