### PR TITLE
Add skill: Sorwcyra/ds-vision-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1876,6 +1876,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[bitwize-music-studio/claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills)** - Full-lifecycle AI music album production
 - **[Alisa0808/vibe-creating-skill](https://github.com/Alisa0808/vibe-creating-skill)** - Rewrites a rough idea or shot script into text-to-video prompts
 - **[Orkas-AI/video-router](https://github.com/Orkas-AI/Orkas-VideoStudio/tree/main/packages/skills/video-router)** - Route video requests through deterministic agent production stages
+- **[Sorwcyra/ds-vision-skill](https://github.com/Sorwcyra/ds-vision-skill)** - Routes image understanding, OCR, and PDF parsing
 
 </details>
 


### PR DESCRIPTION
Adds Sorwcyra/ds-vision-skill to the Community Skills list under Specialized Domains.

The entry follows the documented format and keeps the description short: "Routes image understanding, OCR, and PDF parsing".

Validation:
- Verified the public skill repository link: https://github.com/Sorwcyra/ds-vision-skill
- Checked CONTRIBUTING.md requirements for entry format, category placement, and PR title