### PR TITLE
Add converly-agent (conversion tracking) to Community > Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1688,6 +1688,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[Vladimir-Human/humanizer-ru](https://github.com/Vladimir-Human/humanizer-ru)** - Removes AI-writing markers from Russian text
 - **[Bomx/distribb-skill](https://github.com/Bomx/distribb-skill)** - SEO articles, keyword research, CMS publishing, high-DR backlink exchange
 - **[AIDevGTM/gtm-cofounder](https://github.com/AIDevGTM/gtm-cofounder)** - 18 go-to-market skills for solo technical founders: positioning, first users, launch, pricing, and founder-led sales; grounded in Adam Frankl and Jakub Czakon
+- **[converlyio/converly-agent](https://github.com/converlyio/converly-agent)** - Server-side conversion tracking setup for Google Ads, Meta, GA4, LinkedIn, TikTok and more. Connects the ad platform, builds and publishes the conversion flow, installs the tracking snippet, and verifies real conversions through the Converly CLI
 
 </details>
 


### PR DESCRIPTION
Adds one entry to the end of the **Community Skills → Marketing** subcategory, following the format in CONTRIBUTING.md.

**Skill:** [converlyio/converly-agent](https://github.com/converlyio/converly-agent)

Sets up server-side conversion tracking for ad platforms without writing tracking code. The agent connects the ad platform (OAuth handoff to the user), builds and publishes the conversion flow, installs the tracking snippet, and verifies delivery with a test event plus real conversions. Drives the open-source [@converly/cli](https://www.npmjs.com/package/@converly/cli) (MIT, Node 20+, zero dependencies).

Checklist against the requirements:
- Public repository with a working skill ✅
- Documentation: SKILL.md plus a README and three reference docs ✅
- Author/org prefix included in the name ✅
- MIT licensed ✅

Disclosure: I maintain this skill.