### PR TITLE
Add skill: swaylq/humanize-chinese

### DIFF
--- a/README.md
+++ b/README.md
@@ -1909,6 +1909,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[morluto/rea](https://github.com/morluto/rea/tree/main/skills/reverse-engineer-anything)** - Reverse-engineer binaries, applications, and runtimes with REA
 - **[apitube/news-api-skills](https://github.com/apitube/news-api-skills)** - Search worldwide news by keyword, entity, sentiment, source, date
 - **[zincio/universal-checkout](https://github.com/zincio/skills/tree/master/skills/universal-checkout)** - Official Zinc API (zinc.com) checkout across 50+ US retailers
+- **[swaylq/humanize-chinese](https://github.com/swaylq/humanize-chinese)** - Detect and rewrite AI-generated Chinese text, fully offline, no LLM
 
 </details>
 


### PR DESCRIPTION
Adds [**swaylq/humanize-chinese**](https://github.com/swaylq/humanize-chinese) under **Specialized Domains** — detection and rewriting of AI-generated **Chinese** text.

**What it does.** One CLI with two halves: it scores Chinese text for how AI-generated it reads, then rewrites it to bring the score down. Detection mixes 20+ rule categories with statistical features (sentence-length CV, short-sentence fraction, comma density, perplexity, GLTR, DivEye) and a scene-aware logistic-regression fusion trained separately for general / academic / long-form registers. Rewriting ships 8 style transforms plus best-of-N sampling. Pure Python, no dependencies, fully offline — no LLM call and no API key, which matters because people run it on unpublished papers.

**On your "real community usage" requirement** — I'd rather show evidence than assert it:

- Published **2026-05-21**, so about three months old.
- 12 stars, 2 forks.
- Independently republished on ClawHub by other people: `0xspeter/humanize-chinese-2-0-0` carries the same name and version scheme, and `erongcao/erong-humanize-chinese` is a derivative. Two more Chinese humanizers there (`nanbingxyz/zh-humanizer`, `clarezoe/chinese-humanizer`) sit in the same niche. People re-uploading a skill is usually a better adoption signal than its own star count.

If you still consider it too small, close it and I'll come back when the numbers are better.

**Two disclosures:**

1. **License:** MIT **Non-Commercial**, not plain MIT — flagging it in case your list only takes OSI-approved licenses.
2. **Don't rely on the benchmark numbers currently in its README.** The maintainer is mid-way through a v6 rework and has re-measured them: the before/after score drops were taken on hand-written exaggerated "AI-style" samples rather than real model output, and the detector's separation on 2026-era models is far weaker than the headline figure implies. The tool and its approach are real; those specific numbers are being corrected, and I've kept them out of this PR and out of the entry description.

Description is 11 words; happy to trim to the 10-word guideline or move categories. Also happy to hold this until v6 lands if you'd rather list it once the README is accurate.
