### PR TITLE
Add skill: agiwhitelist/auteur

### DIFF
--- a/README.md
+++ b/README.md
@@ -1814,6 +1814,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[baskduf/codex-fable5](https://github.com/baskduf/FableCodex/tree/main/plugins/codex-fable5/skills/codex-fable5)** - Evidence-based workflow gates for Codex
 - **[csthink/dashmotion](https://github.com/csthink/dashmotion/tree/main/skills/dashmotion)** - Animated technical diagrams from plain English or Mermaid, self-contained HTML/SVG
 - **[browser-act/browser-act](https://github.com/browser-act/skills/tree/main/browser-act)** - Automate authenticated browsers with extraction and human handoff
+- **[agiwhitelist/auteur](https://github.com/agiwhitelist/auteur)** - Builds websites gated by an anti-slop linter and motion QA
 
 </details>
 


### PR DESCRIPTION
Adds `agiwhitelist/auteur` to Community Skills → Development and Testing.

**Repo:** https://github.com/agiwhitelist/auteur — MIT, `SKILL.md` at repo root, documented in English and Chinese.

**What it does.** Builds complete websites from a written art-direction commitment, and enforces the standard with two runnable gates rather than prose: `slopscan`, a zero-dependency linter that fails the build on concrete generic-design tells, and `motionqa`, a Playwright pass under 4x CPU throttle checking FPS, long tasks, console errors, and contrast. Ten live sites at https://agiwhitelist.github.io/auteur/ each pass both, and either script runs standalone against any URL.

**On your maturity requirement.** Your CONTRIBUTING asks for community-adopted skills rather than brand-new ones, so I want to be straight about where this stands instead of letting a star count imply something it should not. The repo is 26 days old with 21 commits and active development, CI gating every showcase site on every push. Install counts are still small. If that reads as too early for this list, close it and I will resubmit when the usage is there — no argument from me.