### PR TITLE
add obsidian-keeper skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1708,7 +1708,8 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill)** - Minimal, low-friction hierarchical memory system with background agents and filesystem-based persistence
 - **[kreuzberg-dev/kreuzberg](https://github.com/kreuzberg-dev/kreuzberg/tree/main/skills/kreuzberg)** - Extract text, tables, and metadata from 62+ document formats
 - **[Paramchoudhary/ResumeSkills](https://github.com/Paramchoudhary/ResumeSkills)** - 20 specialized skills for resume optimization, ATS analysis, interview prep, and career transitions
-- **[RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills)** - Transform docs or codebases into Obsidian StudyVaults with interactive quizzes
+- [RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills) - Transform docs or codebases into Obsidian StudyVaults with interactive quizzes
+- **[huini-dev/obsidian-keeper](https://github.com/huini-dev/obsidian-keeper)** - Maintain Obsidian vault project checkpoints, milestone progress, daily work logs, and format governance
 - **[NeoLabHQ/write-concisely](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/docs/skills/write-concisely)** - Applies the famous *The Elements of Style* book principles to make documentation and writing clearer and more professional by eliminating wordiness and improving structure.
 - **[ReScienceLab/opc-skills](https://github.com/ReScienceLab/opc-skills)** - Agent skills for solopreneurs with SEO, geo, and LLM tools
 - **[SeanZoR/claude-speed-reader](https://github.com/SeanZoR/claude-speed-reader)** - Speed read Claude's responses at 600+ WPM using RSVP with Spritz-style ORP highlighting


### PR DESCRIPTION
Adds `obsidian-keeper` to the community skills list.

    - **Repo**: https://github.com/huini-dev/obsidian-keeper
    - **skills.sh**: https://skills.sh/huini-dev/obsidian-keeper/obsidian-keeper
    - **Description**: A Claude Agent Skill for maintaining Obsidian vault project checkpoints, milestone progress, daily
work logs (from git commits or plain-language check-ins), and format/tag governance.