### PR TITLE
Add skill: sdshah09/amazon-design-doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1821,6 +1821,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[JasonColapietro/suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills)** - Agent orchestration, code review grading, AI eval, creator tooling skills.
 - **[superdesigndev/superdesign-skill](https://github.com/superdesigndev/superdesign-skill)** - Creates design systems from existing codebases and iterates UI drafts
 - **[Ryan-yang125/motion-lexicon](https://github.com/Ryan-yang125/motion-lexicon/tree/main/skills/motion-lexicon)** - Build and review product motion with installable React components
+- **[sdshah09/amazon-design-doc](https://github.com/sdshah09/design-doc-agent-skill)** - Write and review design docs in Amazon's format
 
 </details>
 


### PR DESCRIPTION
Adding `amazon-design-doc` to **Community Skills → Development and Testing**.

```markdown
- **[sdshah09/amazon-design-doc](https://github.com/sdshah09/design-doc-agent-skill)** - Write and review design docs in Amazon's format
```

## What it does

An agent skill that makes a coding assistant write software design docs in Amazon's format, and review existing ones against the same bar. It enforces four writing rules rather than just supplying headings: a 6-8 page budget with everything else in the appendix, no weasel words ("significantly faster", "should scale") without numbers, data-point in the body with methodology in the appendix, and prose instead of bullet lists. In review mode it quotes the specific lines that fail, checks that "do nothing" appears under Alternatives Considered, and flags whether each decision is a one-way or two-way door. Based on Eric Clemmons' "Write Design Docs like Amazon."

## Checklist against CONTRIBUTING

- **Public repository with a working skill** — yes, MIT licensed, with CI.
- **Documentation** — README plus `skills/amazon-design-doc/SKILL.md`, a template, and worked examples.
- **Author/org prefix in the name** — `sdshah09/`.
- **Description 10 words or fewer** — 8 words.
- **Added to the end of the category** — appended as the last bullet inside the `Development and Testing` `<details>` block. One line changed, nothing reordered.
- **Link verified** — returns 200.

Category rationale: this section already holds agent-facing engineering-workflow tooling such as `coderabbitai/skills` and `JasonColapietro/suede-creator-skills`. Design-doc authoring and review is engineering workflow rather than general productivity.

## On the maturity requirement

Flagging this honestly rather than hoping it goes unnoticed: this skill is genuinely new — first published in August — and has not yet accumulated stars or a proven user base. That is squarely what your "brand new skills are not accepted" rule is aimed at, so please close this if it doesn't clear your bar. I'd rather submit it and be told to come back later than misrepresent its traction. Happy to resubmit once it has real adoption if you'd prefer that.