### PR TITLE
Add skill: samuelbushi/anti-ui-slop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1804,6 +1804,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[GanyuanRan/Aegis](https://github.com/GanyuanRan/Aegis)** - Evidence-driven method pack for AI coding agents
 - **[baskduf/codex-fable5](https://github.com/baskduf/FableCodex/tree/main/plugins/codex-fable5/skills/codex-fable5)** - Evidence-based workflow gates for Codex
 - **[csthink/dashmotion](https://github.com/csthink/dashmotion/tree/main/skills/dashmotion)** - Animated technical diagrams from plain English or Mermaid, self-contained HTML/SVG
+- **[samuelbushi/anti-ui-slop](https://github.com/samuelbushi/uizze/tree/main/skills/anti-ui-slop)** - Stops generic UI using real references and a finish gate
 
 </details>
 


### PR DESCRIPTION
Adds samuelbushi/anti-ui-slop to Community Skills → Development and Testing.\n\nThe skill is public, documented, installable, and maintained in the canonical UIZZE plugin repository. It provides a real multi-step workflow: UI-reference research, evidence selection, a product-specific design contract, implementation validation, and a rendered finish gate.\n\nIt is the maintained source behind the live UIZZE agent skill and a service already used by paid customers; it is not a newly generated single-prompt wrapper.\n\n- Skill: https://github.com/samuelbushi/uizze/tree/main/skills/anti-ui-slop\n- Live documentation: https://uizze.com/docs\n- License: MIT\n- Description is 10 words and the author prefix is included.