### PR TITLE
Add skill: serradura/okf

### DIFF
--- a/README.md
+++ b/README.md
@@ -1824,6 +1824,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[sametbrr/llm-wiki-manager](https://github.com/sametbrr/llm-wiki-manager)** - Persistent LLM-managed personal wiki — the model writes, cross-references, and maintains the knowledge base while you curate sources. Implements Karpathy's LLM Wiki pattern with 8 operating modes.
 - **[Panniantong/Agent-Reach](https://github.com/Panniantong/Agent-Reach)** - Multi-platform search CLI for 17 sites including Chinese platforms
 - **[Tubo2333/obsidian-knowledge-brain](https://github.com/Tubo2333/obsidian-knowledge-brain)** - Cross-session knowledge memory and rule evolution for AI coding agents
+- **[serradura/okf](https://github.com/serradura/okf-gem/tree/main/lib/okf/skill)** - Author, curate, and read OKF knowledge bundles with deterministic checks
 
 </details>
 


### PR DESCRIPTION
Adds the `okf` skill to Context Engineering. I maintain it, so this is a self-submission.

The skill teaches an agent the Open Knowledge Format: project knowledge kept as a folder of Markdown files with YAML frontmatter, one concept per file, links between files forming the graph. It covers authoring a bundle from existing code and docs, migrating docs into one without rewriting them, keeping it in sync as the code changes, and reading from it to answer a question instead of re-reading the codebase.

It sits next to `sametbrr/llm-wiki-manager` and `Tubo2333/obsidian-knowledge-brain` in this section, with one difference worth naming: the skill is paired with a CLI that checks its output. The agent's curation gets verified by `okf validate` for spec conformance and `okf lint` for curation quality, so the knowledge base has a deterministic gate rather than relying on the model's judgment about its own work.

Against the requirements in CONTRIBUTING:

- Public repo, Apache-2.0, with a `SKILL.md` plus playbooks, reference material, and templates rather than a single file.
- Not new. The gem is at 1.10.0, roughly 5.9k downloads on RubyGems, and the repo is at 78 stars.
- Portable across agents. `okf skill .claude` or `okf skill .agents` installs the same skill anywhere that reads the format.
- Description is 10 words, and the entry goes at the end of the category.
