### PR TITLE
Add skill: ZeroPointRepo/youtube-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1876,6 +1876,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[bitwize-music-studio/claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills)** - Full-lifecycle AI music album production
 - **[Alisa0808/vibe-creating-skill](https://github.com/Alisa0808/vibe-creating-skill)** - Rewrites a rough idea or shot script into text-to-video prompts
 - **[Orkas-AI/video-router](https://github.com/Orkas-AI/Orkas-VideoStudio/tree/main/packages/skills/video-router)** - Route video requests through deterministic agent production stages
+- **[ZeroPointRepo/youtube-skills](https://github.com/ZeroPointRepo/youtube-skills)** - Agent skills for YouTube: pull video transcripts and discover videos (search, channel and playlist listings) via TranscriptAPI.
 
 </details>
 


### PR DESCRIPTION
Reviving #625 with the requested change.

Feedback on #625 was: "No need a new category, add it to proper existed section please". I removed the new category entirely and added the skill to the end of the existing Specialized Domains section instead. The branch is rebased on current main, so the diff is now a single line.

Note: I tried to reopen #625, but GitHub does not allow reopening after a force-push, so this is a fresh PR from the same branch.

Happy to move it elsewhere if you prefer a different section.

Disclosure: I work on TranscriptAPI, a third-party service that is not affiliated with YouTube or Google.