### PR TITLE
Add skill: Maksim-Burtsev/visual-teacher

### DIFF
--- a/README.md
+++ b/README.md
@@ -1742,6 +1742,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[zapier/zapier-mcp](https://github.com/zapier/zapier-mcp)** - Official plugin distribution for the hosted Zapier MCP server. Connects Claude to thousands of apps — send messages, pull data, trigger workflows.
 - **[Neeeophytee/finding-unknowns-skills](https://github.com/Neeeophytee/finding-unknowns-skills)** - 8 meta-skills that make a coding agent surface your unknowns before they get expensive: blindspot pass, interview, reference hunt, implementation plan/notes, pitch packager, and a pre-merge change quiz. Works in Claude Code, Codex, and Cursor via the agentskills.io SKILL.md format
 - **[kgraph57/strategy-consulting-visualization](https://github.com/kgraph57/mckinsey-style-visualization-skill)** - McKinsey-style charts and consulting slide decks
+- **[Maksim-Burtsev/visual-teacher](https://github.com/Maksim-Burtsev/visual-teacher)** - Explain any topic with Mermaid diagrams, timelines, and note-ready tables
 
 </details>
 


### PR DESCRIPTION
Adds `visual-teacher` to **Community Skills → Productivity and Collaboration**.

- **Repo:** https://github.com/Maksim-Burtsev/visual-teacher
- **What it does:** turns explanation requests into visual, note-ready answers — Mermaid diagrams, timelines, comparison tables, and mental models — instead of walls of prose.
- **Compatibility:** Claude Code and Codex (SKILL.md format).
- **Docs:** README + SKILL.md in the repo.

Single-line addition at the end of the category, matching the existing entry format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)