### PR TITLE
Add skill: morluto/rea

### DIFF
--- a/README.md
+++ b/README.md
@@ -1876,6 +1876,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[bitwize-music-studio/claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills)** - Full-lifecycle AI music album production
 - **[Alisa0808/vibe-creating-skill](https://github.com/Alisa0808/vibe-creating-skill)** - Rewrites a rough idea or shot script into text-to-video prompts
 - **[Orkas-AI/video-router](https://github.com/Orkas-AI/Orkas-VideoStudio/tree/main/packages/skills/video-router)** - Route video requests through deterministic agent production stages
+- **[morluto/rea](https://github.com/morluto/rea/tree/main/skills/reverse-engineer-anything)** - Reverse-engineer binaries, applications, and runtimes with REA
 
 </details>
 


### PR DESCRIPTION
Adds [morluto/rea](https://github.com/morluto/rea/tree/main/skills/reverse-engineer-anything) to Community Skills → Specialized Domains.

The linked public repository contains a working `SKILL.md` and supporting references. REA provides local CLI and MCP tools for reverse engineering native binaries, managed applications, JavaScript/Electron apps, and browser runtimes.

The description is kept within the repository's short-entry format, and REA has an established public project with current adoption.