### PR TITLE
Add skill: Ryan-yang125/motion-lexicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1813,6 +1813,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[csthink/dashmotion](https://github.com/csthink/dashmotion/tree/main/skills/dashmotion)** - Animated technical diagrams from plain English or Mermaid, self-contained HTML/SVG
 - **[browser-act/browser-act](https://github.com/browser-act/skills/tree/main/browser-act)** - Automate authenticated browsers with extraction and human handoff
 - **[JasonColapietro/suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills)** - Agent orchestration, code review grading, AI eval, creator tooling skills.
+- **[Ryan-yang125/motion-lexicon](https://github.com/Ryan-yang125/motion-lexicon/tree/main/skills/motion-lexicon)** - Build and review product motion with installable React components
 
 </details>
 


### PR DESCRIPTION
## What

Adds Motion Lexicon to Community Skills → Development and Testing.

## Why

Motion Lexicon is a public, documented Agent Skill for building, implementing, and reviewing product motion in React. Its repository ships 48 complete components and 44 motion primitives, with installable source, live previews, and reduced-motion paths.

The project currently has 38 GitHub stars. In the latest 14-day GitHub traffic window, it recorded 414 unique cloners.

## Checks

- Public `SKILL.md` link verified
- Description is 9 words
- No existing Motion Lexicon entry
