### PR TITLE
Add skill: Orkas-AI/video-router

### DIFF
--- a/README.md
+++ b/README.md
@@ -1863,6 +1863,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[aklofas/kicad-happy](https://github.com/aklofas/kicad-happy)** - AI-powered KiCad electronics design review and analysis
 - **[bitwize-music-studio/claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills)** - Full-lifecycle AI music album production
 - **[Alisa0808/vibe-creating-skill](https://github.com/Alisa0808/vibe-creating-skill)** - Rewrites a rough idea or shot script into text-to-video prompts
+- **[Orkas-AI/video-router](https://github.com/Orkas-AI/Orkas-VideoStudio/tree/main/packages/skills/video-router)** - Route video requests through deterministic agent production stages
 
 </details>
 


### PR DESCRIPTION
## Summary

Add the OrkasVideoStudio `video-router` skill to Community Skills → Productivity and Collaboration. It routes video requests into deterministic planning, composition, editing, generation, and delivery stages.

## Requirements

- public MIT repository with working `SKILL.md` documentation
- 515 GitHub stars at submission time
- compatible with Codex and Claude Code through the project installer
- eight-word description
- direct skill URL returns HTTP 200
- `git diff --check` passes

Disclosure: submitted on behalf of the OrkasVideoStudio project.