### PR TITLE
Add skill: AaronZ345/codebase-argus

### DIFF
--- a/README.md
+++ b/README.md
@@ -1817,6 +1817,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[browser-act/browser-act](https://github.com/browser-act/skills/tree/main/browser-act)** - Automate authenticated browsers with extraction and human handoff
 - **[JasonColapietro/suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills)** - Agent orchestration, code review grading, AI eval, creator tooling skills.
 - **[Ryan-yang125/motion-lexicon](https://github.com/Ryan-yang125/motion-lexicon/tree/main/skills/motion-lexicon)** - Build and review product motion with installable React components
+- **[AaronZ345/codebase-argus](https://github.com/AaronZ345/codebase-argus/blob/main/skills/codebase-argus/SKILL.md)** - Review PR, CI, and fork-sync evidence with agents
 
 </details>
 


### PR DESCRIPTION
## What changed

Added the Codebase Argus portable skill to Community Skills → Development and Testing.

The skill gives coding agents a read-only, evidence-first playbook for:

- pull request and failing-CI review;
- optional single-provider or multi-provider review;
- downstream fork merge/rebase analysis;
- gated sync and autofix planning.

## Why it fits

The skill is public, documented in `SKILL.md`, and backed by the working Codebase Argus CLI and GitHub Action. A [reproducible CowAgent #2965 case study](https://github.com/AaronZ345/codebase-argus/blob/main/docs/case-studies/cowagent-2965.md) records its deterministic and Codex CLI review paths on a live pull request.

The entry follows the requested author prefix and uses an eight-word description.

## Checks

- Confirmed the linked `SKILL.md` returns HTTP 200.
- Ran `git diff --check`.
- Kept the change to one README entry.
