### PR TITLE
Add skill: browser-act/browser-act

### DIFF
--- a/README.md
+++ b/README.md
@@ -1804,6 +1804,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[GanyuanRan/Aegis](https://github.com/GanyuanRan/Aegis)** - Evidence-driven method pack for AI coding agents
 - **[baskduf/codex-fable5](https://github.com/baskduf/FableCodex/tree/main/plugins/codex-fable5/skills/codex-fable5)** - Evidence-based workflow gates for Codex
 - **[csthink/dashmotion](https://github.com/csthink/dashmotion/tree/main/skills/dashmotion)** - Animated technical diagrams from plain English or Mermaid, self-contained HTML/SVG
+- **[browser-act/browser-act](https://github.com/browser-act/skills/tree/main/browser-act)** - Automate authenticated browsers with extraction and human handoff
 
 </details>
 


### PR DESCRIPTION
## Skill

- Name: `browser-act/browser-act`
- Official Skill: https://github.com/browser-act/skills/tree/main/browser-act
- Category: Community Skills / Development and Testing
- Description: `Automate authenticated browsers with extraction and human handoff`

## Requirement evidence

- Public working Skill with `SKILL.md`, installation guidance, safety gates, and MIT license.
- Maintained in the official `browser-act/skills` repository.
- Community adoption: 4,874 GitHub stars and 231 forks at submission time.
- - The entry links to the canonical Skill instead of copying it into this repository.
- - The description is 8 words, within the 10-word limit.
- 