### PR TITLE
Add skill: product-on-purpose/pm-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1729,6 +1729,16 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[Linked-API/linkedin](https://github.com/Linked-API/linkedin-skills/tree/main/linkedin)** - Fetch LinkedIn profiles, search people and companies, send messages, manage connections, create posts, react, comment, and run custom LinkedIn workflows from Claude Code, Codex, Cursor, and Windsurf.
 - **[pattern-ai-labs/agentcall](https://github.com/pattern-ai-labs/agentcall)** - Let your AI agents join Google Meet, Zoom, Teams calls and collaborate like a real team-mate.
 - **[Sendmux/skills](https://github.com/Sendmux/skills)** - Sendmux email and mailbox workflows for agents
+- **[product-on-purpose/deliver-prd](https://github.com/product-on-purpose/pm-skills/tree/main/skills/deliver-prd)** - Write a PRD covering problem, scope, and success metrics
+- **[product-on-purpose/deliver-acceptance-criteria](https://github.com/product-on-purpose/pm-skills/tree/main/skills/deliver-acceptance-criteria)** - Generate Given/When/Then acceptance criteria for a user story
+- **[product-on-purpose/deliver-user-stories](https://github.com/product-on-purpose/pm-skills/tree/main/skills/deliver-user-stories)** - Break features into persona, action, benefit user stories
+- **[product-on-purpose/deliver-edge-cases](https://github.com/product-on-purpose/pm-skills/tree/main/skills/deliver-edge-cases)** - Catalog edge cases, error states, and recovery paths
+- **[product-on-purpose/discover-competitive-analysis](https://github.com/product-on-purpose/pm-skills/tree/main/skills/discover-competitive-analysis)** - Compare competitor features, pricing, and positioning with a 2x2
+- **[product-on-purpose/define-problem-statement](https://github.com/product-on-purpose/pm-skills/tree/main/skills/define-problem-statement)** - Frame a problem with user impact and success criteria
+- **[product-on-purpose/define-hypothesis](https://github.com/product-on-purpose/pm-skills/tree/main/skills/define-hypothesis)** - Define a testable hypothesis with metrics and validation approach
+- **[product-on-purpose/define-opportunity-tree](https://github.com/product-on-purpose/pm-skills/tree/main/skills/define-opportunity-tree)** - Map outcomes to customer opportunities and candidate solutions
+- **[product-on-purpose/develop-adr](https://github.com/product-on-purpose/pm-skills/tree/main/skills/develop-adr)** - Write an Architecture Decision Record in Nygard format
+- **[product-on-purpose/measure-experiment-design](https://github.com/product-on-purpose/pm-skills/tree/main/skills/measure-experiment-design)** - Design an A/B test with variants, metrics, and duration
 
 </details>
 


### PR DESCRIPTION
Adds 10 product management skills from `product-on-purpose/pm-skills` to **Community Skills > Productivity and Collaboration**.

### Checklist against CONTRIBUTING

- **Public repository with a working skill** - https://github.com/product-on-purpose/pm-skills, Apache 2.0
- **Has documentation** - every skill has a `SKILL.md`; the repo also publishes docs at https://product-on-purpose.github.io/pm-skills/
- **Author/org prefix included** - all entries are prefixed `product-on-purpose/`
- **Descriptions 10 words or fewer** - longest is 10 words
- **Real community usage** - 31.1K installs on skills.sh, 523 GitHub stars, 66 tagged releases since January 2026. The 10 skills submitted are the most-installed ones, ranging from 517 to 689 installs each
- **Links verified** - all 10 return HTTP 200

### Why only 10 and not the whole library

The library has 68 skills. I picked the 10 with the highest install counts rather than listing everything, so the section stays readable. Happy to trim further or move them to "Other" if you would prefer a different placement.

### About the project

Product management skills for AI coding assistants, covering discovery, definition, delivery, measurement, and iteration. Each skill is held to a contract validated in CI and versioned with SemVer, so entries here will not go stale as the library changes.

Note this is unrelated to the similarly named `phuryn/pm-skills` already listed in this README. Different project, different author.
