### PR TITLE
Add skill: webkubor/browser-verify

### DIFF
--- a/README.md
+++ b/README.md
@@ -1778,6 +1778,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[NeoLabHQ/ddd](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/ddd)** - Domain-driven development skills that also include Clean Architecture, SOLID principles, and design patterns.
 - **[NeoLabHQ/sadd](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/sadd)** - Dispatches independent subagents for individual tasks with code review checkpoints between iterations for rapid, controlled development.
 - **[NeoLabHQ/kaizen](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/kaizen)** - Applies continuous improvement methodology with multiple analytical approaches, based on Japanese Kaizen philosophy and Lean methodology.
+- **[webkubor/browser-verify](https://github.com/webkubor/agent-skills/tree/main/skills/browser-verify)** - Visual UI verification via real Chrome CDP screenshots
 - **[hamelsmu/eval-audit](https://github.com/hamelsmu/prompts/tree/main/evals-skills/skills/eval-audit)** - Audit LLM eval pipelines and surface problems
 - **[hamelsmu/error-analysis](https://github.com/hamelsmu/prompts/tree/main/evals-skills/skills/error-analysis)** - Systematically identify failure modes in LLM pipelines
 - **[hamelsmu/generate-synthetic-data](https://github.com/hamelsmu/prompts/tree/main/evals-skills/skills/generate-synthetic-data)** - Create diverse synthetic test inputs for LLM evals


### PR DESCRIPTION
## What

Adds **browser-verify** to Community Skills → Development and Testing.

- Skill: https://github.com/webkubor/agent-skills/tree/main/skills/browser-verify
- What it does: visual definition-of-done for UI changes — drives a real Chrome via CDP, takes screenshots, reads on-screen values, clicks, and checks light/dark/mobile variants, so the agent verifies rendering with its own eyes instead of trusting a green build.
- Companion tooling: [browser-harness](https://www.npmjs.com/package/browser-harness) (CDP browser CLI on npm).
- Extracted from daily production use (documented sharp edges: proxy hijacking, login walls, stale bundles); part of a 20-skill tool-agnostic library with a CLI for targeted install (`skills-cli export --platform/--category`).

## Checklist

- [x] Public repository with a working skill
- [x] Documentation (SKILL.md + bilingual README)
- [x] Author prefix in the name
- [x] Description ≤ 10 words
- [x] Links verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)