### PR TITLE
Add skill: SoraLabsOSS/animating-icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -1811,6 +1811,8 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[GanyuanRan/Aegis](https://github.com/GanyuanRan/Aegis)** - Evidence-driven method pack for AI coding agents
 - **[baskduf/codex-fable5](https://github.com/baskduf/FableCodex/tree/main/plugins/codex-fable5/skills/codex-fable5)** - Evidence-based workflow gates for Codex
 - **[csthink/dashmotion](https://github.com/csthink/dashmotion/tree/main/skills/dashmotion)** - Animated technical diagrams from plain English or Mermaid, self-contained HTML/SVG
+- **[SoraLabsOSS/animating-icons](https://github.com/SoraLabsOSS/skills/tree/main/skills/animating-icons)** - SVG icon hover gestures unique to each glyph
+
 
 </details>
 


### PR DESCRIPTION
## Summary
Adds **SoraLabsOSS/animating-icons** under Community Skills → Development and Testing.

- **Link:** https://github.com/SoraLabsOSS/skills/tree/main/skills/animating-icons
- **Install:** `npx skills add SoraLabsOSS/skills`
- **What it does:** Agent skill for SVG icon hover gestures and icon↔icon morphs (twelve families, failure catalog, measurement-based verify harness). Compatible with Claude Code, Cursor, Codex via Agent Skills format.

## Checklist
- [x] Public repo with SKILL.md / README
- [x] Author/org prefix in the name
- [x] Description ≤ 10 words
- [x] Added at end of matching Community subcategory


Made with [Cursor](https://cursor.com)