### PR TITLE
Add stop-manual-testing to Development and Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1824,6 +1824,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[superdesigndev/superdesign-skill](https://github.com/superdesigndev/superdesign-skill)** - Creates design systems from existing codebases and iterates UI drafts
 - **[Ryan-yang125/motion-lexicon](https://github.com/Ryan-yang125/motion-lexicon/tree/main/skills/motion-lexicon)** - Build and review product motion with installable React components
 - **[aeonfun/aeon](https://github.com/aeonfun/aeon)** - 70+ Claude Code skills + autonomous GitHub Actions agent framework
+- **[Kaiji-Z/stop-manual-testing](https://github.com/Kaiji-Z/stop-manual-testing)** - Stop manually testing AI agents: diagnoses project verifiability, then builds a machine-checkable verification system (regression suite, two-layer judge, GATE compliance mechanism) so the agent self-verifies and converges in a closed loop
 
 </details>
 


### PR DESCRIPTION
## What skill does this PR add?

**[Kaiji-Z/stop-manual-testing](https://github.com/Kaiji-Z/stop-manual-testing)** — stops you from manually testing your AI agent.

Agent developers spend ~90% of dev time manually testing: clicking through the UI, watching the agent run, judging by gut feel whether it got better or worse. This skill:

- Runs a 7-step diagnosis of the project's verifiability (read-only on code)
- Builds a machine-checkable verification system: regression suite, two-layer judge (deterministic assertions + clean-context LLM supervisor), flag-based A/B
- Uses a GATE (Declare-Verify-Enforce) mechanism so agent compliance is visible and checkable
- Orchestrates existing eval tools (DeepEval / LangSmith / pytest / jest) instead of reinventing

Compatible with Claude Code, Codex, and any agent supporting standard skill paths (SKILL.md format). MIT-licensed, self-contained, no runtime dependencies.

## Placement

Added to **Development and Testing** under Community Skills, following the existing entry format.