### PR TITLE
Add skill: skyzer/deslop-the-copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1678,6 +1678,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[infrasity-labs/dev-gtm-claude-skills](https://github.com/infrasity-labs/dev-gtm-claude-skills)**: GTM-focused skill collection for developer go-to-market workflows including launch planning, positioning, and outbound sequences.
 - **[nowork-studio/NotFair](https://github.com/nowork-studio/NotFair)** - SEO, GEO, Google Ads, and Meta Ads skills with live data
 - **[aaron-he-zhu/aaron-marketing-skills](https://github.com/aaron-he-zhu/aaron-marketing-skills)** - 69 marketing skills across SEO/GEO, influencer, paid ads, and email on one shared contract, with 5 benchmark-driven auditor gates (CORE-EEAT, CITE, C³, ROAS, SEND) and keyless data connectors
+- **[skyzer/deslop-the-copy](https://github.com/skyzer/deslop-the-copy)** - Remove AI writing patterns while preserving the writer's voice
 
 </details>
 


### PR DESCRIPTION
## Summary

- Add `skyzer/deslop-the-copy` to Community Skills under Marketing
- Use a nine-word description that follows the contribution limit

## Community usage

- 554 downloads and 16 installs on ClawHub across two published versions
- Listed on skills.sh for cross-agent installation

## Verification

- Public repository with a root `SKILL.md` and README
- Repository link returns HTTP 200
