### PR TITLE
Add skill: Antheurus/anywrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1720,6 +1720,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[Linked-API/linkedin](https://github.com/Linked-API/linkedin-skills/tree/main/linkedin)** - Fetch LinkedIn profiles, search people and companies, send messages, manage connections, create posts, react, comment, and run custom LinkedIn workflows from Claude Code, Codex, Cursor, and Windsurf.
 - **[pattern-ai-labs/agentcall](https://github.com/pattern-ai-labs/agentcall)** - Let your AI agents join Google Meet, Zoom, Teams calls and collaborate like a real team-mate.
 - **[Sendmux/skills](https://github.com/Sendmux/skills)** - Sendmux email and mailbox workflows for agents
+- **[Antheurus/anywrite](https://github.com/Antheurus/anywrite)** - CLI covering all 52 Anytype local API endpoints
 
 </details>
 


### PR DESCRIPTION
Adds **[Antheurus/anywrite](https://github.com/Antheurus/anywrite)** to the Productivity and Collaboration subcategory under Community Skills.

A single compiled CLI covering all 52 endpoints of the Anytype local API — spaces, objects, properties, tags, types, templates, lists, chat, files, members, and search — so an agent can manage notes, tasks, and PKM objects in Anytype without an MCP server.

- Public repository with a working skill and README/SKILL.md documentation
- Author prefix included (`Antheurus/anywrite`)
- Description is under 10 words
- Added to the end of the matching subcategory, format matches CONTRIBUTING.md