### PR TITLE
Add skill: tjboudreaux/cc-thinking-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1729,6 +1729,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[Linked-API/linkedin](https://github.com/Linked-API/linkedin-skills/tree/main/linkedin)** - Fetch LinkedIn profiles, search people and companies, send messages, manage connections, create posts, react, comment, and run custom LinkedIn workflows from Claude Code, Codex, Cursor, and Windsurf.
 - **[pattern-ai-labs/agentcall](https://github.com/pattern-ai-labs/agentcall)** - Let your AI agents join Google Meet, Zoom, Teams calls and collaborate like a real team-mate.
 - **[Sendmux/skills](https://github.com/Sendmux/skills)** - Sendmux email and mailbox workflows for agents
+- **[tjboudreaux/cc-thinking-skills](https://github.com/tjboudreaux/cc-thinking-skills)** - 28 eval-informed mental models for decisions, debugging, systems, and strategy
 
 </details>
 


### PR DESCRIPTION
Adds the source-preserving 28-skill collection to Community Skills → Productivity and Collaboration. The repository has 5.2K recorded skills.sh installs and exposes a released Agent Skills-compatible catalog without mirroring skill bodies.