### PR TITLE
Add warrant-policy-author

### DIFF
--- a/README.md
+++ b/README.md
@@ -1661,6 +1661,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 <summary><h3 style="display:inline">Vector Databases</h3></summary>
 
 - **[qdrant/skills](https://github.com/qdrant/skills)** - Agent skills for Qdrant vector search, covering scaling, performance optimization, search quality, monitoring, deployment, model migration, version upgrades, and SDK usage across Python, TypeScript, Rust, Go, .NET, and Java
+- **[rmanish2000-del/warrant-policy-author](https://github.com/rmanish2000-del/warrant-mcp/tree/main/skills/warrant-policy-author)** - Write plain-English policies for the warrant-mcp tool-call firewall; interviews you, shapes rules for a closed deterministic rule set, and explains why provenance/cost/approval sentences cannot be enforced
 
 </details>
 


### PR DESCRIPTION
Adds **warrant-policy-author**, the authoring skill shipped inside the
[warrant-mcp](https://github.com/rmanish2000-del/warrant-mcp) npm package
(a policy firewall for Claude Code tool calls — plain-English rules,
compiled once, enforced by deterministic code via a PreToolUse hook).

The skill teaches Claude the authoring craft: a short user interview,
sentences shaped for the closed 8-rule vocabulary, and the failure shapes
(provenance, cost/judgement, ask-me-first, cross-action state) explained
rather than avoided. Only `warrant-mcp review` can say whether a policy
compiles; the skill's job is to give it the best possible chance.
Evidence so far: eight policies for genuinely different project types —
three authored directly, five by sessions given nothing but the installed
skill and a vaguely-worded brief — all accepted by review on the first
attempt. A drift test in the package pins the skill's vocabulary to the
compiler's schema so the two cannot diverge silently.

- Real use case: a policy the compiler refuses is the product's main
  onboarding friction; this skill teaches the craft that avoids it and
  explains the refusals it cannot avoid.
- Not a duplicate: no existing entry targets agent-firewall policy authoring.
- License: MIT. Install: `npx warrant-mcp init --skill`; or
  `/plugin marketplace add rmanish2000-del/warrant-mcp` then
  `/plugin install warrant-policy-author@warrant-mcp` (no npm needed); or
  copy the folder into `.claude/skills/`.

Note for maintainers: please link the entry to the source folder rather than
vendoring a copy — the skill is derived from the enforcement engine's schema
and must version with it.