### PR TITLE
Add skill: sdshah09/brag-document-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1740,6 +1740,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[JimmySadek/youtube-fetcher](https://github.com/JimmySadek/youtube-fetcher-to-markdown)** - Create Obsidian-ready Markdown notes from YouTube videos
 - **[zapier/zapier-mcp](https://github.com/zapier/zapier-mcp)** - Official plugin distribution for the hosted Zapier MCP server. Connects Claude to thousands of apps — send messages, pull data, trigger workflows.
 - **[Neeeophytee/finding-unknowns-skills](https://github.com/Neeeophytee/finding-unknowns-skills)** - 8 meta-skills that make a coding agent surface your unknowns before they get expensive: blindspot pass, interview, reference hunt, implementation plan/notes, pitch packager, and a pre-merge change quiz. Works in Claude Code, Codex, and Cursor via the agentskills.io SKILL.md format
+- **[sdshah09/brag-document-skill](https://github.com/sdshah09/brag-document-skill)** - Track accomplishments and write brag documents for performance reviews
 
 </details>
 


### PR DESCRIPTION
Adding `brag-document-skill` to **Community Skills → Productivity and Collaboration**.

```markdown
- **[sdshah09/brag-document-skill](https://github.com/sdshah09/brag-document-skill)** - Track accomplishments and write brag documents for performance reviews
```

## What it does

An agent skill for building and maintaining a brag document — a running record of your accomplishments used for performance reviews and promotion cases. Rather than handing you a template, it reconstructs the record with you from your own PRs, tickets, design docs and calendar, pushes each entry past *what you did* to *what resulted*, and keeps hard-to-quantify work (mentoring, on-call, code review culture) in the document instead of dropping it. Based on Julia Evans' "Get your work recognized: write a brag document."

## Checklist against CONTRIBUTING

- **Public repository with a working skill** — yes, MIT licensed.
- **Documentation** — both a README and `skills/brag-document/SKILL.md`.
- **Author/org prefix in the name** — `sdshah09/`.
- **Description 10 words or fewer** — 9 words.
- **Added to the end of the category** — appended as the last bullet inside the `Productivity and Collaboration` `<details>` block. One line changed, nothing reordered.
- **Link verified** — returns 200.

Category rationale: this section already holds career and review tooling, including `Paramchoudhary/ResumeSkills` and `santifer/career-ops`.

## On the maturity requirement

Being straight with you rather than overstating it: the repo has been public since June and installs across eight agent tools (Claude Code, Cursor, Codex, Gemini, Antigravity, Windsurf, Copilot, Goose), but it does not yet have meaningful star counts or a large user base. If that puts it under your "community-adopted, proven skills" bar, I completely understand you closing this — no hard feelings, and I'd rather you hold the line on list quality than make an exception.