### PR TITLE
Add skill: zeroatflops/flops-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1863,6 +1863,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[aklofas/kicad-happy](https://github.com/aklofas/kicad-happy)** - AI-powered KiCad electronics design review and analysis
 - **[bitwize-music-studio/claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills)** - Full-lifecycle AI music album production
 - **[Alisa0808/vibe-creating-skill](https://github.com/Alisa0808/vibe-creating-skill)** - Rewrites a rough idea or shot script into text-to-video prompts
+- **[zeroatflops/flops-skill](https://github.com/zeroatflops/flops-skill)** - Look up and cite verifiable GPU/compute rental reference prices (spot, on-demand, DePIN) from the public FLOPS Index — price → verify → cite, key-free
 
 </details>
 


### PR DESCRIPTION
Adds **[zeroatflops/flops-skill](https://github.com/zeroatflops/flops-skill)** to the **Specialized Domains** community subcategory.

It is a Claude / Agent SKILL.md skill (SKILL.md + `scripts/flops.py`) that looks up and cites verifiable GPU/compute rental reference prices (spot, on-demand, and DePIN markets) from the public FLOPS Index API. Key-free, and every price comes with a source URL the user can independently verify — the flow is price -> verify -> cite.

- Public repo with SKILL.md + working, self-contained script
- No API key required
- Entry format, category (Specialized Domains, alongside the other market-data / finance skills), and 1-line description follow CONTRIBUTING.md
- Single-line diff, no whole-file churn