### PR TITLE
Fix: Update Antigravity skill directory paths in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1900,7 +1900,7 @@ Agent skills can include prompt injections, tool poisoning, hidden malware paylo
 
 | Tool | Project Path | Global Path | Official Docs |
 |------|-------------|-------------|---------------|
-| Antigravity | `.agent/skills/` | `~/.gemini/antigravity/skills/` | [Antigravity Skills](https://antigravity.google/docs/skills) |
+| Antigravity | `.agents/skills/` | `~/.gemini/config/skills/` | [Antigravity Skills](https://antigravity.google/docs/skills) |
 | Claude Code | `.claude/skills/` | `~/.claude/skills/` | [Claude Code Skills](https://docs.anthropic.com/en/docs/claude-code/skills) |
 | Codex | `.agents/skills/` | `~/.agents/skills/` | [Codex Skills](https://developers.openai.com/codex/skills) |
 | Cursor | `.cursor/skills/` | `~/.cursor/skills/` | [Cursor Skills](https://cursor.com/docs/context/skills) |


### PR DESCRIPTION
Update the workspace and global skill directory paths for Antigravity in `README.md` to align with the latest updates from the [official Antigravity documentation](https://antigravity.google/docs/skills#where-skills-live).

Specifically, workspace-specific skills now default to `<workspace-root>/.agents/skills/<skill-folder>/` (with backward compatibility maintained for `.agent/skills/`), while global skills used across all projects are stored in `~/.gemini/config/skills/<skill-folder>/`. The tool directory reference table in `README.md` has been updated to ensure accurate paths for users and contributors.