### PR TITLE
Add skill: uizze/anti-ui-slop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1826,7 +1826,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[browser-act/browser-act](https://github.com/browser-act/skills/tree/main/browser-act)** - Automate authenticated browsers with extraction and human handoff
 - **[JasonColapietro/suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills)** - Agent orchestration, code review grading, AI eval, creator tooling skills.
 - **[Ryan-yang125/motion-lexicon](https://github.com/Ryan-yang125/motion-lexicon/tree/main/skills/motion-lexicon)** - Build and review product motion with installable React components
-- **[uizze/anti-ui-slop](https://github.com/uizze/uizze/tree/main/skills/anti-ui-slop)** - Prevent generic UI before it ships in coding agents.
+- **[uizze/anti-ui-slop](https://github.com/uizze/uizze/tree/main/skills/anti-ui-slop)** - Free anti-ui-slop Skill for coding agents, grounded in 800,000+ real web and iOS screens with a hard finish gate before UI ships.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -1826,6 +1826,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[browser-act/browser-act](https://github.com/browser-act/skills/tree/main/browser-act)** - Automate authenticated browsers with extraction and human handoff
 - **[JasonColapietro/suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills)** - Agent orchestration, code review grading, AI eval, creator tooling skills.
 - **[Ryan-yang125/motion-lexicon](https://github.com/Ryan-yang125/motion-lexicon/tree/main/skills/motion-lexicon)** - Build and review product motion with installable React components
+- **[uizze/anti-ui-slop](https://github.com/uizze/uizze/tree/main/skills/anti-ui-slop)** - Prevent generic UI before it ships in coding agents.
 
 </details>
 


### PR DESCRIPTION
## Summary

- Add the canonical UIZZE anti-ui-slop Skill to the Design and UI/UX section.
- Use the maintained source at https://github.com/uizze/uizze/tree/main/skills/anti-ui-slop.
- Describe the free Skill as grounded in 800,000+ real web and iOS screens with a hard finish gate.

## Fit

UIZZE gives coding agents a portable workflow for interface work: define product-specific constraints, cover required states, and review the rendered result before shipping. The free Skill works locally; the optional preview adds a deterministic rendered HTML/CSS check.

## Validation

- Confirmed the canonical repository and Skill path.
- Updated the visible README entry to the current free-first 800,000+ copy.
- Ran git diff --check.