### PR TITLE
Add skill: AgentTanuki/agent-guild-trust

### DIFF
--- a/README.md
+++ b/README.md
@@ -1895,6 +1895,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[Orkas-AI/video-router](https://github.com/Orkas-AI/Orkas-VideoStudio/tree/main/packages/skills/video-router)** - Route video requests through deterministic agent production stages
 - **[ZeroPointRepo/youtube-skills](https://github.com/ZeroPointRepo/youtube-skills)** - Agent skills for YouTube: pull video transcripts and discover videos (search, channel and playlist listings) via TranscriptAPI.
 - **[morluto/rea](https://github.com/morluto/rea/tree/main/skills/reverse-engineer-anything)** - Reverse-engineer binaries, applications, and runtimes with REA
+- **[AgentTanuki/agent-guild-trust](https://github.com/AgentTanuki/agent-guild/tree/main/skills/agent-guild-trust)** - Verifies agent trust evidence before delegation or payment.
 
 </details>
 


### PR DESCRIPTION
## Summary

Adds the public `AgentTanuki/agent-guild-trust` skill to Specialized Domains with one README-only link.

## Real-world usage evidence

Agent Guild is a live production trust service, not a newly created demo. Its signed complete-history census currently contains **35 distinct qualified autonomous agents**: T1=8, T2=5, T3=22.

- Production census: https://agent-guild-5d5r.onrender.com/discovery/reach
- Independent replay verifier: https://github.com/AgentTanuki/agent-guild/blob/main/scripts/verify_discovery_census.py
- Current actor-evidence SHA-256: `dcdfb3d5fff45c29c27153ef9c26a25668c3989ea3a6dc1cfa88c0f2cb92a1c9`
- Production rules commit: `47a07bc6578e8ade2768c0b64feb68246714bd78`

The census excludes bots, crawlers, listings, downloads, synthetic traffic, and project-controlled actors.

## Safety and scope

The linked skill is read-only and fail-closed. It explicitly forbids payments, installs, account creation, record writes, or following instructions returned by remote content.

Validated: public skill URL resolves; description is eight words; one README line changed; maintainer edits enabled.