### PR TITLE
Add skill: AceDataCloud/skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1863,6 +1863,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[aklofas/kicad-happy](https://github.com/aklofas/kicad-happy)** - AI-powered KiCad electronics design review and analysis
 - **[bitwize-music-studio/claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills)** - Full-lifecycle AI music album production
 - **[Alisa0808/vibe-creating-skill](https://github.com/Alisa0808/vibe-creating-skill)** - Rewrites a rough idea or shot script into text-to-video prompts
+- **[AceDataCloud/skills](https://github.com/AceDataCloud/Skills)** - 92 skills for AI media generation and multi-platform publishing
 
 </details>
 


### PR DESCRIPTION
Re-submission of #268, which @necatiozmen closed in March with:

> Thanks for the submission. However, the skill file looks quite new at the moment. Please feel free to open a new PR once it has matured a bit more.

Four months on, here is where it stands against the "real community usage" bar in CONTRIBUTING:

| | March 2026 (#268) | Today |
|---|---|---|
| Skills | 18 | **92** |
| npm downloads | just published | **21,012 last month** ([`@acedatacloud/skills`](https://www.npmjs.com/package/@acedatacloud/skills)) |
| Maintenance | 1 day old | 4 months, still shipping daily |

The collection covers AI media generation (music, image, video, TTS, face) and multi-platform publishing (Zhihu, CSDN, Juejin, Medium, Dev.to, X, Reddit, LinkedIn, Bluesky, Mastodon and others), plus cloud-ops skills. Works with Claude Code, Codex, Cursor, and Gemini CLI.

Added to the end of **Specialized Domains**, one line, 9-word description, per the entry format in CONTRIBUTING.

Disclosure: I maintain this collection; the skills call Ace Data Cloud APIs.