### PR TITLE
Add pptx-to-html-trace to Productivity and Collaboration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1741,6 +1741,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[zapier/zapier-mcp](https://github.com/zapier/zapier-mcp)** - Official plugin distribution for the hosted Zapier MCP server. Connects Claude to thousands of apps — send messages, pull data, trigger workflows.
 - **[Neeeophytee/finding-unknowns-skills](https://github.com/Neeeophytee/finding-unknowns-skills)** - 8 meta-skills that make a coding agent surface your unknowns before they get expensive: blindspot pass, interview, reference hunt, implementation plan/notes, pitch packager, and a pre-merge change quiz. Works in Claude Code, Codex, and Cursor via the agentskills.io SKILL.md format
 - **[kgraph57/strategy-consulting-visualization](https://github.com/kgraph57/mckinsey-style-visualization-skill)** - McKinsey-style charts and consulting slide decks
+- **[JunoChenZt/pptx-to-html-trace](https://github.com/JunoChenZt/pptx-to-html-trace)** - Rebuild a PowerPoint or PDF slide as HTML matching the original, with overlay and difference views to verify the match on screen instead of guessing. Reads exact geometry from the .pptx XML; pure Python standard library, no dependencies
 
 </details>
 


### PR DESCRIPTION
Adds one entry to **Community Skills → Productivity and Collaboration**.

**[pptx-to-html-trace](https://github.com/JunoChenZt/pptx-to-html-trace)** rebuilds a PowerPoint or PDF slide as HTML that matches the original, and ships the original render with the page as a comparison layer so the match can actually be checked: HTML only · Reference only · Overlay · Difference. In difference mode matched pixels go black, so only the errors still glow.

Slide replication from a screenshot fails for two reasons, neither of them model intelligence. There is no ruler — coordinates get estimated from pixels and fonts hallucinated — so this reads exact positions, sizes, font sizes, letter-spacing and colours straight out of the `.pptx` XML, and reuses the original image assets instead of redrawing them. And there are no eyes — CSS gets written and never rendered — so every result is judged against a rendered comparison rather than by re-reading the CSS.

The extractor is pure Python standard library: no dependencies, no network. That is not minimalism for its own sake — these things mostly run inside chat sandboxes where `pip install` fails.

It also ships `--verify`, which cross-checks canvas ratio, solid fills, ink in the reference that no extracted element covers, and text spilling out of its box — and says plainly that typography and effects are **not** covered.

Sits naturally next to the existing slide entries in this group, but works in the opposite direction: those generate decks, this reproduces an existing one on the web and lets you prove the reproduction is faithful.

Docs in English and Simplified Chinese, test fixtures and a tagged release included, MIT licensed.
