### PR TITLE
Add SnapTool Skills — 49 developer tools for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1867,6 +1867,13 @@ Official skills published by Cypress to help create, maintain, understand, and f
 </details>
 
 <details>
+<summary><h3 style="display:inline">Developer Tools</h3></summary>
+
+- **[RexHuang/snaptool-skills](https://github.com/RexHuang/snaptool-skills)** - 49 developer tools (JSON/CSS/HTML/SQL/XML formatting, Base64/URL/HTML encoding, SHA-256/512 hashing, UUID/password generation, case conversion, CSV↔JSON, color/unit/timestamp conversion, regex testing, JWT decode) via single REST API. Works with Claude Code, Codex, Cursor. Free tier available.
+
+</details>
+
+<details>
 <summary><h3 style="display:inline">n8n Automation</h3></summary>
 
 - **[czlonkowski/n8n-code-javascript](https://github.com/czlonkowski/n8n-skills/tree/main/skills/n8n-code-javascript)** - JavaScript in n8n Code nodes with data access patterns


### PR DESCRIPTION
## What

Adds [SnapTool Skills](https://github.com/RexHuang/snaptool-skills) to the Community Skills → Developer Tools section.

## Why

SnapTool provides 49 real, working developer utilities accessible via a single REST API endpoint — not just prompt instructions, but actual tools (JSON/CSS/HTML/SQL/XML formatting, Base64/URL/HTML encoding, SHA-256/512 hashing, UUID/password generation, case conversion, CSV↔JSON, color/unit/timestamp conversion, regex testing, JWT decode).

### Unique value
- **Real API backend** — most skills are prompt-only; SnapTool has 49 working endpoints
- **Free tier** — 50 calls/month, no credit card
- **Multi-platform** — SKILL.md + .claude-plugin + .codex-plugin + .cursor-plugin
- **MCP compatible** — also available as MCP server (mcp.json)
- **OpenAPI 3.1** — machine-discoverable

### Links
- GitHub: https://github.com/RexHuang/snaptool-skills
- Website: https://snaptools.uk
- Skills discovery: https://snaptools.uk/api/skills
- MCP: https://snaptools.uk/mcp.json