### PR TITLE
Add skill: KhazP/vibe-coding-prompt-template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1824,6 +1824,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[superdesigndev/superdesign-skill](https://github.com/superdesigndev/superdesign-skill)** - Creates design systems from existing codebases and iterates UI drafts
 - **[Ryan-yang125/motion-lexicon](https://github.com/Ryan-yang125/motion-lexicon/tree/main/skills/motion-lexicon)** - Build and review product motion with installable React components
 - **[aeonfun/aeon](https://github.com/aeonfun/aeon)** - 70+ Claude Code skills + autonomous GitHub Actions agent framework
+- **[KhazP/vibe-coding-prompt-template](https://github.com/KhazP/vibe-coding-prompt-template)** - Plan MVPs into PRD, tech design, and AGENTS.md
 
 </details>
 


### PR DESCRIPTION
Adds one entry to the end of **Community Skills → Development and Testing**.

```markdown
- **[KhazP/vibe-coding-prompt-template](https://github.com/KhazP/vibe-coding-prompt-template)** - Plan MVPs into PRD, tech design, and AGENTS.md
```

**Disclosure:** these are my own skills.

Against the requirements in CONTRIBUTING.md:

- **Public repo with a working skill** — six skills under `.claude/skills/`: `vibe-workflow`, `vibe-research`, `vibe-prd`, `vibe-techdesign`, `vibe-agents`, `vibe-build`.
- **Documentation** — `SKILL.md` per skill, plus a repo README and `.claude/README.md` covering installation.
- **Author/org prefix included** — `KhazP/vibe-coding-prompt-template`.
- **Description 10 words or fewer** — 9.
- **Real community usage, not brand new** — the skills landed in January 2026 (7 months ago) and have matured since; the repo is at 2.8k stars and 360+ forks, and the accompanying CLI is on npm as `vibeworkflow`.
- **PR title** — `Add skill: KhazP/vibe-coding-prompt-template`.

Placed in Development and Testing rather than Context Engineering: the skills produce the planning documents ahead of implementation, rather than managing an agent's context window.
