### PR TITLE
Add skill: chrono-meta/context-doctor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1862,6 +1862,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[stjbrown/agent-knowledge](https://github.com/stjbrown/agent-knowledge)** - Maintains portable, cited agent knowledge bases in plain Markdown
 - **[khendzel/skills-janitor](https://github.com/khendzel/skills-janitor)** - Token audit, usage tracking, and swipe-to-delete skill pruning.
 - **[oliver-zehentleitner/keep-the-why](https://github.com/oliver-zehentleitner/keep-the-why)** - Preserves the reasoning behind a codebase — decisions, workarounds, rejected alternatives
+- **[chrono-meta/context-doctor](https://github.com/chrono-meta/forge-harness/tree/main/plugins/fh-meta/skills/context-doctor)** - Generates .claudeignore and flags context bloat before it costs tokens
 
 </details>
 


### PR DESCRIPTION
Adds one skill to **Community Skills → Context Engineering**.

```markdown
- **[chrono-meta/context-doctor](https://github.com/chrono-meta/forge-harness/tree/main/plugins/fh-meta/skills/context-doctor)** - Generates .claudeignore and flags context bloat before it costs tokens
```

## Checklist against CONTRIBUTING

- Public repo with a working skill — MIT, `SKILL.md` + `SKILL_detail.md`
- Author/org prefix included
- Description is 10 words
- One skill only, appended to the end of the matching subcategory
- Link verified (HTTP 200)

## On the "real community usage" bar — stating this plainly

Your CONTRIBUTING asks for community-adopted, proven skills and rejects brand-new ones. Here is the honest picture, separated so you can weigh it yourself:

- **The harness it ships in** is not new — public since June, on npm (`@chrono-meta/fh-gate`), a Homebrew tap, a Zenodo DOI, listed in `walkinglabs/awesome-harness-engineering`, and it has started receiving external PRs.
- **This individual skill** has no separate adoption metric I can point to. I'm not going to imply otherwise.

So: if your bar is per-skill adoption evidence, this does not clear it yet and a decline is fair. I'm submitting because the format and licensing requirements are met and the skill is genuinely usable on its own — but the judgment is yours.

## Why it belongs in Context Engineering rather than a tooling bucket

The skill works on two axes: filesystem footprint (auto-generating `.claudeignore`, flagging over-read files) and command-output volume. **I verified the standalone claim before submitting** rather than trusting the description: I ran it blind in a throwaway non-harness repo (no `CLAUDE.md`, no hub assets, just `node_modules/`, `dist/`, `.venv/` and one source file). It completed and wrote a correct `.claudeignore`; the hub-only steps skipped cleanly instead of erroring.

One honest limitation from that run: the **command-output axis** depends on an external proxy binary being installed, so it did not execute there. The filesystem axis is fully standalone. "Usable without the hub" and "every feature runs" are not the same claim, and I'd rather you hear that from me than find it later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4gtrgMVh6YVxwEEJQ8msk