### PR TITLE
Add skill: sandbaseai/multi-source-search

### DIFF
--- a/README.md
+++ b/README.md
@@ -1697,6 +1697,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[AIDevGTM/gtm-cofounder](https://github.com/AIDevGTM/gtm-cofounder)** - 18 go-to-market skills for solo technical founders: positioning, first users, launch, pricing, and founder-led sales; grounded in Adam Frankl and Jakub Czakon
 - **[mailtrap/mailtrap-skills](https://github.com/mailtrap/mailtrap-skills)** - Send emails via API/SMTP with sandbox testing
 - **[SupercmoHQ/superCMO-skills](https://github.com/SupercmoHQ/superCMO-skills)** - Open-source skills + local MCP server for marketing video & image production: UGC videos, ad videos, product photography, and image ads from a product photo and a brief; casts AI actors, picks the best image/video models, edits any-length clips with consistent actor and product, and researches competitor ads. BYO or managed keys, Apache-2.0
+- **[sandbaseai/sandbase-skills/multi-source-search](https://github.com/sandbaseai/sandbase-skills/tree/main/research/multi-source-search)** - Evidence-led multi-source research with offline validation
 
 </details>
 


### PR DESCRIPTION
## Summary

Adds SandBase's established `multi-source-search` Agent Skill to the Community Skills → Marketing section.

## Evidence

- Public source: https://github.com/sandbaseai/sandbase-skills/tree/main/research/multi-source-search
- The repository currently has 45 GitHub stars and 1,387 direct GitHub clones in the latest available 14-day traffic window.
- The repository validates its skill catalog, offline evidence ledger, Agent Plugin copy, and marketplace manifest in CI/local checks.
- Description is 6 words and follows the list format.

This is a link-only curated-list contribution; it does not change the skill repository.
