### PR TITLE
Add skill: ConnectiveOne/connectiveone-docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1720,6 +1720,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[Linked-API/linkedin](https://github.com/Linked-API/linkedin-skills/tree/main/linkedin)** - Fetch LinkedIn profiles, search people and companies, send messages, manage connections, create posts, react, comment, and run custom LinkedIn workflows from Claude Code, Codex, Cursor, and Windsurf.
 - **[pattern-ai-labs/agentcall](https://github.com/pattern-ai-labs/agentcall)** - Let your AI agents join Google Meet, Zoom, Teams calls and collaborate like a real team-mate.
 - **[Sendmux/skills](https://github.com/Sendmux/skills)** - Sendmux email and mailbox workflows for agents
+- **[ConnectiveOne/connectiveone-docs](https://github.com/ConnectiveOne/connectiveone-docs/tree/main/skills/connectiveone-docs)** - Official ConnectiveOne product guidance from current sources
 
 </details>
 


### PR DESCRIPTION
## What

Adds the official ConnectiveOne Docs Agent Skill to Productivity and Collaboration.

## Why

The first-party skill helps agents explain ConnectiveOne and retrieve current official product and implementation guidance. It supports the open Agent Skills format and is published as GitHub release v0.2.1.

## Validation

- The repository and direct skill links are public and reachable.
- The entry follows the requested author/skill-name format.
- The description is seven words, within the ten-word limit.
- The skill passes its repository validation and GitHub Agent Skills validation.