### PR TITLE
Add skill: uizze/anti-ui-slop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1826,6 +1826,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[browser-act/browser-act](https://github.com/browser-act/skills/tree/main/browser-act)** - Automate authenticated browsers with extraction and human handoff
 - **[JasonColapietro/suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills)** - Agent orchestration, code review grading, AI eval, creator tooling skills.
 - **[Ryan-yang125/motion-lexicon](https://github.com/Ryan-yang125/motion-lexicon/tree/main/skills/motion-lexicon)** - Build and review product motion with installable React components
+- **[uizze/anti-ui-slop](https://github.com/uizze/uizze/tree/main/skills/anti-ui-slop)** - Prevent generic UI with design contracts and hard finish gates
 
 </details>
 


### PR DESCRIPTION
## Summary
- add UIZZE's portable `anti-ui-slop` Skill to Community Skills → Development and Testing
- link directly to the canonical `uizze/uizze` Skill source
- keep the directory's short-description and community-adoption requirements intact

The Skill is MIT-licensed, has a public SKILL.md, and has established community usage visible through its skills.sh listing.

## Verification
- `git diff --check`
- canonical Skill path: https://github.com/uizze/uizze/tree/main/skills/anti-ui-slop
- free install: `npx skills add https://uizze.com --skill anti-ui-slop`