### PR TITLE
Add simple-man to Development and Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1837,6 +1837,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[JasonColapietro/suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills)** - Agent orchestration, code review grading, AI eval, creator tooling skills.
 - **[superdesigndev/superdesign-skill](https://github.com/superdesigndev/superdesign-skill)** - Creates design systems from existing codebases and iterates UI drafts
 - **[Ryan-yang125/motion-lexicon](https://github.com/Ryan-yang125/motion-lexicon/tree/main/skills/motion-lexicon)** - Build and review product motion with installable React components
+- **[Maksim-Burtsev/simple-man](https://github.com/Maksim-Burtsev/simple-man)** - Strips praise, recaps and filler from agent answers while keeping every fact you act on: findings carry location and fix, refusals carry the safe procedure, tutorials stay long-form. Benchmarked on 1,793 preregistered live calls with raw records committed. Works with Claude Code, Codex, Gemini CLI, Cursor
 
 </details>
 


### PR DESCRIPTION
Adds [simple-man](https://github.com/Maksim-Burtsev/simple-man) — a communication policy that strips praise, recaps and filler from agent answers while keeping every fact you act on.

Why it fits Development and Testing: it changes how a coding agent reports work — every review or security finding carries its location, consequence and one-line fix; a refusal names the target, the missing precondition and the safe procedure; a failed check reports the exact failure. It also knows when *not* to compress, so tutorials and detailed reports stay long-form.

Meets the requirements: public repo, MIT, SKILL.md plus full docs, author prefix in the name. Installs into 20+ agents via `npx skills add`, and ships AGENTS.md surfaces for Codex, Gemini CLI and Cursor.

Evidence, since the claim is measurable: two preregistered runs on `claude-sonnet-5`, 1,793 live calls, all raw records committed — median answer 833 → 520 tokens (−32.4%) with required-fact retention equal to the no-policy baseline. Every published number is rebuilt from the raw records in CI, and the candidates that failed their gates are published rather than hidden.

Single-line addition at the end of the section.