### PR TITLE
Add skill: isatimur/de-slop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1678,6 +1678,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[infrasity-labs/dev-gtm-claude-skills](https://github.com/infrasity-labs/dev-gtm-claude-skills)**: GTM-focused skill collection for developer go-to-market workflows including launch planning, positioning, and outbound sequences.
 - **[nowork-studio/NotFair](https://github.com/nowork-studio/NotFair)** - SEO, GEO, Google Ads, and Meta Ads skills with live data
 - **[aaron-he-zhu/aaron-marketing-skills](https://github.com/aaron-he-zhu/aaron-marketing-skills)** - 69 marketing skills across SEO/GEO, influencer, paid ads, and email on one shared contract, with 5 benchmark-driven auditor gates (CORE-EEAT, CITE, C³, ROAS, SEND) and keyless data connectors
+- **[isatimur/de-slop](https://github.com/isatimur/de-slop)** - Removes AI slop without faking a voice; self-scoring, zero-dependency, MIT
 
 </details>
 


### PR DESCRIPTION
Adds [de-slop](https://github.com/isatimur/de-slop) to the end of the Community Skills > Marketing subcategory. It removes "AI slop" from prose (hedging, listicle stems, filler) without faking a voice — it self-scores against a rubric and flags hollow spans instead of fabricating claims. MIT-licensed and zero-dependency (stdlib-only Python); works in Claude Code, Cursor, Copilot, Codex, Gemini, and Windsurf.