### PR TITLE
Add demo-studio to Development and Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1728,6 +1728,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 
 - **[robzolkos/skill-rails-upgrade](https://github.com/robzolkos/skill-rails-upgrade)** - Analyze Rails apps and provide upgrade assessments
 - **[Shpigford/screenshots](https://github.com/Shpigford/skills/tree/main/screenshots)** - Generate marketing screenshots with Playwright
+- **[AlexAnsart/demo-studio](https://github.com/AlexAnsart/demo-studio)** - Polished narrated product demo videos via agent skills
 - **[antonbabenko/terraform-skill](https://github.com/antonbabenko/terraform-skill)** - Terraform and OpenTofu patterns: testing, modules, state, CI/CD.
 - **[zxkane/aws-skills](https://github.com/zxkane/aws-skills)** - AWS development with infrastructure automation and cloud architecture patterns
 - **[Rootly-AI-Labs/rootly-incident-responder](https://github.com/Rootly-AI-Labs/Rootly-MCP-server/blob/main/examples/skills/rootly-incident-responder.md)** - AI-powered incident response with ML similarity matching, solution suggestions, and on-call coordination. Requires [Rootly MCP Server](https://github.com/Rootly-AI-Labs/Rootly-MCP-server)


### PR DESCRIPTION
## Summary

Add [AlexAnsart/demo-studio](https://github.com/AlexAnsart/demo-studio) to **Development and Testing** â€” narrated product demo videos via agent skills (Playwright + optional ElevenLabs/Whisper pipeline).

## Test plan

- [ ] Link resolves on GitHub
- [ ] Description â‰¤ 10 words per CONTRIBUTING
