### PR TITLE
Add skill: kurtschmidt/storyblok-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1814,6 +1814,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[baskduf/codex-fable5](https://github.com/baskduf/FableCodex/tree/main/plugins/codex-fable5/skills/codex-fable5)** - Evidence-based workflow gates for Codex
 - **[csthink/dashmotion](https://github.com/csthink/dashmotion/tree/main/skills/dashmotion)** - Animated technical diagrams from plain English or Mermaid, self-contained HTML/SVG
 - **[browser-act/browser-act](https://github.com/browser-act/skills/tree/main/browser-act)** - Automate authenticated browsers with extraction and human handoff
+- **[kurtschmidt/storyblok-skill](https://github.com/kurtschmidt/storyblok-skill)** - Storyblok CMS engineering: schemas, draft preview, migrations, and CI gates
 
 </details>
 


### PR DESCRIPTION
Adds [kurtschmidt/storyblok-skill](https://github.com/kurtschmidt/storyblok-skill) to Community Skills > Development and Testing.

Storyblok CMS engineering for Next.js and Astro: the Delivery vs Management API split, component schemas, draft/preview wiring, image transforms, migration scripts, and CI gates.

- Public repo, MIT, documented in README + SKILL.md, no executable scripts
- In use across two production Storyblok builds; extended after the second with the traps found there
- Install: `npx skills add kurtschmidt/storyblok-skill`