### PR TITLE
Add skill: vshulcz/deja-history

### DIFF
--- a/README.md
+++ b/README.md
@@ -1850,6 +1850,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[khendzel/skills-janitor](https://github.com/khendzel/skills-janitor)** - Token audit, usage tracking, and swipe-to-delete skill pruning.
 - **[oliver-zehentleitner/keep-the-why](https://github.com/oliver-zehentleitner/keep-the-why)** - Preserves the reasoning behind a codebase — decisions, workarounds, rejected alternatives
 - **[thedotmack/claude-mem](https://github.com/thedotmack/claude-mem)** - Compresses and persists agent memory across sessions
+- **[vshulcz/deja-history](https://github.com/vshulcz/deja-vu/tree/main/claude-plugin/skills/deja-history)** - Searches your own past sessions across 20 coding agents
 
 </details>
 


### PR DESCRIPTION
Adds deja-history to Context Engineering. It is the skill shipped with deja-vu, a local index over the session files 20 coding agents already write to disk, so the agent can search what you did before instead of re-deriving it. MIT, no network calls, one Go binary: https://github.com/vshulcz/deja-vu