### PR TITLE
Add skill: thedotmack/claude-mem

### DIFF
--- a/README.md
+++ b/README.md
@@ -1850,6 +1850,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[stjbrown/agent-knowledge](https://github.com/stjbrown/agent-knowledge)** - Maintains portable, cited agent knowledge bases in plain Markdown
 - **[khendzel/skills-janitor](https://github.com/khendzel/skills-janitor)** - Token audit, usage tracking, and swipe-to-delete skill pruning.
 - **[oliver-zehentleitner/keep-the-why](https://github.com/oliver-zehentleitner/keep-the-why)** - Preserves the reasoning behind a codebase — decisions, workarounds, rejected alternatives
+- **[thedotmack/claude-mem](https://github.com/thedotmack/claude-mem)** - Compresses and persists agent memory across sessions
 
 </details>
 


### PR DESCRIPTION
## Summary

Adds `thedotmack/claude-mem` to the Context Engineering community section, alongside the other memory/context-persistence skills already listed there (`hanfang/claude-memory-skill`, `awrshift/claude-memory-kit`, `k-kolomeitsev/data-structure-protocol`).

It's a memory-compression system that persists context across Claude Code (and other agent) sessions, packaged as a plugin with a `plugin/skills/` directory of individual skills (`mem-search`, `learn-codebase`, `pathfinder`, etc.).

Meets the contributing guidelines' quality bar:
- Public repo with working skills and extensive documentation (README + individual SKILL.md files, 12 translated READMEs)
- Author/org prefix included: `thedotmack/claude-mem`
- Not brand new: created 2025-08-31, actively maintained (30 tagged releases, latest v13.15.0, pushed as recently as yesterday)
- Real community usage, not just stars: 7,929 forks, 445 open issues, ~63k npm downloads in the last 30 days, part of the Vercel OSS program

## Test plan

- [x] Confirmed the repo isn't already referenced anywhere in README.md under this or another name
- [x] Confirmed placement matches the existing Context Engineering subcategory per CONTRIBUTING.md
- [x] Description is 8 words, under the 10-word limit
- [x] Verified adoption signals beyond star count (npm downloads, forks, issue activity, release cadence) given how easily GitHub stars can be inflated