### PR TITLE
Add skill: talivia-group/agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1680,6 +1680,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[Eronred/aso-skills](https://github.com/Eronred/aso-skills)** - 30+ App Store Optimization skills for keyword research, metadata optimization, competitor analysis, creative optimization, and mobile growth strategies via Appeeky API
 - **[degausai/wonda](https://github.com/degausai/wonda)** - AI content creation: images, video, music, audio, editing, publishing
 - **[gitroomhq/postiz-agent](https://github.com/gitroomhq/postiz-agent)** - Schedule social media posts across 28+ platforms programmatically
+- **[talivia-group/agent](https://github.com/talivia-group/agent)** - Install and verify revenue analytics through Talivia MCP
 - **[taisly/agent](https://github.com/taisly/agent)** - Codex plugin, Agent Skill, CLI, and MCP server for publishing approved short-form videos to TikTok, Instagram Reels, YouTube Shorts, X, and Facebook through Taisly
 - **[indranilbanerjee/digital-marketing-pro](https://github.com/indranilbanerjee/digital-marketing-pro)** - 150-skill engagement methodology — 12-Part Strategy Flow, 25 specialist agents, EU AI Act Article 50 ready (C2PA signing), 6-platform AEO/GEO incl. Google AI Mode
 - **[infrasity-labs/dev-gtm-claude-skills](https://github.com/infrasity-labs/dev-gtm-claude-skills)**: GTM-focused skill collection for developer go-to-market workflows including launch planning, positioning, and outbound sequences.


### PR DESCRIPTION
Talivia is revenue-first website analytics installed and verified by AI agents through MCP.

Official resources:
- Source: https://github.com/talivia-group/agent
- Hosted OAuth MCP: `https://talivia.com/mcp`
- npm: `@talivia/agent` version `0.1.0`
- Official MCP Registry: `io.github.talivia-group/agent`
- Integration guide: https://talivia.com/ai-agent-kit

The server helps agents install tracking, verify live events, connect payment attribution through a secure browser flow, and identify which referrers, campaigns, pages, and customer journeys become revenue.

This adds the official Agent Skill to the Marketing category with a concise description.