### PR TITLE
Add skill: Antheurus/sshepherd

### DIFF
--- a/README.md
+++ b/README.md
@@ -1804,6 +1804,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[GanyuanRan/Aegis](https://github.com/GanyuanRan/Aegis)** - Evidence-driven method pack for AI coding agents
 - **[baskduf/codex-fable5](https://github.com/baskduf/FableCodex/tree/main/plugins/codex-fable5/skills/codex-fable5)** - Evidence-based workflow gates for Codex
 - **[csthink/dashmotion](https://github.com/csthink/dashmotion/tree/main/skills/dashmotion)** - Animated technical diagrams from plain English or Mermaid, self-contained HTML/SVG
+- **[Antheurus/sshepherd](https://github.com/Antheurus/sshepherd)** - Zero-knowledge SSH ops CLI for checks, deploys, logs, DB introspection
 
 </details>
 


### PR DESCRIPTION
Adds **[Antheurus/sshepherd](https://github.com/Antheurus/sshepherd)** to the Development and Testing subcategory under Community Skills.

Zero-knowledge SSH ops CLI for remote server checks, deploys, log tailing, and Postgres introspection — the agent only ever passes an ssh alias, pg-target, or recipe name, never a credential.

- Public repository with a working skill and README/SKILL.md documentation
- Author prefix included (`Antheurus/sshepherd`)
- Description is under 10 words
- Added to the end of the matching subcategory, format matches CONTRIBUTING.md