### PR TITLE
Add gulmezeren2-byte/erp-report-engine (safe ERP SQL querying)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1804,6 +1804,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[GanyuanRan/Aegis](https://github.com/GanyuanRan/Aegis)** - Evidence-driven method pack for AI coding agents
 - **[baskduf/codex-fable5](https://github.com/baskduf/FableCodex/tree/main/plugins/codex-fable5/skills/codex-fable5)** - Evidence-based workflow gates for Codex
 - **[csthink/dashmotion](https://github.com/csthink/dashmotion/tree/main/skills/dashmotion)** - Animated technical diagrams from plain English or Mermaid, self-contained HTML/SVG
+- **[gulmezeren2-byte/erp-report-engine](https://github.com/gulmezeren2-byte/erp-report-engine/tree/main/skills)** - Safe read-only querying of an ERP's SQL database for AI agents: canonical entities (never raw tables), a statement-checking read-only guard, and dry-run-before-query discipline (Logo Tiger, Netsis, Mikro)
 
 </details>
 


### PR DESCRIPTION
Adds **erp-report-engine** to the *Development and Testing* subcategory under Community Skills.

Its skills (`erp-safe-query`, `explain-kpi-move`, `write-erp-profile`) teach an agent to query the SQL database behind an ERP **safely**: canonical entities only (never raw ERP tables), read-only through a statement-checking guard, dry-run before querying, and treating every returned row as untrusted data. Bundled profiles for Logo Tiger, Netsis, Mikro.

- Public repo with working skills documented as `SKILL.md` files: https://github.com/gulmezeren2-byte/erp-report-engine/tree/main/skills
- Follows the entry format (`**[author/name](url)** - description`), author prefix included, appended to the end of the section.
