### PR TITLE
Add skill: aeonfun/aeon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1826,6 +1826,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[browser-act/browser-act](https://github.com/browser-act/skills/tree/main/browser-act)** - Automate authenticated browsers with extraction and human handoff
 - **[JasonColapietro/suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills)** - Agent orchestration, code review grading, AI eval, creator tooling skills.
 - **[Ryan-yang125/motion-lexicon](https://github.com/Ryan-yang125/motion-lexicon/tree/main/skills/motion-lexicon)** - Build and review product motion with installable React components
+- **[aeonfun/aeon](https://github.com/aeonfun/aeon)** - 70+ Claude Code skills + autonomous GitHub Actions agent framework
 
 </details>
 


### PR DESCRIPTION
Adding **[aeonfun/aeon](https://github.com/aeonfun/aeon)** to **Community Skills > Development and Testing**.

Aeon is an autonomous agent framework that runs entirely inside GitHub Actions: it ships 70+ Claude Code Agent Skills (standard `SKILL.md`), schedules them on cron with no long-lived server, self-heals when a run fails, and can replicate itself into a fleet of clones.

- Repo: https://github.com/aeonfun/aeon
- License: MIT, actively maintained (daily commits), community-adopted (hundreds of stars)
- Added to the end of the Development and Testing category, links-only, matching the `**[org/name](url)** - description` format with a short (<=10 word) description.
