### PR TITLE
Add kurtschmidt/storyblok-skill to Development and Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1804,6 +1804,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[GanyuanRan/Aegis](https://github.com/GanyuanRan/Aegis)** - Evidence-driven method pack for AI coding agents
 - **[baskduf/codex-fable5](https://github.com/baskduf/FableCodex/tree/main/plugins/codex-fable5/skills/codex-fable5)** - Evidence-based workflow gates for Codex
 - **[csthink/dashmotion](https://github.com/csthink/dashmotion/tree/main/skills/dashmotion)** - Animated technical diagrams from plain English or Mermaid, self-contained HTML/SVG
+- **[kurtschmidt/storyblok-skill](https://github.com/kurtschmidt/storyblok-skill)** - Storyblok CMS engineering for Claude Code: CDA vs MAPI split, the pagination trap (totals live in response headers, not the JSON body), draft-mode auth, component schemas, Next.js App Router and Astro integration, and CI quality gates
 
 </details>
 


### PR DESCRIPTION
## Description

Adds **[kurtschmidt/storyblok-skill](https://github.com/kurtschmidt/storyblok-skill)** to the Development and Testing section.

This is the first publicly available Claude Code skill for Storyblok CMS. It covers the non-obvious mechanics that fail silently when violated:

- CDA vs MAPI split (separate hosts, separate auth, separate rate limits)
- Pagination trap: totals live in response headers, not the JSON body
- Draft-mode auth (plain SHA-1 vs HMAC-SHA1 for the revalidation webhook)
- Component schemas: completeness contract, idempotent push, resolve_relations limits
- Next.js App Router integration (App Router fetch patterns, draft mode, revalidation)
- Astro integration (loadEnv, Visual Editor wiring, rich text resolvers)
- CI quality gates: catalog of ten checks that catch silent failures

**Install:** `npx skills add kurtschmidt/storyblok-skill`

**License:** MIT