### PR TITLE
Add dark-psychology-skills to Community Skills (Marketing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1698,6 +1698,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[Citlyze/citlyze-skills](https://github.com/citlyze/citlyze-skills)** - AI search visibility skills from the Citlyze team: window-over-window visibility reports, citation gap analysis, prompt audits, and action plans via the Citlyze MCP server, plus a standalone AEO page audit that grades any URL without an account
 - **[AIDevGTM/gtm-cofounder](https://github.com/AIDevGTM/gtm-cofounder)** - 18 go-to-market skills for solo technical founders: positioning, first users, launch, pricing, and founder-led sales; grounded in Adam Frankl and Jakub Czakon
 - **[mailtrap/mailtrap-skills](https://github.com/mailtrap/mailtrap-skills)** - Send emails via API/SMTP with sandbox testing
+- **[YannisKiefer/dark-psychology-skills](https://github.com/YannisKiefer/dark-psychology-skills)** - 13 sales and negotiation skills for agents distilled from 36 books (CIA psyop manuals, FBI behavioral research, propaganda science, persuasion classics); every tactic passes an honest-influence filter: it must still work when fully disclosed
 - **[SupercmoHQ/superCMO-skills](https://github.com/SupercmoHQ/superCMO-skills)** - Open-source skills + local MCP server for marketing video & image production: UGC videos, ad videos, product photography, and image ads from a product photo and a brief; casts AI actors, picks the best image/video models, edits any-length clips with consistent actor and product, and researches competitor ads. BYO or managed keys, Apache-2.0
 
 </details>


### PR DESCRIPTION
Adds [dark-psychology-skills](https://github.com/YannisKiefer/dark-psychology-skills) under Community Skills > Marketing.

**What it is:** 13 sales and negotiation skills in the standard SKILL.md agent format, distilled from 36 books read cover to cover: CIA psyop manuals, FBI behavioral research (*The Like Switch*), propaganda science (Ellul), dark psychology taxonomies, and the direct-response persuasion classics (Hopkins, Schwartz, Sugarman, Halbert, Kennedy).

**Quality notes per your standards:**
- Original content, no book excerpts, MIT licensed
- CI-linted structure (`scripts/lint.py` validates frontmatter, sections, length)
- Plain-English writing pass; each skill has The Big Idea / Moves / When It Backfires
- Honest-influence filter documented in SOURCES.md: every tactic must still work when fully disclosed. Manipulation taxonomy included as defense material only.

Happy to adjust placement or wording.