### PR TITLE
Add skill: tonydzi/second-brain-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1732,6 +1732,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[Sendmux/skills](https://github.com/Sendmux/skills)** - Sendmux email and mailbox workflows for agents
 - **[zapier/zapier-mcp](https://github.com/zapier/zapier-mcp)** - Official plugin distribution for the hosted Zapier MCP server. Connects Claude to thousands of apps — send messages, pull data, trigger workflows.
 - **[Neeeophytee/finding-unknowns-skills](https://github.com/Neeeophytee/finding-unknowns-skills)** - 8 meta-skills that make a coding agent surface your unknowns before they get expensive: blindspot pass, interview, reference hunt, implementation plan/notes, pitch packager, and a pre-merge change quiz. Works in Claude Code, Codex, and Cursor via the agentskills.io SKILL.md format
+- **[tonydzi/second-brain-skills](https://github.com/tonydzi/second-brain-starter-kit)** - 101 production skills for second-brain, CRM, and assistant workflows
 
 </details>
 


### PR DESCRIPTION
Adds **[tonydzi/second-brain-skills](https://github.com/tonydzi/second-brain-starter-kit)** to Community Skills > Productivity and Collaboration.

- 101 skills extracted from a live daily-driver operation (second brain on Obsidian + CRM + assistant workflows), personal data replaced with fictional examples
- Standard Agent Skills format (SKILL.md per skill), installable via `npx skills add tonydzi/second-brain-starter-kit` or as a Claude Code plugin marketplace
- Docs: README + per-skill SKILL.md + skills/INDEX.md map
- In daily production use on a 5-machine fleet since May 2026; repo public since v0.1.0

Assisted-by: Claude (Mycroft, synthetic cofounder of the lab)