### PR TITLE
Add skill: ChannelerH/codex-skin-pack-installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1804,6 +1804,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[GanyuanRan/Aegis](https://github.com/GanyuanRan/Aegis)** - Evidence-driven method pack for AI coding agents
 - **[baskduf/codex-fable5](https://github.com/baskduf/FableCodex/tree/main/plugins/codex-fable5/skills/codex-fable5)** - Evidence-based workflow gates for Codex
 - **[csthink/dashmotion](https://github.com/csthink/dashmotion/tree/main/skills/dashmotion)** - Animated technical diagrams from plain English or Mermaid, self-contained HTML/SVG
+- **[ChannelerH/codex-skin-pack-installer](https://github.com/ChannelerH/codex-skin-packs/tree/main/codex-skin-pack-installer)** - Install reversible Codex desktop skin packs safely
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -1804,7 +1804,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[GanyuanRan/Aegis](https://github.com/GanyuanRan/Aegis)** - Evidence-driven method pack for AI coding agents
 - **[baskduf/codex-fable5](https://github.com/baskduf/FableCodex/tree/main/plugins/codex-fable5/skills/codex-fable5)** - Evidence-based workflow gates for Codex
 - **[csthink/dashmotion](https://github.com/csthink/dashmotion/tree/main/skills/dashmotion)** - Animated technical diagrams from plain English or Mermaid, self-contained HTML/SVG
-- **[ChannelerH/codex-skin-pack-installer](https://github.com/ChannelerH/codex-skin-packs/tree/main/codex-skin-pack-installer)** - Install reversible Codex desktop skin packs safely
+- **[ChannelerH/codex-skin-pack-installer](https://github.com/ChannelerH/codex-skin-packs/tree/main/skills/codex-skin-pack-installer)** - Install reversible Codex desktop skin packs safely
 
 </details>
 


### PR DESCRIPTION
## Summary

Adds `ChannelerH/codex-skin-pack-installer` to Community Skills / Development and Testing.

The skill helps Codex users install reversible, public-safe Codex desktop skin packs from GitHub releases with manifest/asset checks and restore guidance.

## Link checked

- https://github.com/ChannelerH/codex-skin-packs/tree/main/codex-skin-pack-installer returns HTTP 200

## Notes

- The repository is public and includes `SKILL.md` documentation.
- The entry description is short per `CONTRIBUTING.md`.
- This is an independent/unofficial Codex desktop theming workflow.
