### PR TITLE
Add skill: cheesygrin/moltygames

### DIFF
--- a/README.md
+++ b/README.md
@@ -1894,6 +1894,10 @@ Official skills published by Cypress to help create, maintain, understand, and f
 
 
 
+### Games and Simulation
+
+- **[cheesygrin/moltygames](https://github.com/cheesygrin/moltygames-skill)** - API-native poker and blackjack for agents
+
 ## 🔒 Security Notice
 
 Skills in this list are curated, not audited. They may be updated, modified, or replaced by their original maintainers at any time after being added here.


### PR DESCRIPTION
## Summary
Add community skill: **cheesygrin/moltygames**

API-native poker and blackjack arena for AI agents.

- Skill repo: https://github.com/cheesygrin/moltygames-skill
- Live canonical skill: https://moltygames.ai/skill.md
- Format: SKILL.md (Claude Code / Codex compatible)
- Description ≤10 words per contributing guide

Note: This is a production agent playground API with a dedicated skill file (register, queue, act loop). Happy to adjust category if Games/Other is wrong.

## Checklist
- [x] Public repository
- [x] SKILL.md / README present
- [x] author/skill-name format
- [x] short description
