### PR TITLE
Add skill: QoderAI/better-harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -1811,6 +1811,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[GanyuanRan/Aegis](https://github.com/GanyuanRan/Aegis)** - Evidence-driven method pack for AI coding agents
 - **[baskduf/codex-fable5](https://github.com/baskduf/FableCodex/tree/main/plugins/codex-fable5/skills/codex-fable5)** - Evidence-based workflow gates for Codex
 - **[csthink/dashmotion](https://github.com/csthink/dashmotion/tree/main/skills/dashmotion)** - Animated technical diagrams from plain English or Mermaid, self-contained HTML/SVG
+- **[QoderAI/better-harness](https://github.com/QoderAI/better-harness)** - Cross-host plugin for evidence-backed Agent Work Loop improvement
 
 </details>
 


### PR DESCRIPTION
## Summary

Adds [QoderAI/better-harness](https://github.com/QoderAI/better-harness) to **Community Skills → Development and Testing**.

Better Harness is a cross-host plugin with a working Agent Skill. It analyzes repository and coding-session evidence, identifies gaps in the Agent Work Loop, and produces prioritized, verifiable improvements for Claude Code, Codex, Qoder, Cursor, Qwen Code, GitHub Copilot, and other supported hosts.

## Why it fits

- Public, documented, MIT-licensed repository
- Includes a working `skills/better-harness/SKILL.md`
- Established project with more than 1,000 GitHub stars
- Supports multiple Agent Skills-compatible coding hosts
- Entry explicitly retains the product's plugin positioning

## Validation

- Added one README entry at the end of `Development and Testing`
- Used the required `author/skill-name` format
- Kept the description to 8 words
- Verified the repository and `SKILL.md` URLs
- Ran `git diff --check` and a category-placement check
