### PR TITLE
Add skill: OakcoderX/nomtiq

### DIFF
--- a/README.md
+++ b/README.md
@@ -1863,6 +1863,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[aklofas/kicad-happy](https://github.com/aklofas/kicad-happy)** - AI-powered KiCad electronics design review and analysis
 - **[bitwize-music-studio/claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills)** - Full-lifecycle AI music album production
 - **[Alisa0808/vibe-creating-skill](https://github.com/Alisa0808/vibe-creating-skill)** - Rewrites a rough idea or shot script into text-to-video prompts
+- **[OakcoderX/nomtiq](https://github.com/OakcoderX/nomtiq)** - Personalized restaurant discovery with live search and local taste memory
 
 </details>
 


### PR DESCRIPTION
## What changed

Adds `OakcoderX/nomtiq` to Community Skills → Specialized Domains.

## Why

Nomtiq is a portable Agent Skill for personalized restaurant discovery. It uses live restaurant search, occasion-aware filtering, and a local taste profile.

## Adoption and maintenance evidence

- Published on ClawHub since February 2026
- 1,311 downloads and 42 installs at submission time
- Public MIT-0 repository with Agent Skills-compatible root `SKILL.md`
- Official `skills-ref` validation passes
- GitHub Actions validates Python 3.9/3.12, Agent Skills discovery, setup flow, core boundary, and obvious secrets
- Public documentation, security policy, release, and fresh remote install path

## Checks

- Repository URL returns HTTP 200
- Entry follows the required `author/skill-name` format
- Description is 10 words
- Added at the end of the matching Specialized Domains category
