### PR TITLE
Add skill: orziz/odai

### DIFF
--- a/README.md
+++ b/README.md
@@ -1862,6 +1862,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[stjbrown/agent-knowledge](https://github.com/stjbrown/agent-knowledge)** - Maintains portable, cited agent knowledge bases in plain Markdown
 - **[khendzel/skills-janitor](https://github.com/khendzel/skills-janitor)** - Token audit, usage tracking, and swipe-to-delete skill pruning.
 - **[oliver-zehentleitner/keep-the-why](https://github.com/oliver-zehentleitner/keep-the-why)** - Preserves the reasoning behind a codebase — decisions, workarounds, rejected alternatives
+- **[orziz/odai](https://github.com/orziz/odai/tree/main/skills/odai)** - Govern evidence, responsibility routing, safety boundaries, and verified delivery
 
 </details>
 


### PR DESCRIPTION
Adds the canonical [Odai](https://github.com/orziz/odai/tree/main/skills/odai) governance skill to Context Engineering. It governs evidence, responsibility routing, authorization and safety boundaries, and verified delivery. The project is actively maintained with 88 GitHub stars and 464 recorded installs on skills.sh.