### PR TITLE
Add skill: liuboacean/mubu-integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1727,6 +1727,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[Linked-API/linkedin](https://github.com/Linked-API/linkedin-skills/tree/main/linkedin)** - Fetch LinkedIn profiles, search people and companies, send messages, manage connections, create posts, react, comment, and run custom LinkedIn workflows from Claude Code, Codex, Cursor, and Windsurf.
 - **[pattern-ai-labs/agentcall](https://github.com/pattern-ai-labs/agentcall)** - Let your AI agents join Google Meet, Zoom, Teams calls and collaborate like a real team-mate.
 - **[Sendmux/skills](https://github.com/Sendmux/skills)** - Sendmux email and mailbox workflows for agents
+- **[liuboacean/mubu-integration](https://github.com/liuboacean/mubu-integration)** - Mubu (幕布) outline CLI & AI Agent Skill — import/export Markdown with true round-trip fidelity, plus OPML/FreeMind export.
 
 </details>
 


### PR DESCRIPTION
## Summary

Add [liuboacean/mubu-integration](https://github.com/liuboacean/mubu-integration) to the **Community Skills → Productivity and Collaboration** section.

**Entry added:**

- **[liuboacean/mubu-integration](https://github.com/liuboacean/mubu-integration)** - Mubu (幕布) outline CLI & AI Agent Skill — import/export Markdown with true round-trip fidelity, plus OPML/FreeMind export.

## Details

- **Repo:** public, ~12 stars, includes both `README.md` and `SKILL.md` (documentation requirement met)
- **Category:** Productivity and Collaboration — Mubu/幕布 is a Chinese outliner / mind-map knowledge tool, sitting naturally alongside the Notion, NotebookLM, and Obsidian entries already in this subcategory
- **Format:** follows the existing `- **[author/skill](url)** - description` bullet style; inserted at the end of the subcategory, no other lines or structure changed
- **Link verified:** https://github.com/liuboacean/mubu-integration returns a working public repository

Thanks for maintaining this curated list!
