### PR TITLE
Add skill: sandbaseai/sandbase

### DIFF
--- a/README.md
+++ b/README.md
@@ -1825,6 +1825,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[browser-act/browser-act](https://github.com/browser-act/skills/tree/main/browser-act)** - Automate authenticated browsers with extraction and human handoff
 - **[JasonColapietro/suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills)** - Agent orchestration, code review grading, AI eval, creator tooling skills.
 - **[Ryan-yang125/motion-lexicon](https://github.com/Ryan-yang125/motion-lexicon/tree/main/skills/motion-lexicon)** - Build and review product motion with installable React components
+- **[sandbaseai/sandbase](https://github.com/sandbaseai/cli/tree/main/assets/skills/sandbase)** - Safely connect coding agents to SandBase through an MCP bridge
 
 </details>
 


### PR DESCRIPTION
## Summary

Adds the canonical SandBase Agent Skill to **Community Skills → Development and Testing**.

Canonical Skill source: https://github.com/sandbaseai/cli/tree/main/assets/skills/sandbase
Independent community listing: https://clawhub.ai/joeliu926/skills/sandbase

## Requirement checks

- Public repository with a complete `SKILL.md`
- Canonical source is maintained and versioned by `sandbaseai`
- The independent ClawHub listing reports 304 downloads and 1 install across 2 versions
- The listing reports clean static, SkillSpector, LLM, and VirusTotal checks
- Description is 10 words

## Ownership disclosure

This PR is submitted from the official `sandbaseai` organization fork and links to the organization-maintained source. The ClawHub page is a third-party community mirror used only as adoption evidence; it is not owned or endorsed by SandBase.