### PR TITLE
Add skill: superdesigndev/superdesign-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1813,6 +1813,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[csthink/dashmotion](https://github.com/csthink/dashmotion/tree/main/skills/dashmotion)** - Animated technical diagrams from plain English or Mermaid, self-contained HTML/SVG
 - **[browser-act/browser-act](https://github.com/browser-act/skills/tree/main/browser-act)** - Automate authenticated browsers with extraction and human handoff
 - **[JasonColapietro/suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills)** - Agent orchestration, code review grading, AI eval, creator tooling skills.
+- **[superdesigndev/superdesign-skill](https://github.com/superdesigndev/superdesign-skill)** - Creates design systems from existing codebases and iterates UI drafts
 
 </details>
 


### PR DESCRIPTION
Adds `superdesigndev/superdesign-skill` to Community Skills under Development and Testing.

The public MIT repository documents Agent Skills installation (`npx skills add`) and Claude Code plugin installation, and includes a working SKILL.md. It currently has 396 stars, 27 forks and 4 contributors, and was last pushed 2026-08-05.

Placement follows the existing design and UX entries in this subcategory. Description is 10 words. Link verified.

Disclosure: I maintain this repository.