### PR TITLE
Add community skills: find-my-goal, kaiji-fitness-coach

### DIFF
--- a/README.md
+++ b/README.md
@@ -1663,6 +1663,20 @@ Official skills published by Cypress to help create, maintain, understand, and f
 ### Community Skills
 
 <details>
+<summary><h3 style="display:inline">Goal Management & Planning</h3></summary>
+
+- **[Kaiji-Z/find-my-goal](https://github.com/Kaiji-Z/find-my-goal)** - Zero-barrier /goal drafter: turns vague wishes into strong goals with executable acceptance criteria, scope, iteration budget and stop conditions via multiple-choice Q&A (bilingual 中文/EN)
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Health & Fitness</h3></summary>
+
+- **[Kaiji-Z/kaiji-fitness-coach](https://github.com/Kaiji-Z/kaiji-fitness-coach)** - Full-cycle AI fitness coach built on free-exercise-db (800+ exercises): training plans, exercise tutorials, data analysis, nutrition guidance, periodization
+
+</details>
+
+<details>
 <summary><h3 style="display:inline">Vector Databases</h3></summary>
 
 - **[qdrant/skills](https://github.com/qdrant/skills)** - Agent skills for Qdrant vector search, covering scaling, performance optimization, search quality, monitoring, deployment, model migration, version upgrades, and SDK usage across Python, TypeScript, Rust, Go, .NET, and Java


### PR DESCRIPTION
Adds two community skills under new Community Skills categories:

**Goal Management & Planning**
- **find-my-goal** — zero-barrier /goal drafter for agents with a native /goal loop (ZCode, Codex 0.128+, opencode+omo). Real use case: users paste weak goals like \u201c/goal optimize my project\u201d and loops spin; this skill drafts strong goals (executable acceptance criteria, scope, budget, stop conditions) via multiple-choice Q&A. Bilingual README (EN + 中文), MIT.

**Health & Fitness**
- **kaiji-fitness-coach** — full-cycle AI fitness coach on free-exercise-db (800+ exercises): training plans, exercise tutorials, workout data analysis, nutrition guidance, periodization. Includes working Python scripts and 10 reference docs.