### PR TITLE
Add skill: HUANGCHIHHUNGLeo/claude-real-video

### DIFF
--- a/README.md
+++ b/README.md
@@ -1863,6 +1863,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[aklofas/kicad-happy](https://github.com/aklofas/kicad-happy)** - AI-powered KiCad electronics design review and analysis
 - **[bitwize-music-studio/claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills)** - Full-lifecycle AI music album production
 - **[Alisa0808/vibe-creating-skill](https://github.com/Alisa0808/vibe-creating-skill)** - Rewrites a rough idea or shot script into text-to-video prompts
+- **[HUANGCHIHHUNGLeo/claude-real-video](https://github.com/HUANGCHIHHUNGLeo/claude-real-video)** - Scene-aware keyframes plus transcripts so any LLM watches videos
 
 </details>
 


### PR DESCRIPTION
Adds claude-real-video to Community Skills → Specialized Domains.

- Public repo with SKILL.md and full README: https://github.com/HUANGCHIHHUNGLeo/claude-real-video
- What it does: scene-aware keyframe extraction + timestamped transcripts (Whisper, speaker labels) so Claude Code — or any LLM — can actually watch and analyze a video, fully local.
- Community usage: 1.8k+ GitHub stars, ~9.5k PyPI downloads last month, installable via `npx skills add HUANGCHIHHUNGLeo/claude-real-video` (16 hosts) and the Claude Code plugin marketplace; front page of Hacker News.
- Links verified working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)