### PR TITLE
Add NTCHz/off-by-none (Development and Testing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1758,6 +1758,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[obra/condition-based-waiting](https://github.com/obra/superpowers/blob/main/skills/condition-based-waiting/SKILL.md)** - Manage conditional pauses or delays
 - **[obra/commands](https://github.com/obra/superpowers/tree/main/skills/commands)** - Create and manage command structures
 - **[obra/writing-skills](https://github.com/obra/superpowers/blob/main/skills/writing-skills/SKILL.md)** - Develop and document capabilities
+- **[NTCHz/off-by-none](https://github.com/NTCHz/off-by-none)** - Spec-faithful implementation: spec-derived tests, mandatory boundary coverage, evidence-gated done reports; each rule TDD-tested against baseline failures on Opus, Sonnet, and Haiku
 - **[fvadicamo/dev-agent-skills](https://github.com/fvadicamo/dev-agent-skills)** - Git and GitHub workflow skills for commits, PRs, and code reviews
 - **[omkamal/pypict-skill](https://github.com/omkamal/pypict-claude-skill/blob/main/SKILL.md)** - Pairwise test generation
 - **[alinaqi/claude-bootstrap](https://github.com/alinaqi/claude-bootstrap)** - Opinionated project initialization with security-first guardrails, spec-driven atomic todos, LLM testing patterns, and CLI tool orchestration (gh, vercel, supabase)


### PR DESCRIPTION
Adds [off-by-none](https://github.com/NTCHz/off-by-none) to Community Skills → Development and Testing.

Spec-faithful implementation skill: spec-derived tests before code, mandatory boundary-value coverage, and an evidence-gated done-report (Verified / Assumed / Seen-but-not-touched). Every rule was added via TDD-for-skills only when a baseline agent failed a hidden grader without it — validated over 8 rounds on Opus 4.8, Sonnet 5, and Haiku 4.5 with clean bare-model baselines (3-5 runs per cell); the eval harness ships in the repo (`eval/`).

Meets the listed requirements: public repo, documented (README + SKILL.md), author prefix in the name, added at the end of the matching subcategory.