### PR TITLE
Add skill: meursyphus/mobile-web-app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1804,6 +1804,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[GanyuanRan/Aegis](https://github.com/GanyuanRan/Aegis)** - Evidence-driven method pack for AI coding agents
 - **[baskduf/codex-fable5](https://github.com/baskduf/FableCodex/tree/main/plugins/codex-fable5/skills/codex-fable5)** - Evidence-based workflow gates for Codex
 - **[csthink/dashmotion](https://github.com/csthink/dashmotion/tree/main/skills/dashmotion)** - Animated technical diagrams from plain English or Mermaid, self-contained HTML/SVG
+- **[meursyphus/mobile-web-app](https://github.com/meursyphus/ssgoi/tree/latest/plugins/ssgoi/skills/mobile-web-app)** - Add native app-like page transitions to mobile web apps
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -1804,7 +1804,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[GanyuanRan/Aegis](https://github.com/GanyuanRan/Aegis)** - Evidence-driven method pack for AI coding agents
 - **[baskduf/codex-fable5](https://github.com/baskduf/FableCodex/tree/main/plugins/codex-fable5/skills/codex-fable5)** - Evidence-based workflow gates for Codex
 - **[csthink/dashmotion](https://github.com/csthink/dashmotion/tree/main/skills/dashmotion)** - Animated technical diagrams from plain English or Mermaid, self-contained HTML/SVG
-- **[meursyphus/mobile-web-app](https://github.com/meursyphus/ssgoi/tree/latest/plugins/ssgoi/skills/mobile-web-app)** - Add native app-like page transitions to mobile web apps
+- **[meursyphus/mobile-web-app](https://github.com/meursyphus/ssgoi/tree/latest/plugins/ssgoi/skills/mobile-web-app)** - Native app-like mobile-web transitions — [docs and live demos](https://ssgoi.dev)
 
 </details>
 


### PR DESCRIPTION
Adds `meursyphus/mobile-web-app` to **Community Skills → Development and
Testing** as a single source link.

The skill helps coding agents apply SSGOI's native app-like routed page
transitions to existing mobile web apps while preserving the application's
router. It routes agents to the canonical `https://ssgoi.dev/llms.txt` and the
matching framework guide instead of duplicating setup documentation.

The listing links directly to https://ssgoi.dev so users can inspect the live
drill, sheet, slide, and zoom demos and supported frameworks before installing
the skill.

This is not a newly created library submission: SSGOI has been public since
2023, is MIT licensed, and currently has more than 900 GitHub stars and 40
forks.

Skill source:
https://github.com/meursyphus/ssgoi/tree/latest/plugins/ssgoi/skills/mobile-web-app

Documentation and live demos: https://ssgoi.dev
