### PR TITLE
Add TranscriptOut YouTube skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1666,6 +1666,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 <details>
 <summary><h3 style="display:inline">Vector Databases</h3></summary>
 
+- **[artemchuikin/youtube-skills](https://github.com/artemchuikin/youtube-skills)** - 12 skills for YouTube transcripts in five formats, video and channel search, playlists, and 4,000-video batch jobs through a hosted API with a free tier
 - **[qdrant/skills](https://github.com/qdrant/skills)** - Agent skills for Qdrant vector search, covering scaling, performance optimization, search quality, monitoring, deployment, model migration, version upgrades, and SDK usage across Python, TypeScript, Rust, Go, .NET, and Java
 
 </details>


### PR DESCRIPTION
Adds artemchuikin/youtube-skills to Community Skills, in alphabetical order by owner.

12 skills covering YouTube transcripts in five formats (text, JSON, SRT, VTT, raw srv3) with adjustable segment sizes for RAG, video and channel search, channel and playlist listings, and asynchronous batch jobs for up to 4,000 videos. Backed by a hosted API with a free tier (100 credits on signup, no card); every skill documents the exact request, its cost and its error recovery.