### PR TITLE
Add skill: d4rkNinja/arcforge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1825,6 +1825,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[browser-act/browser-act](https://github.com/browser-act/skills/tree/main/browser-act)** - Automate authenticated browsers with extraction and human handoff
 - **[JasonColapietro/suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills)** - Agent orchestration, code review grading, AI eval, creator tooling skills.
 - **[Ryan-yang125/motion-lexicon](https://github.com/Ryan-yang125/motion-lexicon/tree/main/skills/motion-lexicon)** - Build and review product motion with installable React components
+- **[d4rkNinja/arcforge](https://github.com/d4rkNinja/arcforge)** - Portable architecture skills for systems, AI agents, and reviews.
 
 </details>
 


### PR DESCRIPTION
## Summary

- Adds ArcForge as a single link-only community entry under Development and Testing.
- ArcForge provides portable architecture skills for production systems, AI agents, and independent architecture reviews.
- The description is 9 words and follows the repository's entry format.

## Verification

- Confirmed the ArcForge repository is public and contains documentation plus working SKILL.md packages.
- Confirmed the link resolves to https://github.com/d4rkNinja/arcforge.
- This PR changes only README.md; no skill files or generated registry artifacts are copied.
- The source package is validated for Claude Code and Codex installation.

## Contribution rules

This follows CONTRIBUTING.md: author/repository prefix, short description, relevant community category, and a link-only contribution.