### PR TITLE
Add skill: ludo-technologies/python-best-practices

### DIFF
--- a/README.md
+++ b/README.md
@@ -1804,6 +1804,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[GanyuanRan/Aegis](https://github.com/GanyuanRan/Aegis)** - Evidence-driven method pack for AI coding agents
 - **[baskduf/codex-fable5](https://github.com/baskduf/FableCodex/tree/main/plugins/codex-fable5/skills/codex-fable5)** - Evidence-based workflow gates for Codex
 - **[csthink/dashmotion](https://github.com/csthink/dashmotion/tree/main/skills/dashmotion)** - Animated technical diagrams from plain English or Mermaid, self-contained HTML/SVG
+- **[ludo-technologies/python-best-practices](https://github.com/ludo-technologies/python-best-practices)** - Python best practices: 44 rules for coding, tooling, and testing
 
 </details>
 


### PR DESCRIPTION
## What

Adds [ludo-technologies/python-best-practices](https://github.com/ludo-technologies/python-best-practices) to Community Skills > Development and Testing.

## About the skill

Python best practices skills for AI coding agents — 44 rules across coding standards (error handling, performance, async, design principles), tooling (ruff, mypy, pytest, uv, pyscn), and pytest test-writing practices. Each rule includes rationale and bad/good code examples.

- Public repo with README and SKILL.md documentation
- Installable via `uvx add-skills ludo-technologies/python-best-practices`
- Maintained by ludo-technologies (authors of [pyscn](https://github.com/ludo-technologies/pyscn), a Python static analysis tool)