### PR TITLE
Add UIZZE — STOP UI SLOP skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1804,7 +1804,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[GanyuanRan/Aegis](https://github.com/GanyuanRan/Aegis)** - Evidence-driven method pack for AI coding agents
 - **[baskduf/codex-fable5](https://github.com/baskduf/FableCodex/tree/main/plugins/codex-fable5/skills/codex-fable5)** - Evidence-based workflow gates for Codex
 - **[csthink/dashmotion](https://github.com/csthink/dashmotion/tree/main/skills/dashmotion)** - Animated technical diagrams from plain English or Mermaid, self-contained HTML/SVG
-- **[samuelbushi/uizze](https://github.com/samuelbushi/uizze/tree/main/skills/anti-ui-slop)** - Ground UI in real screens and enforce a finish gate
+- **[UIZZE — STOP UI SLOP](https://github.com/samuelbushi/uizze/tree/main/skills/anti-ui-slop)** - Ground coding agents in 800,000+ real screens and force a hard finish gate before generic UI ships
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -1804,7 +1804,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[GanyuanRan/Aegis](https://github.com/GanyuanRan/Aegis)** - Evidence-driven method pack for AI coding agents
 - **[baskduf/codex-fable5](https://github.com/baskduf/FableCodex/tree/main/plugins/codex-fable5/skills/codex-fable5)** - Evidence-based workflow gates for Codex
 - **[csthink/dashmotion](https://github.com/csthink/dashmotion/tree/main/skills/dashmotion)** - Animated technical diagrams from plain English or Mermaid, self-contained HTML/SVG
-- **[UIZZE — STOP UI SLOP](https://github.com/samuelbushi/uizze/tree/main/skills/anti-ui-slop)** - 800,000+ real screens for agents; hard finish gate blocks slop. [uizze.com](https://uizze.com)
+- **[UIZZE — STOP UI SLOP](https://github.com/uizze/uizze/tree/main/skills/anti-ui-slop)** - 800,000+ real screens for agents; hard finish gate blocks slop. [uizze.com](https://uizze.com)
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -1804,6 +1804,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[GanyuanRan/Aegis](https://github.com/GanyuanRan/Aegis)** - Evidence-driven method pack for AI coding agents
 - **[baskduf/codex-fable5](https://github.com/baskduf/FableCodex/tree/main/plugins/codex-fable5/skills/codex-fable5)** - Evidence-based workflow gates for Codex
 - **[csthink/dashmotion](https://github.com/csthink/dashmotion/tree/main/skills/dashmotion)** - Animated technical diagrams from plain English or Mermaid, self-contained HTML/SVG
+- **[samuelbushi/uizze](https://github.com/samuelbushi/uizze/tree/main/skills/anti-ui-slop)** - Ground UI in real screens and enforce a finish gate
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -1804,7 +1804,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[GanyuanRan/Aegis](https://github.com/GanyuanRan/Aegis)** - Evidence-driven method pack for AI coding agents
 - **[baskduf/codex-fable5](https://github.com/baskduf/FableCodex/tree/main/plugins/codex-fable5/skills/codex-fable5)** - Evidence-based workflow gates for Codex
 - **[csthink/dashmotion](https://github.com/csthink/dashmotion/tree/main/skills/dashmotion)** - Animated technical diagrams from plain English or Mermaid, self-contained HTML/SVG
-- **[UIZZE — STOP UI SLOP](https://github.com/samuelbushi/uizze/tree/main/skills/anti-ui-slop)** - Ground coding agents in 800,000+ real screens and force a hard finish gate before generic UI ships
+- **[UIZZE — STOP UI SLOP](https://github.com/samuelbushi/uizze/tree/main/skills/anti-ui-slop)** - 800,000+ real screens for agents; hard finish gate blocks slop. [uizze.com](https://uizze.com)
 
 </details>
 


### PR DESCRIPTION
Adds the free UIZZE `anti-ui-slop` skill to Development and Testing.

**STOP UI SLOP.** The skill grounds Codex, Claude Code, Cursor, Copilot, and other coding agents in 800,000+ real web and iOS screens, locks a product-specific design contract, and forces a hard finish gate before generic UI ships.

The linked skill is public, installable, instruction-only, and has no bundled scripts or secret requirements.

Disclosure: first-party UIZZE submission.