### PR TITLE
Add skill: apitube/news-api-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1898,6 +1898,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[GarethManning/competency-unpacker](https://github.com/GarethManning/education-agent-skills/tree/main/skills/curriculum-assessment/competency-unpacker)** - Unpacks broad competencies into assessable sub-skills and success criteria
 - **[ZeroPointRepo/youtube-skills](https://github.com/ZeroPointRepo/youtube-skills)** - Agent skills for YouTube: pull video transcripts and discover videos (search, channel and playlist listings) via TranscriptAPI.
 - **[morluto/rea](https://github.com/morluto/rea/tree/main/skills/reverse-engineer-anything)** - Reverse-engineer binaries, applications, and runtimes with REA
+- **[apitube/news-api-skills](https://github.com/apitube/news-api-skills)** - Search worldwide news by keyword, entity, sentiment, source, date
 
 </details>
 


### PR DESCRIPTION
Adds one line to **Community Skills → Specialized Domains**:

```
- **[apitube/news-api-skills](https://github.com/apitube/news-api-skills)** - Search worldwide news by keyword, entity, sentiment, source, date
```

### What the skill does

`apitube-news-api` teaches an agent to call the [APITube](https://apitube.io) News API without
guessing parameter names: authentication (three forms — `Authorization: Bearer`, `X-API-Key`,
`api_key=`), the `/news/everything` filters (keyword, entity, sentiment, source, country,
language, category, date range), plain-language `prompt=` queries, the response shape,
pagination, rate limits and error codes.

Every parameter, field name, limit and error code in `SKILL.md` was executed against the live
API at `api.apitube.io` before being written down.

### Meets the entry requirements

- Public repo, MIT: https://github.com/apitube/news-api-skills
- Documentation: repo `README.md` + `skills/apitube-news-api/SKILL.md`
- Org prefix in the name (`apitube/`)
- Description is 9 words
- Works in any `SKILL.md`-compatible agent (Claude Code, Cursor, Codex, Copilot, Gemini CLI);
  installable with `npx skills add apitube/news-api-skills --skill apitube-news-api` or as a
  Claude Code plugin marketplace

### Why Specialized Domains

The section already holds skills that wrap an external data source for the agent —
`ZeroPointRepo/youtube-skills` (TranscriptAPI), `helius-labs/helius-skills`, `video-db/skills`.
This is the same shape. Happy to move it if you see it elsewhere.

### Disclosure

Self-submission: APITube is our product and this is its official skill. Published 2026-08-15,
no usage metrics claimed. The API has a free tier (100 requests/day, no card) so the skill is
usable without a paid account.
