### PR TITLE
Add resource: open-web-bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1761,6 +1761,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[sanjay3290/deep-research](https://github.com/sanjay3290/ai-skills/tree/main/skills/deep-research)** - Autonomous multi-step research using Gemini Deep Research Agent
 - **[jthack/ffuf-claude-skill](https://github.com/jthack/ffuf_claude_skill)** - Web fuzzing with ffuf
 - **[lackeyjb/playwright-skill](https://github.com/lackeyjb/playwright-skill)** - Browser automation with Playwright
+- **[woniu9524/open-web-bridge](https://github.com/woniu9524/open-web-bridge)** - Drive your real, logged-in Chrome via CDP from Claude Code, Codex, or Gemini CLI: semantic snapshots, real mouse clicks, human handoff for captchas and logins, HAR capture and replay
 - **[ibelick/ui-skills](https://github.com/ibelick/ui-skills)** - Opinionated, evolving constraints to guide agents when building interfaces
 - **[muthuishere/hand-drawn-diagrams](https://github.com/muthuishere/hand-drawn-diagrams)** - Generate hand-drawn Excalidraw diagrams from a prompt — animated SVG, hosted edit link, and PNG export. Works with Claude Code, Codex, Gemini CLI, and any agent supporting standard skill paths
 - **[nextlevelbuilder/ui-ux-pro-max-skill](https://github.com/nextlevelbuilder/ui-ux-pro-max-skill)** - UI/UX design patterns and best practices


### PR DESCRIPTION
Adds **open-web-bridge** to *Development and Testing*.

A CLI + local daemon + MV3 Chrome extension that let a coding agent (Claude Code, Codex, Gemini CLI) drive your actual logged-in Chrome over CDP instead of a clean headless browser: semantic @eN snapshots, real CDP mouse clicks, human handoff for captchas/logins, HAR recording and replay-script generation, an optional relay mode for remote control. MIT, npm package, no telemetry.

Disclosure: I'm the author.