### PR TITLE
Add skill: The-825/breadcrumbs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1835,6 +1835,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[ohad6k/emulo](https://github.com/ohad6k/emulo)** - Mines AI coding logs into personal agent profiles
 - **[Tubo2333/obsidian-knowledge-brain](https://github.com/Tubo2333/obsidian-knowledge-brain)** - Cross-session knowledge memory and rule evolution for AI coding agents
 - **[oliver-zehentleitner/keep-the-why](https://github.com/oliver-zehentleitner/keep-the-why)** - Preserves the reasoning behind a codebase — decisions, workarounds, rejected alternatives
+- **[The-825/breadcrumbs](https://github.com/The-825/breadcrumbs)** - Agent memory kit: ledgers, retrieval exams, merge gates
 
 </details>
 


### PR DESCRIPTION
Adding The-825/breadcrumbs under Community > Context Engineering.

Breadcrumbs is a public kit of agent-memory and repo-operations machinery: append-only decision ledgers with supersession, a retrieval exam with a forbidden-hit check (catches superseded entries that still win injection), tiered merge gates, and paste-able rule sets, each with selftests. SKILL.md and README document the collection; every skill lives in the repo with stdlib-only Python.

Community usage, per the maturity bar: independently evaluated in the Agent Memory Atlas (https://neoneye.github.io/agent-memory-atlas/systems/breadcrumbs/), active discussion in r/AIMemory, and three defects found by external review have been patched, so the review loop is real, not just a listing.

Link verified working. Entry follows the author/skill-name format, description under 10 words.