### PR TITLE
Add mailtrap/mailtrap-skills to Community Skills - Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1688,6 +1688,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[Vladimir-Human/humanizer-ru](https://github.com/Vladimir-Human/humanizer-ru)** - Removes AI-writing markers from Russian text
 - **[Bomx/distribb-skill](https://github.com/Bomx/distribb-skill)** - SEO articles, keyword research, CMS publishing, high-DR backlink exchange
 - **[AIDevGTM/gtm-cofounder](https://github.com/AIDevGTM/gtm-cofounder)** - 18 go-to-market skills for solo technical founders: positioning, first users, launch, pricing, and founder-led sales; grounded in Adam Frankl and Jakub Czakon
+- **[mailtrap/mailtrap-skills](https://github.com/mailtrap/mailtrap-skills)** - Send emails via API/SMTP with sandbox testing
 
 </details>
 


### PR DESCRIPTION
Adds mailtrap/mailtrap-skills as a single link under the Marketing subcategory of Community Skills, per CONTRIBUTING.md.

This replaces #828, which was closed due to markdown formatting issues from a messy commit history. This is a fresh branch with a single clean commit.