### PR TITLE
Add skill: squirrelscan/squirrelscan

### DIFF
--- a/README.md
+++ b/README.md
@@ -1804,6 +1804,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[GanyuanRan/Aegis](https://github.com/GanyuanRan/Aegis)** - Evidence-driven method pack for AI coding agents
 - **[baskduf/codex-fable5](https://github.com/baskduf/FableCodex/tree/main/plugins/codex-fable5/skills/codex-fable5)** - Evidence-based workflow gates for Codex
 - **[csthink/dashmotion](https://github.com/csthink/dashmotion/tree/main/skills/dashmotion)** - Animated technical diagrams from plain English or Mermaid, self-contained HTML/SVG
+- **[squirrelscan/squirrelscan](https://github.com/squirrelscan/squirrelscan/tree/main/skills)** - Audits websites for SEO, performance, security, accessibility and returns fixes
 
 </details>
 


### PR DESCRIPTION
Adds squirrelscan to the Community Skills > Development and Testing category.

- **Skill:** [squirrelscan/squirrelscan](https://github.com/squirrelscan/squirrelscan/tree/main/skills)
- **What it does:** audits a website for SEO, performance, security, accessibility, and agent experience issues (260+ rules) and returns exact fixes to a coding agent, then drives an audit-then-fix loop.
- **Install:** `npx skills add squirrelscan/squirrelscan`
- **Homepage:** https://squirrelscan.com

Entry format, category placement, and description length (10 words or fewer) follow CONTRIBUTING.md and mirror recently merged entries.