### PR TITLE
Add SPIDER - statement-level dead code analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1908,6 +1908,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[czlonkowski/n8n-node-configuration](https://github.com/czlonkowski/n8n-skills/tree/main/skills/n8n-node-configuration)** - Node configuration with dependency rules and AI connections
 - **[czlonkowski/n8n-validation-expert](https://github.com/czlonkowski/n8n-skills/tree/main/skills/n8n-validation-expert)** - Fix n8n validation errors with error catalog
 - **[czlonkowski/n8n-workflow-patterns](https://github.com/czlonkowski/n8n-skills/tree/main/skills/n8n-workflow-patterns)** - Workflow patterns for webhook, HTTP, database, and AI tasks
+- **[baytcho/spider-dead-code-skill](https://github.com/baytcho/spider-dead-code-skill)** - Finds the code a project does not need and proves it. Splits the codebase into individual statements, starts at the entry points and follows the links, so whatever the execution never reaches is reported with its exact file and lines. Python, TypeScript, JavaScript and CSS in one model; a name assembled at runtime is never declared unused.
 
 </details>
 


### PR DESCRIPTION
Adds SPIDER.

An agent skill that finds the code a project does not need, and proves it. It
splits the whole codebase into individual top-level statements, starts at the
entry points and follows the links. Whatever the execution reaches is alive;
whatever it never reaches is reported with its exact file and line numbers.

What sets it apart from the static tools in this space:

- statement level, not file or export level, so it can say that three rules in a
  stylesheet are alive and the fourth is dead;
- Python, TypeScript, JavaScript and CSS in one model, measured by one rule;
- a third state during the work, `unresolved`, so a name assembled at runtime is
  never declared unused - no confidence percentages, no deleting on a hunch;
- every decision is written down with its address, so the reasoning can be
  checked afterwards;
- ships with an answer key: a small project carrying six deliberate traps and 29
  machine checks, run in CI on every push.

Proven on a production Next.js application: 858 statements, 66 files, 121
statements that nothing in the running program ever reaches. MIT, public
repository, packaged release available.
