### PR TITLE
Add skill: plasma-ai/fractal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1804,6 +1804,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[GanyuanRan/Aegis](https://github.com/GanyuanRan/Aegis)** - Evidence-driven method pack for AI coding agents
 - **[baskduf/codex-fable5](https://github.com/baskduf/FableCodex/tree/main/plugins/codex-fable5/skills/codex-fable5)** - Evidence-based workflow gates for Codex
 - **[csthink/dashmotion](https://github.com/csthink/dashmotion/tree/main/skills/dashmotion)** - Animated technical diagrams from plain English or Mermaid, self-contained HTML/SVG
+- **[plasma-ai/fractal](https://github.com/plasma-ai/fractal/tree/main/fractal/skills/fractal)** - Bounded hierarchical agent loops in isolated git worktrees
 
 </details>
 


### PR DESCRIPTION
## Summary

Add `plasma-ai/fractal` to Community Skills → Development and Testing.

Fractal runs bounded hierarchical agent loops in isolated Git worktrees. The
linked folder contains the canonical `SKILL.md`; the public project currently
has 572 stars and 41 forks.

## Validation

- Confirmed the skill-folder URL and `SKILL.md` resolve
- Confirmed no existing Fractal entry or submission
- Ran `git diff --check`

Disclosure: I’m affiliated with the project.
