### PR TITLE
Add skill: sudosubin/gh-attach

### DIFF
--- a/README.md
+++ b/README.md
@@ -1811,6 +1811,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[GanyuanRan/Aegis](https://github.com/GanyuanRan/Aegis)** - Evidence-driven method pack for AI coding agents
 - **[baskduf/codex-fable5](https://github.com/baskduf/FableCodex/tree/main/plugins/codex-fable5/skills/codex-fable5)** - Evidence-based workflow gates for Codex
 - **[csthink/dashmotion](https://github.com/csthink/dashmotion/tree/main/skills/dashmotion)** - Animated technical diagrams from plain English or Mermaid, self-contained HTML/SVG
+- **[sudosubin/gh-attach](https://github.com/sudosubin/gh-attach/tree/main/skills/gh-attach)** - Upload and download GitHub user-attachments from the command line
 
 </details>
 


### PR DESCRIPTION
Adds `sudosubin/gh-attach` to Community Skills > Development and Testing. One line, links to the skill source path (`skills/gh-attach/`), no other entries touched.

gh-attach is a GitHub CLI extension that uploads and downloads GitHub user-attachments (screenshots, PDFs, zips, videos) from the terminal, producing URLs that work in issues, PRs, and READMEs. MIT licensed, with README and SKILL.md docs.
