### PR TITLE
Add skill: riffkit/skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1688,6 +1688,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[Vladimir-Human/humanizer-ru](https://github.com/Vladimir-Human/humanizer-ru)** - Removes AI-writing markers from Russian text
 - **[Bomx/distribb-skill](https://github.com/Bomx/distribb-skill)** - SEO articles, keyword research, CMS publishing, high-DR backlink exchange
 - **[AIDevGTM/gtm-cofounder](https://github.com/AIDevGTM/gtm-cofounder)** - 18 go-to-market skills for solo technical founders: positioning, first users, launch, pricing, and founder-led sales; grounded in Adam Frankl and Jakub Czakon
+- **[riffkit/skill](https://github.com/riffkit/skill)** - Turn a winning short video into your product's video
 
 </details>
 


### PR DESCRIPTION
Adds **riffkit/skill** to Community Skills → Marketing.

- Repo: https://github.com/riffkit/skill
- Live skill: https://riffkit.ai/SKILL.md
- Entry: `- **[riffkit/skill](https://github.com/riffkit/skill)** - Turn a winning short video into your product's video` (9 words)

Give it one short video that already performed and it rebuilds that video's formula — hook, pacing, emotional beats — into brand-new footage around your own product, character and language. The source clip is never reused.

Meets the requirements: public MIT repo, SKILL.md with YAML frontmatter plus README and worked examples, tagged release v1.3.1 kept in sync with the live SKILL.md, author prefix in the name, description under 10 words.

On maturity: published since early July 2026 and in production behind riffkit.ai — it is the primary way agent users reach the product, with steady installs and signups attributed to the agent ecosystem over the past month. Also listed in VoltAgent/awesome-openclaw-skills (merged in #549).

Works with Claude Code, Cursor, Codex — any agent that can read a URL — plus the OpenClaw CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)