### PR TITLE
Add skill: muyen/meihua-yishu

### DIFF
--- a/README.md
+++ b/README.md
@@ -1894,6 +1894,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[GarethManning/competency-unpacker](https://github.com/GarethManning/education-agent-skills/tree/main/skills/curriculum-assessment/competency-unpacker)** - Unpacks broad competencies into assessable sub-skills and success criteria
 - **[ZeroPointRepo/youtube-skills](https://github.com/ZeroPointRepo/youtube-skills)** - Agent skills for YouTube: pull video transcripts and discover videos (search, channel and playlist listings) via TranscriptAPI.
 - **[morluto/rea](https://github.com/morluto/rea/tree/main/skills/reverse-engineer-anything)** - Reverse-engineer binaries, applications, and runtimes with REA
+- **[muyen/meihua-yishu](https://github.com/muyen/meihua-yishu)** - Plum Blossom (梅花易數) I Ching divination with deterministic hexagram casting
 
 </details>
 


### PR DESCRIPTION
Adds `muyen/meihua-yishu` to **Community Skills → Specialized Domains**.

**What it does:** 梅花易數 (Plum Blossom) I Ching divination — deterministic hexagram casting from time or user-supplied numbers, then the classical text and a line-by-line reading. Runs fully locally; no API keys, no external service.

**Against the contribution requirements:**

- Public repository with a working skill — https://github.com/muyen/meihua-yishu
- Documentation: `SKILL.md` at the repo root, plus `README.md` (EN) and `README.zh-TW.md`
- Author/org prefix included in the name
- Description is 10 words
- Real community usage: 195 stars, 60 forks; published well before this submission, not newly created
- Not a SaaS wrapper — the skill is self-contained Python and needs no paid service

Also ships an `ETHICS.md`, since divination output is the kind of thing an agent should be careful about presenting as fact.
