### PR TITLE
Add hedralab/eskill — meta-skill to build Agent Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1748,6 +1748,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 <details>
 <summary><h3 style="display:inline">Development and Testing</h3></summary>
 
+- **[hedralab/eskill](https://github.com/hedralab/eskill)** - Meta-skill to build top-tier Agent Skills: spec-compliant SKILL.md, eval loop, validator, market research, numbered-file pipeline
 - **[robzolkos/skill-rails-upgrade](https://github.com/robzolkos/skill-rails-upgrade)** - Analyze Rails apps and provide upgrade assessments
 - **[Shpigford/screenshots](https://github.com/Shpigford/skills/tree/main/screenshots)** - Generate marketing screenshots with Playwright
 - **[antonbabenko/terraform-skill](https://github.com/antonbabenko/terraform-skill)** - Terraform and OpenTofu patterns: testing, modules, state, CI/CD.


### PR DESCRIPTION
Adds **[hedralab/eskill](https://github.com/hedralab/eskill)** to Development and Testing: a meta-skill (SKILL.md) for building spec-compliant Agent Skills — interview first, market/insight research, one-page plan, numbered-file pipeline, eval loop, validator, commercialization checklist. MIT, free, used daily by its author (eat-your-own-dogfood).
