### PR TITLE
Add skill: wp-a/nature-academic-search

### DIFF
--- a/README.md
+++ b/README.md
@@ -1863,6 +1863,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[aklofas/kicad-happy](https://github.com/aklofas/kicad-happy)** - AI-powered KiCad electronics design review and analysis
 - **[bitwize-music-studio/claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills)** - Full-lifecycle AI music album production
 - **[Alisa0808/vibe-creating-skill](https://github.com/Alisa0808/vibe-creating-skill)** - Rewrites a rough idea or shot script into text-to-video prompts
+- **[wp-a/nature-academic-search](https://github.com/wp-a/nature-academic-search)** - Searches, verifies, deduplicates, and exports papers across scholarly sources
 
 </details>
 


### PR DESCRIPTION
Adds wp-a/nature-academic-search to Community Skills under Specialized Domains.

The public MIT-licensed skill supports Codex and Claude Code and has current documentation, examples, tests, and community usage.

Maintainer disclosure: I maintain this skill.
Automation disclosure: this submission was prepared with an automated coding assistant.

Validation:
- public SKILL.md and README checked
- description is 9 words
- project currently has 51 GitHub stars
- git diff --check