### PR TITLE
Add skill: JasonColapietro/suede-creator-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1814,6 +1814,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[baskduf/codex-fable5](https://github.com/baskduf/FableCodex/tree/main/plugins/codex-fable5/skills/codex-fable5)** - Evidence-based workflow gates for Codex
 - **[csthink/dashmotion](https://github.com/csthink/dashmotion/tree/main/skills/dashmotion)** - Animated technical diagrams from plain English or Mermaid, self-contained HTML/SVG
 - **[browser-act/browser-act](https://github.com/browser-act/skills/tree/main/browser-act)** - Automate authenticated browsers with extraction and human handoff
+- **[JasonColapietro/suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills)** - Agent orchestration, code review grading, AI eval, creator tooling skills.
 
 </details>
 


### PR DESCRIPTION
## What's being added

[JasonColapietro/suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills) — a 23-skill pack for Claude Code and Codex, adding to Development and Testing under Community Skills.

## What it includes

Agent orchestration with WIP collision detection and rollback trees, a Codex CLI worker fleet, code review with an A-F ship grade across evidence-backed lanes, AI eval scaffolding, plus design, copy, and SEO/AEO/AI-EO audits. MIT licensed, public repo with a SKILL.md-documented catalog.

## Checklist (per CONTRIBUTING.md)

- [x] Public repository with a working skill pack
- [x] Documented (README + per-skill SKILL.md files)
- [x] Author/org prefix included in the entry name
- [x] Description kept to 10 words or fewer
- [x] Links verified working