### PR TITLE
Add skill: thousandflowers/skillreaper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1862,6 +1862,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[stjbrown/agent-knowledge](https://github.com/stjbrown/agent-knowledge)** - Maintains portable, cited agent knowledge bases in plain Markdown
 - **[khendzel/skills-janitor](https://github.com/khendzel/skills-janitor)** - Token audit, usage tracking, and swipe-to-delete skill pruning.
 - **[oliver-zehentleitner/keep-the-why](https://github.com/oliver-zehentleitner/keep-the-why)** - Preserves the reasoning behind a codebase — decisions, workarounds, rejected alternatives
+- **[thousandflowers/skillreaper](https://github.com/thousandflowers/skillreaper)** - Prunes unused skills, MCP servers, and subagents from transcript evidence
 
 </details>
 


### PR DESCRIPTION
Adds skillreaper to Community Skills → Context Engineering.

**What it does:** measures what share of an agent's loaded context ever actually fires — skills, MCP servers, subagents, hooks, always-loaded prose — using evidence from the user's own session transcripts, then prunes the dead weight reversibly. Runs locally; nothing is uploaded.

https://github.com/thousandflowers/skillreaper

Checklist:
- [x] Public repo, MIT licensed, README + SKILL.md docs
- [x] Author prefix included in the name
- [x] Description is 10 words
- [x] Added to the end of the matching subcategory
- [x] Not brand new: first commit 2026-06-10, released through v0.5.0, ships on Homebrew, npm and as static binaries for six platforms