### PR TITLE
Add skill: OthmanAdi/planning-with-files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1824,6 +1824,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[sametbrr/llm-wiki-manager](https://github.com/sametbrr/llm-wiki-manager)** - Persistent LLM-managed personal wiki — the model writes, cross-references, and maintains the knowledge base while you curate sources. Implements Karpathy's LLM Wiki pattern with 8 operating modes.
 - **[Panniantong/Agent-Reach](https://github.com/Panniantong/Agent-Reach)** - Multi-platform search CLI for 17 sites including Chinese platforms
 - **[Tubo2333/obsidian-knowledge-brain](https://github.com/Tubo2333/obsidian-knowledge-brain)** - Cross-session knowledge memory and rule evolution for AI coding agents
+- **[OthmanAdi/planning-with-files](https://github.com/OthmanAdi/planning-with-files)** - Persistent markdown plans that survive context loss and /clear
 
 </details>
 


### PR DESCRIPTION
Adds OthmanAdi/planning-with-files to the end of Context Engineering.

Public repository with SKILL.md documentation, shipping since early 2026, currently v3.7.0 with community contributors and adapters for Claude Code, Codex CLI, Cursor, and other SKILL.md hosts. Description kept under ten words per the entry format.