### PR TITLE
Add skill: Anmoll-W/decoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1727,6 +1727,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[Linked-API/linkedin](https://github.com/Linked-API/linkedin-skills/tree/main/linkedin)** - Fetch LinkedIn profiles, search people and companies, send messages, manage connections, create posts, react, comment, and run custom LinkedIn workflows from Claude Code, Codex, Cursor, and Windsurf.
 - **[pattern-ai-labs/agentcall](https://github.com/pattern-ai-labs/agentcall)** - Let your AI agents join Google Meet, Zoom, Teams calls and collaborate like a real team-mate.
 - **[Sendmux/skills](https://github.com/Sendmux/skills)** - Sendmux email and mailbox workflows for agents
+- **[Anmoll-W/decoder](https://github.com/Anmoll-W/decoder)** - Explains technical concepts to PMs with live research and analogies
 
 </details>
 


### PR DESCRIPTION
Adds Anmoll-W/decoder to the end of Community Skills > Productivity and Collaboration.

Decoder explains technical concepts to PMs: drop a link or describe a situation, it researches live, explains with character analogies, and closes with one smart question. Works in any Claude Code session.

Repo: https://github.com/Anmoll-W/decoder