### PR TITLE
Add zapier/zapier-mcp to Productivity and Collaboration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1720,6 +1720,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[Linked-API/linkedin](https://github.com/Linked-API/linkedin-skills/tree/main/linkedin)** - Fetch LinkedIn profiles, search people and companies, send messages, manage connections, create posts, react, comment, and run custom LinkedIn workflows from Claude Code, Codex, Cursor, and Windsurf.
 - **[pattern-ai-labs/agentcall](https://github.com/pattern-ai-labs/agentcall)** - Let your AI agents join Google Meet, Zoom, Teams calls and collaborate like a real team-mate.
 - **[Sendmux/skills](https://github.com/Sendmux/skills)** - Sendmux email and mailbox workflows for agents
+- **[zapier/zapier-mcp](https://github.com/zapier/zapier-mcp)** - Official plugin distribution for the hosted Zapier MCP server. Connects Claude to thousands of apps — send messages, pull data, trigger workflows.
 
 </details>
 


### PR DESCRIPTION
Adds Zapier's official MCP server plugin distribution repo, alongside other app-connection skills in this section (Notion, WhatsApp integrations, etc.).

- Repo: https://github.com/zapier/zapier-mcp