### PR TITLE
Add skill: eduardo-sl/go-agent-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1804,6 +1804,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[GanyuanRan/Aegis](https://github.com/GanyuanRan/Aegis)** - Evidence-driven method pack for AI coding agents
 - **[baskduf/codex-fable5](https://github.com/baskduf/FableCodex/tree/main/plugins/codex-fable5/skills/codex-fable5)** - Evidence-based workflow gates for Codex
 - **[csthink/dashmotion](https://github.com/csthink/dashmotion/tree/main/skills/dashmotion)** - Animated technical diagrams from plain English or Mermaid, self-contained HTML/SVG
+- **[eduardo-sl/go-agent-skills](https://github.com/eduardo-sl/go-agent-skills)** - Curated Go skills for code review, concurrency, testing, and architecture
 
 </details>
 


### PR DESCRIPTION
## What

Adds [go-agent-skills](https://github.com/eduardo-sl/go-agent-skills) — a collection of 28 curated agent skills for Go projects — to the **Community Skills → Development and Testing** subcategory.

## Why it fits this list

- Covers code review, concurrency review, error handling, testing (table-driven), gRPC, observability, and architecture for Go
- Built on established references: Uber Go Style Guide, Effective Go, Go Code Review Comments
- Works across Claude Code, Cursor, Codex, GitHub Copilot, Windsurf, OpenCode (37+ agents)
- One-command install: `npx skills add eduardo-sl/go-agent-skills`
- MIT licensed, CI validation for skill format, contribution guidelines in place

Per CONTRIBUTING.md, the entry was added to the end of the matching subcategory, uses the `author/skill-name` format, and keeps the description to 10 words. Happy to adjust anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)