### PR TITLE
Add CANOA numismatics research/education skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1858,6 +1858,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[wanshuiyin/Auto-claude-code-research-in-sleep](https://github.com/wanshuiyin/Auto-claude-code-research-in-sleep)** - Autonomous ML research with cross-model review loops and GPU deployment
 - **[zechenzhangAGI/AI-research-SKILLs](https://github.com/zechenzhangAGI/AI-research-SKILLs)** - 77 AI research skills for model training, inference, and MLOps
 - **[Orchestra-Research/AI-research-SKILLs](https://github.com/Orchestra-Research/AI-research-SKILLs)** - 20-module AI research skill library for model architecture, training, and ML paper writing
+- **[canoa-dev/canoa-skills](https://github.com/canoa-dev/canoa-skills)** - Numismatics research and education skills: CANOA API usage for ancient world coinage (Greece, Rome, Persia, Byzantium), regional hoard analysis (coin distribution by emperors/periods, charts, PDF articles)
 - **[komal-SkyNET/claude-skill-homeassistant](https://github.com/komal-SkyNET/claude-skill-homeassistant)** - Supercharge and manage Home Assistant workflows
 - **[more-io/apple-bridges](https://github.com/more-io/claude-apple-bridges)** - Native macOS app access — manage Apple Reminders, Calendar, Contacts, Notes, Mail, and tmux sessions via Swift CLI bridges
 - **[hanhuark/mechanical-engineering-research-skill](https://github.com/hanhuark/mechanical-engineering-research-skill)** - Thermal-fluid research writing, proposals, DOE, and presentation feedback


### PR DESCRIPTION
Adds canoa-dev/canoa-skills to Community Skills → Specialized Domains. Two Agent Skills: canoa-api (CANOA API usage for ancient coinage research — 128,500+ types, 540,000+ specimens, metrology, statistics) and canoa-hoard-analysis (regional hoard analysis: coin distribution by emperors/periods, charts, PDF articles). No API key or DB access needed; works with Hermes Agent, Claude Code, Cursor, Codex.