### PR TITLE
Add skill: qimister-code/liuyao-quanjie

### DIFF
--- a/README.md
+++ b/README.md
@@ -1877,6 +1877,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[bitwize-music-studio/claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills)** - Full-lifecycle AI music album production
 - **[Alisa0808/vibe-creating-skill](https://github.com/Alisa0808/vibe-creating-skill)** - Rewrites a rough idea or shot script into text-to-video prompts
 - **[Orkas-AI/video-router](https://github.com/Orkas-AI/Orkas-VideoStudio/tree/main/packages/skills/video-router)** - Route video requests through deterministic agent production stages
+- **[qimister-code/liuyao-quanjie](https://github.com/qimister-code/liuyao-quanjie)** - I Ching (Liu Yao) divination: coin casting, Najia charting, 64 hexagrams
 
 </details>
 


### PR DESCRIPTION
Add [qimister-code/liuyao-quanjie](https://github.com/qimister-code/liuyao-quanjie) to the Specialized Domains category under Community Skills.

I Ching (Liu Yao / Jingfang Najia) divination skill for AI agents: zero-dependency coin casting + Najia charting engine (31 regression tests), complete 64-hexagram knowledge base with resolve guides, 13 SVG charts, dual license (MIT code + CC BY-NC-SA content).