### PR TITLE
Add skill: Simon-He95/markstream-install

### DIFF
--- a/README.md
+++ b/README.md
@@ -1804,6 +1804,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[GanyuanRan/Aegis](https://github.com/GanyuanRan/Aegis)** - Evidence-driven method pack for AI coding agents
 - **[baskduf/codex-fable5](https://github.com/baskduf/FableCodex/tree/main/plugins/codex-fable5/skills/codex-fable5)** - Evidence-based workflow gates for Codex
 - **[csthink/dashmotion](https://github.com/csthink/dashmotion/tree/main/skills/dashmotion)** - Animated technical diagrams from plain English or Mermaid, self-contained HTML/SVG
+- **[Simon-He95/markstream-install](https://github.com/Simon-He95/markstream-vue/tree/main/.agents/skills/markstream-install)** - Install streaming Markdown renderers across five frontend frameworks
 
 </details>
 


### PR DESCRIPTION
Adds the `markstream-install` skill to Community Skills → Development and Testing.

The skill helps coding agents select and install the appropriate Markstream package for Vue, React, Svelte, Angular, or Vue 2, including peer dependencies, CSS order, SSR considerations, and a minimal renderer setup. It is documented in a public MIT-licensed repository with established community usage.

I selected the general installation skill rather than listing every framework-specific skill, to keep the directory concise. Thank you for reviewing it.