### PR TITLE
Add skill: gooseworks-ai/goose-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1678,6 +1678,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[infrasity-labs/dev-gtm-claude-skills](https://github.com/infrasity-labs/dev-gtm-claude-skills)**: GTM-focused skill collection for developer go-to-market workflows including launch planning, positioning, and outbound sequences.
 - **[nowork-studio/NotFair](https://github.com/nowork-studio/NotFair)** - SEO, GEO, Google Ads, and Meta Ads skills with live data
 - **[aaron-he-zhu/aaron-marketing-skills](https://github.com/aaron-he-zhu/aaron-marketing-skills)** - 69 marketing skills across SEO/GEO, influencer, paid ads, and email on one shared contract, with 5 benchmark-driven auditor gates (CORE-EEAT, CITE, C³, ROAS, SEND) and keyless data connectors
+- **[gooseworks-ai/goose-skills](https://github.com/gooseworks-ai/goose-skills)** - 125 growth and GTM skills: ads, content, lead gen, SEO
 
 </details>
 


### PR DESCRIPTION
Adds **[gooseworks-ai/goose-skills](https://github.com/gooseworks-ai/goose-skills)** to the end of the **Community Skills → Marketing** subcategory.

**Per the contributing requirements:**
- Public repository with working skills: 125 growth/GTM skills across ads, content, lead generation, outreach, competitive intel, monitoring, research, and SEO
- Documentation: README + per-skill SKILL.md with metadata contract, installable via CLI
- Real community usage: 1,000+ stars, in production use since early 2026
- MIT licensed
- Author/org prefix included; description kept to 10 words

— Himanshu Bamoria, co-founder @ [GooseWorks](https://gooseworks.ai)

🤖 Generated with [Claude Code](https://claude.com/claude-code)