### PR TITLE
Add skill: landedjobs/ai-job-hunt-os

### DIFF
--- a/README.md
+++ b/README.md
@@ -1863,6 +1863,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[aklofas/kicad-happy](https://github.com/aklofas/kicad-happy)** - AI-powered KiCad electronics design review and analysis
 - **[bitwize-music-studio/claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills)** - Full-lifecycle AI music album production
 - **[Alisa0808/vibe-creating-skill](https://github.com/Alisa0808/vibe-creating-skill)** - Rewrites a rough idea or shot script into text-to-video prompts
+- **[landedjobs/ai-job-hunt-os](https://github.com/landedjobs/ai-job-hunt-os)** - Six job-hunt skills: decode JDs, tailor resumes, negotiate offers
 
 </details>
 


### PR DESCRIPTION
Adds `landedjobs/ai-job-hunt-os` to Community Skills under Specialized Domains.

Six skills covering one workflow end to end: `jd-decoder`, `company-researcher`, `resume-tailor`, `cold-outreach-writer`, `mock-interviewer`, and `salary-negotiator`.

- Public repo, MIT licensed, each skill has a `SKILL.md` with valid frontmatter
- A validator runs in CI over all six skills on every push
- `CONTRIBUTING.md` and `SOURCES.md` document claim provenance; skills source current market facts at run time rather than freezing benchmarks into the text

Entry follows the format in CONTRIBUTING.md, description is 9 words, and the link is verified working.
