### PR TITLE
Add skill: aroldobossoni/community-scripts-rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1830,6 +1830,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[Maksim-Burtsev/simple-man](https://github.com/Maksim-Burtsev/simple-man)** - Strips praise, recaps and filler from agent answers while keeping every fact you act on: findings carry location and fix, refusals carry the safe procedure, tutorials stay long-form. Benchmarked on 1,793 preregistered live calls with raw records committed. Works with Claude Code, Codex, Gemini CLI, Cursor
 - **[aeonfun/aeon](https://github.com/aeonfun/aeon)** - 70+ Claude Code skills + autonomous GitHub Actions agent framework
 - **[lindblomstefan/skills-library](https://github.com/lindblomstefan/skills-library)** - Guided discovery skill for Claude Code: runs an interview to recommend from a catalog of 100+ AI skills; records session feedback that validates candidates over time
+- **[aroldobossoni/community-scripts-rules](https://github.com/aroldobossoni/community-scripts-agent-skill)** - Rules and standards for contributing to Community Scripts (ProxmoxVED)
 
 </details>
 


### PR DESCRIPTION
### Skill Information
- **Repository:** https://github.com/aroldobossoni/community-scripts-agent-skill
- **Skill Name:** `community-scripts-rules`
- **Description:** Rules and standards for contributing to Community Scripts and Proxmox VE Helper Scripts (ProxmoxVED).

### Checklist
- [x] Public repository with a working skill
- [x] Has documentation (README.md and SKILL.md)
- [x] Author prefix included in the name
- [x] Short description (<= 10 words)