### PR TITLE
Add skill: JimmySadek/youtube-fetcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -1729,6 +1729,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[Linked-API/linkedin](https://github.com/Linked-API/linkedin-skills/tree/main/linkedin)** - Fetch LinkedIn profiles, search people and companies, send messages, manage connections, create posts, react, comment, and run custom LinkedIn workflows from Claude Code, Codex, Cursor, and Windsurf.
 - **[pattern-ai-labs/agentcall](https://github.com/pattern-ai-labs/agentcall)** - Let your AI agents join Google Meet, Zoom, Teams calls and collaborate like a real team-mate.
 - **[Sendmux/skills](https://github.com/Sendmux/skills)** - Sendmux email and mailbox workflows for agents
+- **[JimmySadek/youtube-fetcher](https://github.com/JimmySadek/youtube-fetcher-to-markdown)** - Create Obsidian-ready Markdown notes from YouTube videos
 
 </details>
 


### PR DESCRIPTION
Adds YouTube Fetcher under Community Skills → Productivity and Collaboration.

- Converts YouTube videos into structured, Obsidian-ready Markdown notes with transcripts, metadata, chapters, and truthful caption labels.
- Mature public project: 191 GitHub stars, 15 forks, and 118 tracked skills.sh installs as of 2026-08-04.
- Points to the canonical repository; no skill files are copied into this list.
- The v1.1.0 release has automated tests and isolated installation verification.