### PR TITLE
Add skill: Kusdianta/disk-space-detective

### DIFF
--- a/README.md
+++ b/README.md
@@ -1863,6 +1863,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[aklofas/kicad-happy](https://github.com/aklofas/kicad-happy)** - AI-powered KiCad electronics design review and analysis
 - **[bitwize-music-studio/claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills)** - Full-lifecycle AI music album production
 - **[Alisa0808/vibe-creating-skill](https://github.com/Alisa0808/vibe-creating-skill)** - Rewrites a rough idea or shot script into text-to-video prompts
+- **[Kusdianta/disk-space-detective](https://github.com/Kusdianta/disk-space-detective)** - Finds what silently fills a disk, installs permanent fix
 
 </details>
 


### PR DESCRIPTION
Adds [Kusdianta/disk-space-detective](https://github.com/Kusdianta/disk-space-detective) to **Community Skills → Specialized Domains**, alongside the existing system-management entries there (Windows 11 management, VMware AIops, Home Assistant).

### What it does

A diagnostic methodology for the case where a disk keeps refilling and clearing the usual caches has stopped helping — it separates recurring **churn** (caches that regrow) from a permanent **ratchet** (something that accumulates monthly and never shrinks), then finds and permanently fixes the ratchet.

- Ranked sizing with junction/symlink-safe walking, plus a reconciliation gate that catches broken measurements (`sum(children) ≈ OS-reported used`)
- Growth-by-month bucketing from a single scan, to identify what actually accumulates
- Windows Installer orphan detection via the Installer API (`MsiEnumProductsEx`/`MsiEnumPatchesEx`), which reads patch state so superseded patches can be removed while applied ones are kept
- Finishes by installing a scheduled job + audit log, not a one-time wipe

Cross-platform: Windows, macOS, Linux. Standalone PowerShell 5.1 and POSIX bash scripts, no runtime dependencies. MIT.

### Notes

- Public repo, documented (README + SKILL.md + per-OS references), links verified
- Read-only by default; the reclaim scripts require an explicit `-Execute` / `--execute` flag
- Description is 9 words, added to the end of the category per CONTRIBUTING

I'll note honestly that this repository is new and does not yet have community adoption, which I understand is a stated bar. Submitting for your consideration — entirely understood if you'd prefer it mature first, and I'm happy to resubmit later.
