### PR TITLE
Add solo-skills (productivity kit for solo founders)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1744,6 +1744,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[kgraph57/strategy-consulting-visualization](https://github.com/kgraph57/mckinsey-style-visualization-skill)** - McKinsey-style charts and consulting slide decks
 
 </details>
+- **[bam-bam-2/solo-skills](https://github.com/bam-bam-2/solo-skills)** - 15 skills a solo founder actually runs daily: product demo videos without screen recording, markdown-to-book PDF/EPUB, meeting transcript to Notion minutes, KakaoTalk CLI messaging, Naver blog writing, and reply-voice reverse-engineering. Korea-focused tools, failure modes documented alongside working paths
 
 <details>
 <summary><h3 style="display:inline">Development and Testing</h3></summary>


### PR DESCRIPTION
Adds `bam-bam-2/solo-skills` to **Community Skills → Productivity and Collaboration**.

15 agent skills that I actually run every day as a one-person business (no designers, no developers, no marketers):

- **web-demo-video** — product demo videos without any screen recorder (iframe + real click events + ffmpeg, deterministic frames)
- **book-pdf** — markdown manuscript to a real-looking PDF/EPUB with page-numbered TOC and running headers (Paged.js)
- **meeting-minutes** — transcript to structured minutes, posted to Notion, announced on Discord
- **kakaotalk-cli** — read/send KakaoTalk on macOS (Korea's dominant messenger)
- **naver-blog-post** — search-optimized posts for Naver (Korea's main search engine)
- **threads-reply** — reverse-engineer your own writing voice from past replies before drafting new ones

Each skill documents the paths that **failed** and why, not just the working one.

MIT licensed. Third-party tools are credited in the README.