### PR TITLE
Add SuperCMO Skills (Community Skills > Marketing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1688,6 +1688,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[Vladimir-Human/humanizer-ru](https://github.com/Vladimir-Human/humanizer-ru)** - Removes AI-writing markers from Russian text
 - **[Bomx/distribb-skill](https://github.com/Bomx/distribb-skill)** - SEO articles, keyword research, CMS publishing, high-DR backlink exchange
 - **[AIDevGTM/gtm-cofounder](https://github.com/AIDevGTM/gtm-cofounder)** - 18 go-to-market skills for solo technical founders: positioning, first users, launch, pricing, and founder-led sales; grounded in Adam Frankl and Jakub Czakon
+- **[SupercmoHQ/superCMO-skills](https://github.com/SupercmoHQ/superCMO-skills)** - Open-source skills + local MCP server for marketing video & image production: UGC videos, ad videos, product photography, and image ads from a product photo and a brief; casts AI actors, picks the best image/video models, edits any-length clips with consistent actor and product, and researches competitor ads. BYO or managed keys, Apache-2.0
 
 </details>
 


### PR DESCRIPTION
Adds **SupercmoHQ/superCMO-skills** to **Community Skills → Marketing**.

Open-source (Apache-2.0) skills + a local MCP server for marketing video & image production — UGC videos, ad videos, product photography, and image ads from a product photo and a brief; casts AI actors, picks the best image/video models, edits any-length clips with consistent actor + product, and researches competitor ads.

Not a fresh throwaway: 10 skills, live on the official MCP registry (`io.github.SupercmoHQ/supercmo`), PyPI (`supercmo-skills`), and npm (`@supercmo/skills`); Glama-graded (Tool Quality A). Repo: https://github.com/SupercmoHQ/superCMO-skills