### PR TITLE
Add Skills by HumanPen

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Official skills by VoltAgent for building AI agents with the VoltAgent TypeScrip
 <details>
 <summary><h3 style="display:inline">Skills by HumanPen</h3></summary>
 
-- **[humanpen/humanpen-skill](https://github.com/humanpen/humanpen-skill)** - Rewrites Word/PPT/PDF docs to read as human-written
+- **[humanpen/humanpen-skill](https://github.com/humanpen/humanpen-skill)** - Document-level AI humanizer that edits .docx/.pptx in place
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,13 @@ Official skills by VoltAgent for building AI agents with the VoltAgent TypeScrip
 </details>
 
 <details>
+<summary><h3 style="display:inline">Skills by HumanPen</h3></summary>
+
+- **[humanpen/humanpen-skill](https://github.com/humanpen/humanpen-skill)** - Rewrites Word/PPT/PDF docs to read as human-written
+
+</details>
+
+<details>
 <summary><h3 style="display:inline">Skills by TestMu AI</h3></summary>
 
 Production-grade Agent Skills for every major test automation framework, maintained by the TestMu AI (formerly LambdaTest) team. They help AI coding assistants generate expert-level test automation code across web, mobile, API, BDD, and unit testing stacks.


### PR DESCRIPTION
Adds a **Skills by HumanPen** block.

[humanpen/humanpen-skill](https://github.com/humanpen/humanpen-skill) rewrites Word/PowerPoint/PDF documents to read as human-written and lowers AI-detection scores, keeping every fact, number, table and all formatting intact. Ships `SKILL.md`; Apache-2.0.