### PR TITLE
Add skill: JOYLINK-LTD/lacuna-music

### DIFF
--- a/README.md
+++ b/README.md
@@ -1863,6 +1863,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[aklofas/kicad-happy](https://github.com/aklofas/kicad-happy)** - AI-powered KiCad electronics design review and analysis
 - **[bitwize-music-studio/claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills)** - Full-lifecycle AI music album production
 - **[Alisa0808/vibe-creating-skill](https://github.com/Alisa0808/vibe-creating-skill)** - Rewrites a rough idea or shot script into text-to-video prompts
+- **[JOYLINK-LTD/lacuna-music](https://github.com/JOYLINK-LTD/lacuna-toolkit/tree/main/skills/lacuna-music)** - AI music generation via the Lacuna Music API
 
 </details>
 


### PR DESCRIPTION
Adds the `lacuna-music` agent skill to Community Skills → Specialized Domains.

- Skill: https://github.com/JOYLINK-LTD/lacuna-toolkit/tree/main/skills/lacuna-music (SKILL.md with full parameter reference)
- What it does: lets an agent generate AI music through the [Lacuna](https://lacuna.fm) Music API — full songs with vocals and lyrics, or instrumentals — including style prompts, task polling, and audio download.
- Public open-source repo with README/SKILL.md documentation; the monorepo also ships a TypeScript SDK, CLI, and MCP server, all published on npm.

Entry appended to the end of the matching subcategory per CONTRIBUTING.md, description kept within 10 words.

🤖 Generated with [Claude Code](https://claude.com/claude-code)