### PR TITLE
Add skill: perso-ai/perso-dubbing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1876,6 +1876,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[bitwize-music-studio/claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills)** - Full-lifecycle AI music album production
 - **[Alisa0808/vibe-creating-skill](https://github.com/Alisa0808/vibe-creating-skill)** - Rewrites a rough idea or shot script into text-to-video prompts
 - **[Orkas-AI/video-router](https://github.com/Orkas-AI/Orkas-VideoStudio/tree/main/packages/skills/video-router)** - Route video requests through deterministic agent production stages
+- **[perso-ai/perso-dubbing](https://github.com/perso-ai/perso-dubbing-plugin)** - Video translator: dubbing, lip-sync, subtitles, and short clips
 
 </details>
 


### PR DESCRIPTION
### What this adds

`perso-ai/perso-dubbing` — a video translation skill bundle for coding agents.
Three skills ship in the repo:

- `dubbing` — voice-translates video into another language, with optional
  lip-sync and voice/background separation
- `srt` — extracts subtitles via STT, translates them, and burns styled
  subtitles onto the video
- `clip` — cuts short-form clips and reframes 16:9 to 9:16, or picks
  highlight moments from an STT transcript

Files, folders, and YouTube/TikTok URLs are all accepted as input.

### Category

Added to the end of **Community Skills → Specialized Domains**, next to the
existing video entries (`video-db/skills`, `Orkas-AI/video-router`).

### Maintenance

Built and maintained by the Perso AI dev team. Actively released — currently at
v0.8.11 — MIT licensed, and it runs on Claude Code, Codex, Cursor, and
Antigravity, with documentation in 13 languages.

Subtitle translation, styling, and clipping run locally with no account
required; only the server-side operations (dubbing, lip-sync, STT, voice
separation) use Perso AI credits.