### PR TITLE
Add e2e-skills to Development and Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1804,6 +1804,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[GanyuanRan/Aegis](https://github.com/GanyuanRan/Aegis)** - Evidence-driven method pack for AI coding agents
 - **[baskduf/codex-fable5](https://github.com/baskduf/FableCodex/tree/main/plugins/codex-fable5/skills/codex-fable5)** - Evidence-based workflow gates for Codex
 - **[csthink/dashmotion](https://github.com/csthink/dashmotion/tree/main/skills/dashmotion)** - Animated technical diagrams from plain English or Mermaid, self-contained HTML/SVG
+- **[voidmatcha/e2e-skills](https://github.com/voidmatcha/e2e-skills)** - Playwright/Cypress skills that review specs for silent always-pass anti-patterns, generate fail-capable E2E tests, and debug report failures.
 
 </details>
 


### PR DESCRIPTION
Adds **e2e-skills** — Playwright/Cypress skills for Claude Code & Codex: review specs for silent always-pass anti-patterns, generate fail-capable tests, and debug failures.

Added under **Development and Testing**. Apache-2.0.

Adoption: 14 test-fix PRs merged into OSS repos (Storybook, code-server, SvelteKit…), plus companion ESLint rules on npm.