### PR TITLE
Add skill: Melvynx/lumail

### DIFF
--- a/README.md
+++ b/README.md
@@ -1688,6 +1688,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[Vladimir-Human/humanizer-ru](https://github.com/Vladimir-Human/humanizer-ru)** - Removes AI-writing markers from Russian text
 - **[Bomx/distribb-skill](https://github.com/Bomx/distribb-skill)** - SEO articles, keyword research, CMS publishing, high-DR backlink exchange
 - **[AIDevGTM/gtm-cofounder](https://github.com/AIDevGTM/gtm-cofounder)** - 18 go-to-market skills for solo technical founders: positioning, first users, launch, pricing, and founder-led sales; grounded in Adam Frankl and Jakub Czakon
+- **[Melvynx/lumail](https://github.com/Melvynx/lumail-opensource)** - Manage email campaigns, subscribers, and workflows from agents
 
 </details>
 


### PR DESCRIPTION
Adding one community skill to the Marketing category.

1. Melvynx/lumail

Manage email campaigns, subscribers, and workflows from agents.

Skill repo: https://github.com/Melvynx/lumail-opensource
Skill path: https://github.com/Melvynx/lumail-opensource/tree/main/skills/lumail
Install: `npx skills add Melvynx/lumail-opensource`
MCP: `https://lumail.io/mcp` (OAuth 2.1, no API token)

The repo has a documented README plus SKILL.md for the CLI and the OAuth MCP plugin. Lumail is used in production for AI-native email marketing from Claude Code, Codex, and Cursor.


Made with [Cursor](https://cursor.com)