### PR TITLE
Add skill: JanYork/using-lwc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1850,6 +1850,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[stjbrown/agent-knowledge](https://github.com/stjbrown/agent-knowledge)** - Maintains portable, cited agent knowledge bases in plain Markdown
 - **[khendzel/skills-janitor](https://github.com/khendzel/skills-janitor)** - Token audit, usage tracking, and swipe-to-delete skill pruning.
 - **[oliver-zehentleitner/keep-the-why](https://github.com/oliver-zehentleitner/keep-the-why)** - Preserves the reasoning behind a codebase — decisions, workarounds, rejected alternatives
+- **[JanYork/using-lwc](https://github.com/JanYork/using-lwc)** - Persistent project memory with verified document and code graphs
 
 </details>
 


### PR DESCRIPTION
Adds `JanYork/using-lwc` to Community Skills > Context Engineering.

The skill provides persistent project memory with independently verified document and code graphs. Its canonical repository is public and includes `SKILL.md` documentation.