### PR TITLE
Add skill: 5dive-ai/skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1825,6 +1825,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[browser-act/browser-act](https://github.com/browser-act/skills/tree/main/browser-act)** - Automate authenticated browsers with extraction and human handoff
 - **[JasonColapietro/suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills)** - Agent orchestration, code review grading, AI eval, creator tooling skills.
 - **[Ryan-yang125/motion-lexicon](https://github.com/Ryan-yang125/motion-lexicon/tree/main/skills/motion-lexicon)** - Build and review product motion with installable React components
+- **[5dive-ai/skills](https://github.com/5dive-ai/skills)** - Agent skills for inter-agent comms, knowledge compilation, fleet diagnostics
 
 </details>
 


### PR DESCRIPTION
Adds `5dive-ai/skills` to Community Skills -> Development and Testing.

- Repo: https://github.com/5dive-ai/skills (public, MIT, created 2026-04-27)
- 17 skills, each a `SKILL.md` bundle with its own README
- Loads in Claude Code and any harness that reads skills.sh-format prompts

One line added at the end of the category, per CONTRIBUTING; description is 9 words.
