### PR TITLE
Add skill: kgraph57/strategy-consulting-visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1729,6 +1729,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[pattern-ai-labs/agentcall](https://github.com/pattern-ai-labs/agentcall)** - Let your AI agents join Google Meet, Zoom, Teams calls and collaborate like a real team-mate.
 - **[Sendmux/skills](https://github.com/Sendmux/skills)** - Sendmux email and mailbox workflows for agents
 - **[Neeeophytee/finding-unknowns-skills](https://github.com/Neeeophytee/finding-unknowns-skills)** - 8 meta-skills that make a coding agent surface your unknowns before they get expensive: blindspot pass, interview, reference hunt, implementation plan/notes, pitch packager, and a pre-merge change quiz. Works in Claude Code, Codex, and Cursor via the agentskills.io SKILL.md format
+- **[kgraph57/strategy-consulting-visualization](https://github.com/kgraph57/mckinsey-style-visualization-skill)** - McKinsey-style charts and consulting slide decks
 
 </details>
 


### PR DESCRIPTION
## Type
- [x] Skill

## Checklist
- [x] Link works
- [x] Relevant to Claude Skills
- [x] Formatting correct
- [x] Added to correct section (Community Skills → Productivity and Collaboration)
- [x] Author prefix included

Public repo with root SKILL.md. Skill name strategy-consulting-visualization. Install: npx skills add kgraph57/mckinsey-style-visualization-skill. Independent package; not affiliated with any consulting firm.